### PR TITLE
Updates from Vertex.AI for 2018.01.17

### DIFF
--- a/bzl/venv.tpl.py
+++ b/bzl/venv.tpl.py
@@ -16,10 +16,7 @@ WORKSPACE = "__BZL_WORKSPACE__"
 
 
 def _find_in_runfiles(logical_name):
-    key = logical_name
-    if key.startswith('external/'):
-        key = key[len('external/'):]
-    key = WORKSPACE + '/' + key
+    key = WORKSPACE + '/' + logical_name
     try:
         return _find_in_runfiles.manifest.get(key, logical_name)
     except AttributeError:
@@ -46,7 +43,7 @@ class VirtualEnv(object):
             hasher.update(arg)
         for requirement in requirements:
             with open(_find_in_runfiles(requirement)) as file_:
-                hasher.update(file_.read())
+                hasher.update(file_.read().encode())
         self._path = os.path.join(os.path.expanduser('~'), '.t2', 'venv', hasher.hexdigest())
 
         if platform.system() == 'Windows':

--- a/plaidml/experimental.json
+++ b/plaidml/experimental.json
@@ -80,7 +80,7 @@
         },
         "settings": {
           "threads": 64,
-          "vec_size": 4,
+          "vec_size": 1,
           "mem_width": 256,
           "max_mem": 7300,
           "max_regs": 4000,

--- a/plaidml/plaidml++.h
+++ b/plaidml/plaidml++.h
@@ -688,6 +688,10 @@ class device {
  public:
   device() = default;
 
+  bool operator!() const {
+    return !ptr_;
+  }
+
   buffer allocate(uint64_t size) const {
     buffer r;
 

--- a/plaidml/plaidml.cc
+++ b/plaidml/plaidml.cc
@@ -924,6 +924,10 @@ extern "C" bool plaidml_save_function(plaidml_function* function, const char* fi
 }
 
 extern "C" plaidml_function* plaidml_load_function(vai_ctx* ctx, plaidml_device* platform, const char* filename) {
+  if (!platform) {
+    vertexai::SetLastOOM();
+    return 0;
+  }
   try {
     unzFile in_file = unzOpen64(filename);
     std::string xo = read_string(in_file, "code");

--- a/tile/hal/opencl/emitocl.cc
+++ b/tile/hal/opencl/emitocl.cc
@@ -131,26 +131,30 @@ void Emit::Visit(const sem::BinaryExpr& n) {
 void Emit::Visit(const sem::CondExpr& n) {
   auto ty_tcase = TypeOf(n.tcase);
   auto ty_fcase = TypeOf(n.fcase);
+  auto ty_cond = TypeOf(n.cond);
   auto ty = Promote({ty_tcase, ty_fcase});
+  ty.vec_width = std::max(ty.vec_width, ty_cond.vec_width);
   emit("select(");
   EmitWithTypeConversion(ty_fcase, ty, n.fcase, true);
   emit(", ");
   EmitWithTypeConversion(ty_tcase, ty, n.tcase, true);
   emit(", ");
-  EmitWithWidthConversion(TypeOf(n.cond), ty, n.cond, true);
+  EmitWithWidthConversion(ty_cond, ty, n.cond, true);
   emit(")");
 }
 
 void Emit::Visit(const sem::SelectExpr& n) {
   auto ty_tcase = TypeOf(n.tcase);
   auto ty_fcase = TypeOf(n.fcase);
+  auto ty_cond = TypeOf(n.cond);
   auto ty = Promote({ty_tcase, ty_fcase});
+  ty.vec_width = std::max(ty.vec_width, ty_cond.vec_width);
   emit("select(");
   EmitWithTypeConversion(ty_fcase, ty, n.fcase, true);
   emit(", ");
   EmitWithTypeConversion(ty_tcase, ty, n.tcase, true);
   emit(", ");
-  EmitWithWidthConversion(TypeOf(n.cond), ty, n.cond, true);
+  EmitWithWidthConversion(ty_cond, ty, n.cond, true);
   emit(")");
 }
 

--- a/tile/hal/opencl/exprtype.cc
+++ b/tile/hal/opencl/exprtype.cc
@@ -194,11 +194,13 @@ void ExprType::Visit(const sem::BinaryExpr& n) {
 
 void ExprType::Visit(const sem::CondExpr& n) {
   ty_ = Promote({TypeOf(n.tcase), TypeOf(n.fcase)});
+  ty_.vec_width = std::max(ty_.vec_width, TypeOf(n.cond).vec_width);
   IVLOG(5, "ExprType(CondExpr): " << ty_);
 }
 
 void ExprType::Visit(const sem::SelectExpr& n) {
   ty_ = Promote({TypeOf(n.tcase), TypeOf(n.fcase)});
+  ty_.vec_width = std::max(ty_.vec_width, TypeOf(n.cond).vec_width);
   IVLOG(5, "ExprType(SelectExpr): " << ty_);
 }
 

--- a/tile/platform/local_machine/BUILD
+++ b/tile/platform/local_machine/BUILD
@@ -153,7 +153,7 @@ plaidml_cc_library(
 plaidml_cc_test(
     name = "loose_scheduler_test",
     srcs = ["loose_scheduler_test.cc"],
-    tags = ["rtest_fail"],
+    tags = ["rtest_fail", "windows_path_fail"],
     deps = [
         ":loose_scheduler",
         ":scheduler_test",
@@ -176,7 +176,7 @@ plaidml_cc_library(
 plaidml_cc_test(
     name = "linear_scheduler_test",
     srcs = ["linear_scheduler_test.cc"],
-    tags = ["rtest_fail"],
+    tags = ["rtest_fail", "windows_path_fail"],
     deps = [
         ":linear_scheduler",
         ":scheduler_test",
@@ -199,7 +199,7 @@ plaidml_cc_library(
 plaidml_cc_test(
     name = "tdep_scheduler_test",
     srcs = ["tdep_scheduler_test.cc"],
-    tags = ["rtest_fail"],
+    tags = ["rtest_fail", "windows_path_fail"],
     deps = [
         ":scheduler_test",
         ":tdep_scheduler",

--- a/tile/platform/local_machine/platform.cc
+++ b/tile/platform/local_machine/platform.cc
@@ -112,7 +112,7 @@ Platform::Platform(const context::Context& ctx, const proto::Platform& config) {
           } else {
             auto size_goal = memory->size_goal() * kGoalMemPercentage;
             IVLOG(1, "Using loose scheduler; size_goal=" << size_goal);
-            pd.scheduler = std::make_shared<LooseScheduler>(std::move(placer), size_goal);
+            pd.scheduler = std::make_shared<LooseScheduler>(std::move(placer), std::lround(std::floor(size_goal)));
           }
           devs_[id] = std::move(pd);
         }

--- a/tile/platform/local_machine/scheduler.cc
+++ b/tile/platform/local_machine/scheduler.cc
@@ -24,7 +24,7 @@ class InputDepUpdater final : public AllocVisitor {
 
   void Visit(const TmpAlloc& tmp_alloc) final;
   void Visit(const ProgramInputAlloc& input_alloc) final {}
-  void Visit(const ProgramOutputAlloc& output_alloc) final {}
+  void Visit(const ProgramOutputAlloc& output_alloc) final;
 
  private:
   AllocPtr allocp_;
@@ -38,6 +38,11 @@ InputDepUpdater::InputDepUpdater(AllocPtr allocp, StepPtr stepp,
 
 void InputDepUpdater::Visit(const TmpAlloc& tmp_alloc) {
   IVLOG(5, "  Adding input dep for a" << (*allocp_)->idx << " on last writer s" << (*stepp_)->idx);
+  (*stepp_)->deps.insert(latest_tmp_writer_->at(allocp_));
+}
+
+void InputDepUpdater::Visit(const ProgramOutputAlloc& out_alloc) {
+  IVLOG(5, "  Adding output dep for a" << (*allocp_)->idx << " on last writer s" << (*stepp_)->idx);
   (*stepp_)->deps.insert(latest_tmp_writer_->at(allocp_));
 }
 

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -39,7 +39,7 @@ build:macos-10.12 --build_tag_filters=-large,-llvm,-darwin_fail,-msvc
 test:macos-10.12 --test_tag_filters=-large,-llvm,-darwin_fail,-msvc
 
 build:windows-10 --build_tag_filters=-deb,-keras,-llvm,-shell,-tensorflow,-uvc
-test:windows-10 --test_tag_filters=-deb,-keras,-llvm,-shell,-tensorflow,-uvc --test_env=NUMBER_OF_PROCESSORS
+test:windows-10 --test_tag_filters=-deb,-keras,-llvm,-shell,-tensorflow,-uvc,-windows_path_fail --test_env=NUMBER_OF_PROCESSORS
 
 build:callgrind -c dbg
 build:callgrind --cxxopt=-O3


### PR DESCRIPTION
* Encode hashes to ensure py3 compatability
* Include output deps in schedules
* Trivial scheduler size fixup
* Fixes to opencl emit and turning off vectorization on Iris