### PR TITLE
Added extract_images_patches impl

### DIFF
--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -1693,6 +1693,57 @@ def zeros_like(x, dtype=floatx(), name=None):
                 .sole_output()
 
 
+class ImagePatches(ptile.Operation):
+    def __init__(self, images, ksizes, strides, rates=(1,1,1,1), padding="VALID", name=None):
+        """
+        Compatible to tensorflow.extract_image_patches. 
+        Extract patches from images and put them in the "depth" output dimension.
+        Args:
+            images: A tensor with a shape of [batch, rows, cols, depth]
+            ksizes: The size of the patches with a shape of [1, patch_rows, patch_cols, 1]
+            strides: How far the center of two patches are in the image with a shape of [1, stride_rows, stride_cols, 1]
+            rates: How far two consecutive pixel are in the input. Equivalent to dilation. Expect shape of [1, rate_rows, rate_cols, 1]
+            padding: A string of "VALID" or "SAME" defining padding.
+        """
+        i_shape = images.shape.dims
+        patch_row_eff = ksizes[1] + ((ksizes[1] - 1) * (rates[1] -1))
+        patch_col_eff = ksizes[2] + ((ksizes[2] - 1) * (rates[2] -1))
+
+        if padding.upper() == "VALID":
+            out_rows = math.ceil((i_shape[1] - patch_row_eff + 1.) / float(strides[1]))
+            out_cols = math.ceil((i_shape[2] - patch_col_eff + 1.) / float(strides[2]))
+        else:
+            out_rows = math.ceil( i_shape[1] / float(strides[1]) )
+            out_cols = math.ceil( i_shape[2] / float(strides[2]) )
+            pad_top = max(0, ( (out_rows - 1) * strides[1] + patch_row_eff - i_shape[1] ) // 2)
+            pad_left = max(0, ( (out_cols - 1) * strides[2] + patch_col_eff - i_shape[2] ) // 2)
+            # we simply assume padding right == padding left + 1 (same for top/down).
+            # This might lead to us padding more as we would need but that won't matter.
+            # TF splits padding between both sides so left_pad +1 should keep us on the safe side.
+            images = spatial_2d_padding(images, ((pad_top, pad_top+1), (pad_left, pad_left+1)))
+
+        o_shape = (i_shape[0], out_rows, out_cols, ksizes[1]*ksizes[2]*i_shape[-1])
+        code = """function (I[B,Y,X,D]) -> (O) {{
+                    TMP[b, ny, nx, y, x, d: B, {NY}, {NX}, {KY}, {KX}, D] =
+                        =(I[b, ny * {SY} + y * {RY}, nx * {SX} + x * {RX}, d]);
+                    O = reshape(TMP, B, {NY}, {NX}, {KY} * {KX} * D);
+                }}
+        """.format(
+            NY=out_rows, NX=out_cols,
+            KY=ksizes[1], KX=ksizes[2],
+            SY=strides[1], SX=strides[2],
+            RY=rates[1], RX=rates[2]
+        )
+        super(ImagePatches, self).__init__(code,
+                [('I', images),],
+                [('O', plaidml.tile.Shape(images.shape.dtype, o_shape))],
+                name=name
+        )
+        
+
+extract_image_patches = ImagePatches.function
+
+
 # Dynamically add Keras functionality to the underlying tile.Value class.
 # This allows us to transparently use Value as the tensor type exposed by
 # the Keras backend; it's a little squirrelly in this one place, but it

--- a/plaidml/tf_test.py
+++ b/plaidml/tf_test.py
@@ -1,0 +1,132 @@
+# Copyright 2018 Intel Corporation.
+"""Tensorflow like operation tests."""
+
+from __future__ import print_function
+
+import argparse
+import sys
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+# Tensorflow needs some code called directly
+import tensorflow
+ 
+# Hack to avoid using the plaidml.keras submodule when trying to load keras
+sys.path = sys.path[1:] + [sys.path[0]]
+from keras.backend import tensorflow_backend as tf
+from keras.backend import floatx
+sys.path = [sys.path[-1]] + sys.path[:-1]
+
+import plaidml
+from plaidml.keras import backend as pkb
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--fp16', action='store_true')
+    parser.add_argument('-v', '--verbose', action='count', default=0)
+    args, remainder = parser.parse_known_args()
+
+    plaidml._internal_set_vlog(args.verbose)
+    if args.fp16:
+        pkb.set_floatx('float16')
+        DEFAULT_TOL = 1e-2
+        DEFAULT_ATOL = 1e-5
+    else:
+        pkb.set_floatx('float32')
+        DEFAULT_TOL = 1e-3
+        DEFAULT_ATOL = 1e-8
+
+
+def opTest(in_data,
+           tol=DEFAULT_TOL,
+           atol=DEFAULT_ATOL,
+           skip_tensorflow=False,
+           verbose=False):
+    # If using with non-tensor parameters, all tensor params must appear before
+    # all non-tensor params
+    def run_one_backend(self, data, test_func, b, *run_args):
+        tf_session = tensorflow.Session()
+        tf.set_session(tf_session)
+        results = []
+        with tf_session.as_default():
+            x = [b.placeholder(shape=t.shape) for t in data if hasattr(t, 'shape')]
+            xv = [b.variable(t, dtype=floatx()) for t in data if hasattr(t, 'shape')]
+            ps = [t for t in data if not hasattr(t, 'shape')]
+            grad_funcs = test_func(self, b, *(x + ps + list(run_args)))
+            funcs = test_func(self, b, *(xv + ps + list(run_args)))
+            tf_session.run(tensorflow.global_variables_initializer())
+            for gf, f in zip(grad_funcs, funcs):
+                df = b.gradients(b.mean(gf), x)
+                gfn = b.function(x, df, updates=[])
+                fr = f.eval()
+                gr = gfn([t for t in data if hasattr(t, 'shape')])
+                try:
+                    values = gr[0].values
+                    dense_shape = gr[0].dense_shape
+                    indices = gr[0].indices
+                    result = np.zeros(dense_shape)
+                    for i in indices:
+                        result[i] += values[i]
+                    gr[0] = result
+                except AttributeError:
+                    # This wasn't an IndexedSlices object, do nothing
+                    pass
+                if args.verbose or verbose:
+                    print('data: {}'.format(data))
+                    print('fr: {}'.format(fr))
+                    print('gr: {}'.format(gr))
+                results.append((fr, gr))
+        tf_session.close()
+        return results
+
+    def apply(test_func):
+
+        def output(self, *args):
+            for didx, data in enumerate(in_data):
+                if not skip_tensorflow:
+                    tensorflow_results = run_one_backend(self, data, test_func, tf, *args)
+                plaidml_results = run_one_backend(self, data, test_func, pkb, *args)
+                if not skip_tensorflow:
+                    for idx, (pmlr, tfr) in enumerate(zip(plaidml_results, tensorflow_results)):
+                        idx = idx + 1
+                        npt.assert_allclose(
+                            pmlr[0],
+                            tfr[0],
+                            rtol=tol,
+                            atol=atol,
+                            err_msg='ERR: datum={}, test={}, x=plaidml, y=tensorflow'.format(
+                                didx, idx))
+                        for x in range(0, len(pmlr[1])):
+                            npt.assert_allclose(
+                                pmlr[1][x],
+                                tfr[1][x],
+                                rtol=tol,
+                                atol=atol,
+                                err_msg='ERR: datum={}, test={}, grad, x=plaidml, y=tensorflow'.
+                                format(didx, idx))
+
+        return output
+
+    return apply
+
+
+class TestTF(unittest.TestCase):
+    """Tensorflow like operation tests."""
+
+    @opTest([
+        [np.random.random((5, 60, 10, 3)), [1,3,4,1], [1,3,3,1], [1,1,1,1], "SAME"],
+        [np.random.random((5, 60, 10, 3)), [1,3,4,1], [1,3,3,1], [1,1,1,1], "VALID"],
+        [np.random.random((5, 60, 10, 3)), [1,4,3,1], [1,1,1,1], [1,1,1,1], "SAME"],
+        [np.random.random((5, 60, 10, 3)), [1,4,3,1], [1,1,1,1], [1,6,5,1], "SAME"],
+    ])
+    def testExtractImagePatches(self, b, images, ksizes, strides, rates=(1,1,1,1), padding="VALID"):
+        func = tensorflow.extract_image_patches if b == tf else plaidml.op.extract_image_patches
+        return [func(images, ksizes, strides, rates, padding)]
+
+
+if __name__ == '__main__':
+    np.set_printoptions(threshold=np.inf)
+    #plaidml._internal_set_vlog(5)
+    unittest.main(argv=sys.argv[:1] + remainder, verbosity=args.verbose + 1)


### PR DESCRIPTION
This PR provides an operation compatible to tensorflows extract_image_patches function. #243
The only case where it provides different results as the tensorflow implementation is when no patch can be extracted, in which case tensorflow produces a shape like [batch, 0, x, depth] and this implementation provides a shape of [0].
It does not honor the data_format of the backend. If that is required that should be easy(ish) to add tho.

Tested with this crude testcase:
```
    BATCHES = 2
    DEPTH = 3
    tf_session = tf.Session()    
    # lol
    for iy in range(1, 6):
        for ix in range(1, 6):
            images = np.random.rand(*(BATCHES, iy, ix, DEPTH))
            k_images = K.variable(images, dtype=images.dtype)
            for ky in range(1, iy):
                for kx in range(1, ix):
                    for sy in range(1, iy):
                        for sx in range(1, ix):
                            for ry in range(1, iy):
                                for rx in range(1, ix):
                                    for padding in ("SAME", "VALID"):
                                        if padding == "VALID" and (ky*ry > iy or kx*rx > ix):
                                            continue
                                        ksizes = [1, ky, kx, 1]
                                        strides = [1, sy, sx, 1]
                                        rates = [1, ry, rx, 1]
                                        print("[%s] img=%s, ksizes=%s, strides=%s, rates=%s, padding=%s" % (
                                            "?",
                                            images.shape,
                                            ksizes, strides,
                                            rates, padding
                                        ), end="\t")
                                        with tf_session.as_default():
                                            tf_patches = tf.extract_image_patches(images, ksizes=ksizes, strides=strides, rates=rates, padding=padding).eval()
                                        k_patches = extract_image_patches(k_images, ksizes, strides, rates, padding).eval()
                                        if np.any(tf_patches != k_patches):
                                            print("\033[91m\033[1mFAILED\033[0m")
                                            print("tf shape: ", tf_patches.shape)
                                            print(tf_patches)
                                            print("k_patches shape: ", k_patches.shape)
                                            print(k_patches)
                                        else:
                                            print("\033[92m\033[1mSUCCESS\033[0m")
```

For the interested here is the same implementation with pure K functions:
```
def extract_image_patches_k(images, ksizes, strides, rates, padding):
    ishape = images.shape.dims
    laxis = ksizes[1]*ksizes[2]*ishape[-1]
    patch_row_eff = ksizes[1] + ((ksizes[1] - 1) * (rates[1] -1))
    patch_col_eff = ksizes[2] + ((ksizes[2] - 1) * (rates[2] -1))
    
    if padding.upper() == "VALID":
        out_rows = math.ceil((ishape[1] - patch_row_eff + 1.) / float(strides[1]))
        out_cols = math.ceil((ishape[2] - patch_col_eff + 1.) / float(strides[2]))
        pad_top = 0
        pad_left = 0
    else:
        out_rows = math.ceil( ishape[1] / float(strides[1]) )
        out_cols = math.ceil( ishape[2] / float(strides[2]) )
        pad_top = max(0, ( (out_rows - 1) * strides[1] + patch_row_eff - ishape[1] ) // 2)
        pad_left = max(0, ( (out_cols - 1) * strides[2] + patch_col_eff - ishape[2] ) // 2)
        # we simply assume padding right + 1 == padding left (same for top/down).
        # This might lead to us padding more as we would need but that won't matter.
        # TF tries to split padding to both sides so left_pad +1 should keep us on the safe side.
        images = K.spatial_2d_padding(images, ((pad_top, pad_top+1), (pad_left, pad_left+1)))

    if out_rows * out_cols == 0:
        return K.constant(np.ndarray(0, dtype=images.shape.dtype.name.lower()))

    if rates[1] != ksizes:
        ksizes[1] = ksizes[1] + (ksizes[1] -1) * (rates[1] - 1)
    if rates[2] != ksizes:
        ksizes[2] = ksizes[2] + (ksizes[2] -1) * (rates[2] - 1)
    ishape = images.shape.dims
    patches = []
    for y in range(out_rows):
        for x in range(out_cols):
            patch = images[:, y*strides[1]:y*strides[1]+ksizes[1]:rates[1], x*strides[2]:x*strides[2]+ksizes[2]:rates[2], :]
            patch = K.reshape(patch, (ishape[0], 1, 1, laxis))
            patches.append(patch)
    patches = K.concatenate(patches, -1)
    nshape = (ishape[0], out_rows, out_cols, laxis)
    patches = K.reshape(patches, nshape)
    return patches
```