### PR TITLE
Enable concat to work with symbolic tensors

### DIFF
--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -708,7 +708,8 @@ def get_value(x):
     tensor = plaidml.Tensor(_device(), shape)
     invoker.set_output('out', tensor)
     invoker.invoke()
-    array = np.ndarray(x.shape.dims, dtype=ptile.convert_pml_dtype_to_np(x.shape.dtype))
+    out_shape = tuple(x.size for x in shape.dimensions)
+    array = np.ndarray(out_shape, dtype=ptile.convert_pml_dtype_to_np(x.shape.dtype))
     with tensor.mmap_current() as view:
         view.copy_to_ndarray(array)
     return array

--- a/plaidml/op.py
+++ b/plaidml/op.py
@@ -1121,7 +1121,7 @@ class Concatenate(tile.Operation):
 
         offsets = [0]
         for i in range(len(tensors)):
-            offsets.append(offsets[i] + tensors[i].shape.dims[axis])
+            offsets.append("+".join("A{}".format(j) for j in range(i+1)))
         out_dims = tuple(
             tensors[0].shape.dims[i] if i != axis else offsets[len(tensors)] for i in range(rank))
 
@@ -1149,8 +1149,6 @@ class Concatenate(tile.Operation):
         body_str = ''
         line_subs = {'beg': indices_begin, 'end': indices_end, 'odims': output_dims_str}
         for i in range(len(tensors)):
-            # TODO: If offsets[i] is symbolic, add it to the function
-            # inputs and use it symbolically.
             line_subs['off'] = '+{}'.format(offsets[i])
             line_subs['i'] = i
             curr_line = '  T{i}[{beg}{off}{end}: {odims}] = =(I{i}[{beg}{end}]);\n'.format(
@@ -1162,9 +1160,9 @@ class Concatenate(tile.Operation):
 
         # Example 'code' (concatenating (4,3,2), (4,5,2), (4,1,2)):
         #   function (I0[N0, A0, N2], I1[N0, A1, N2], I2[N0, A2, N2]) -> (O) {
-        #     T0[n0, a, n2: N0, 9, N2] = =(I0[n0, a, n2]);
-        #     T1[n0, a+3, n2: N0, 9, N2] = =(I1[n0, a, n2]);
-        #     T2[n0, a+8, n2: N0, 9, N2] = =(I2[n0, a, n2]);
+        #     T0[n0, a, n2: N0, A0+A1+A2, N2] = =(I0[n0, a, n2]);
+        #     T1[n0, a+A0, n2: N0, A0+A1+A2, N2] = =(I1[n0, a, n2]);
+        #     T2[n0, a+A0+A1, n2: N0, A0+A1+A2, N2] = =(I2[n0, a, n2]);
         #     O = T0 + T1 + T2;
         #   }
         code = ('function ({inputs}) -> (O) {{\n{body}\n}}').format(


### PR DESCRIPTION
Currently concatenate doesn't work when the "merging" axis is symbolic.
This PR should fix that.
This is not super carefully tested, so please do so yourself before merging.
I don't see a reason it shouldn't work though.

Example to demonstrate the problem:
```
    DIM_FIX = False
    def dummy_loss(y_true, y_pred): # I am not sure why y_true has a symbolic shape for all axis at all, but that one might be on keras ?
        print("y_true shape:", K.int_shape(y_true)) # -> (None, None, None, None)
        print("y_pred shape:", K.int_shape(y_pred)) # -> (None, 64, 64, 3)
        mask = 1 # in reality this has a shape of (B, Y, X, 1)
        if DIM_FIX:
            y_true = K.reshape(y_true, K.int_shape(y_pred))       # works
            #y_true = K.reshape(y_true, (None, None, 64, None))   # works
            #y_true = K.reshape(y_true, (None, None, None, None)) # Same as unchanged. Doesn't work
            #y_true = K.reshape(y_true, (None, None, None, 3))    # Doesn't work
            #y_true = K.reshape(y_true, (None, 64, None, None))   # Doesn't work
        n_true = K.concatenate([y_true[:, :, :, i] * mask for i in range(3)])
        n_pred = K.concatenate([y_pred[:, :, :, i] * mask for i in range(3)])
        return keras.losses.mean_squared_error(n_true, n_pred)
    
    in_ = x = keras.Input((64, 64, 3))
    x = keras.layers.Conv2D(3, 3, strides=1, padding="same")(x)    
    model = keras.Model(in_, x)
    model.compile("Adam", dummy_loss)
    
    model.train_on_batch(np.zeros((32, 64, 64, 3)), np.ones((32, 64, 64, 3)))
```

With `DIM_FIX` set to false (and thus y_true being fully symbolic) i get a kernel like:
```
function (I0[N0, N1, A0], I1[N0, N1, A1], I2[N0, N1, A2]) -> (O) {
  T0[n0, n1, a+0: N0, N1, Add UINT64()] = =(I0[n0, n1, a]);
  T1[n0, n1, a+Ceiling UINT64(): N0, N1, Add UINT64()] = =(I1[n0, n1, a]);
  T2[n0, n1, a+Add UINT64(): N0, N1, Add UINT64()] = =(I2[n0, n1, a]);
  O = T0 + T1 + T2;
}
```

which of course doesn't work.