### PR TITLE
#227 Adjust experimental.json to support Odroid XU4 Mali-T628 card

### DIFF
--- a/plaidml/configs/experimental.json
+++ b/plaidml/configs/experimental.json
@@ -144,10 +144,10 @@
                     "and": {
                         "sel": [
                             {
-                                "vendor_regex": "ARM"
+                                "vendor_regex": ".*ARM.*"
                             },
                             {
-                                "name_regex": "Mali-T760"
+                                "name_regex": ".*Mali-T760.*"
                             }
                         ]
                     }
@@ -168,10 +168,10 @@
                     "and": {
                         "sel": [
                             {
-                                "vendor_regex": "ARM"
+                                "vendor_regex": ".*ARM.*"
                             },
                             {
-                                "name_regex": "Mali-T628"
+                                "name_regex": ".*Mali-T628.*"
                             }
                         ]
                     }


### PR DESCRIPTION
As suggested by @tzerrell changing the regex in experimental.json fixed "No supported devices found ..." on ODroid XU4 with Mali-T628. Also changed for Mali-T760 but I wasn't able to test on such configuration.