### PR TITLE
Add SpatialDropout support in dropout

### DIFF
--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -584,13 +584,18 @@ dot = op.dot
 
 
 def dropout(x, level, noise_shape=None, seed=None):
-    if noise_shape is not None:
-        raise PlaidMLKerasException('Unimplemented noise shape in dropout')
+    if noise_shape is not None and len(noise_shape) != x.shape.ndims:
+        raise ValueError("Length of noise_shape doesn't match input ndims")
 
     rng_state = _make_rng_state(seed)
-
     szs = ', '.join(['S' + str(i) for i in range(x.shape.ndims)])
-    args = ', '.join(['I'] + ['S' + str(i) for i in range(x.shape.ndims)])
+    if noise_shape is None:
+        args = 'I, ' + szs
+    else:
+        ishape = x.shape.dims
+        args = ', '.join(['I'] + [
+            "S{}".format(i) if v == ishape[i] or v in (None, -1) else "1" for i, v in enumerate(noise_shape)
+        ])        
     rng_step = 'function (I, X[{szs}]) -> (O) {{ O = prng_step({args}); }}'.format(
         szs=szs, args=args)
     rng_value = """function (I, X, L) -> (O) {


### PR DESCRIPTION
This PR adds support for noise_shape in the dropout function and thus adds support for SpatialDropout*d.
I am not absolutely sure the math is correct but it should ?

On question about this (and the previous) implementation though:
`rng_step` uses `x` (the input) to get the correct shapes even with symbolic tensors.
Does that mean x is always copied onto the device even when it only is used to get the correct shape or is that optimized away ?
And if it is always copied to the device would there be a way to add support to tile to provide correct shape only without really copying the data ?