### PR TITLE
Add EDSL shared operations

### DIFF
--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -1683,7 +1683,7 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
         dtype = floatx()
     if seed:
         np.random.seed(seed)
-    return stddev * scipy.stats.truncnorm.rvs(-2.0, 2.0, size=shape) + mean
+    return variable(stddev * scipy.stats.truncnorm.rvs(-2.0, 2.0, size=shape) + mean, dtype)
 
 
 def update(x, new_x):

--- a/plaidml/keras/backend_test.py
+++ b/plaidml/keras/backend_test.py
@@ -885,14 +885,13 @@ class TestBackendOps(unittest.TestCase):
     @compareForwardClose(.1)
     def testTruncatedNormalMean(self, b):
         rand = b.truncated_normal((1000, 1000), mean=42.0, stddev=0.1)
-        return b.mean(b.variable(rand))
+        return b.mean(rand)
 
     @compareForwardClose(.1, skip_theano=True)
     def testTruncatedNormalDev(self, b):
         rand = b.truncated_normal((1000, 1000), mean=42.0, stddev=0.1)
-        X = b.variable(rand)
-        mean = b.mean(X)
-        diffs = X - mean
+        mean = b.mean(rand)
+        diffs = rand - mean
         return b.mean(b.square(diffs))
 
     @opTest([
@@ -1160,6 +1159,15 @@ class TestBackendOps(unittest.TestCase):
         return [b.reshape(x, s)]
 
     @opTest([
+        [m(3)],
+        [m()],
+        [m(4, 7)],
+        [m(6, 3, 2, 4, 7, 1, 5)],
+    ])
+    def testTranspose(self, b, x):
+        return [b.transpose(x)]
+
+    @opTest([
         [m(1, 1, 60), (60,)],
         [m(4, 3, 70, 2), (14, 10, 6, 2)],
         [m(7, 3, 2, 4), (-1,)],
@@ -1167,6 +1175,15 @@ class TestBackendOps(unittest.TestCase):
     ])
     def testTransposeReshape(self, b, x, s):
         return [b.reshape(b.transpose(x), s)]
+
+    @opTest([
+        [m(3), (0,)],
+        [m(), tuple()],
+        [m(4, 7), (1, 0)],
+        [m(3, 6, 2, 4, 7, 1, 5), (5, 2, 0, 3, 6, 1, 4)],
+    ])
+    def testPermuteDimensions(self, b, x, s):
+        return [b.permute_dimensions(x, pattern=s)]
 
     @opTest([
         [m(4, 2, 1, 3, 2), 2],

--- a/plaidml2/op/__init__.py
+++ b/plaidml2/op/__init__.py
@@ -21,8 +21,16 @@ def op(op_name, args):
     return edsl.Value(ffi_call(lib.plaidml_op_make, op_name.encode(), value.as_ptr()))
 
 
+def abs(x):
+    return op('abs', [x]).as_tensor()
+
+
 def argmax(x, axis=-1):
     return op('argmax', [x, axis]).as_tensor()
+
+
+def concatenate(tensors, axis=-1):
+    return op('concatenate', [tensors, axis]).as_tensor()
 
 
 def convolution(I, F, strides, dilations, data_dilations, filter_shape, groups, autopad_mode,
@@ -49,6 +57,10 @@ def convolution(I, F, strides, dilations, data_dilations, filter_shape, groups, 
 
 def dot(x, y):
     return op('dot', [x, y]).as_tensor()
+
+
+def expand_dims(x, axis=-1):
+    return op('expand_dims', [x, axis]).as_tensor()
 
 
 def mean(I, axis=None, keepdims=False):
@@ -91,7 +103,29 @@ def square(I):
     return I * I
 
 
+def squeeze(x, axis):
+    return op("squeeze", [x, axis]).as_tensor()
+
+
 def sum(I, axis=None, keepdims=False):
     if isinstance(axis, np.ndarray):
         axis = axis.tolist()
     return op('sum', [I, axis, keepdims]).as_tensor()
+
+
+def tile(I, n):
+    if isinstance(n, np.ndarray):
+        n = n.tolist()
+    return op('tile', [I, n]).as_tensor()
+
+
+def transpose(I, pattern=None):
+    if isinstance(pattern, np.ndarray):
+        pattern = pattern.tolist()
+    return op('transpose', [I, pattern]).as_tensor()
+
+
+def variance(I, axis=None, keepdims=False):
+    if isinstance(axis, np.ndarray):
+        axis = axis.tolist()
+    return op('variance', [I, axis, keepdims]).as_tensor()

--- a/plaidml2/op/op.h
+++ b/plaidml2/op/op.h
@@ -90,5 +90,10 @@ inline edsl::Tensor sum(const edsl::Tensor& I, const edsl::Value& axes = edsl::N
   return details::op("sum", args).as_tensor();
 }
 
+inline edsl::Tensor variance(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(), bool keepdims = false) {
+  auto args = edsl::make_tuple(I, axes, keepdims);
+  return details::op("variance", args).as_tensor();
+}
+
 }  // namespace op
 }  // namespace plaidml

--- a/tile/lang/ast/ast.h
+++ b/tile/lang/ast/ast.h
@@ -203,7 +203,6 @@ struct ContractionExpr : Expr {
   ContractionExpr();
   void Accept(AstVisitor<void>* visitor) { visitor->Visit(*this); }
   std::string str() const;
-  size_t logical_input_size() const { return (use_default ? inputs.size() - 1 : inputs.size()); }
   void ComputeShape(const std::string& layout);
 };
 

--- a/tile/lang/ast/gradient.cc
+++ b/tile/lang/ast/gradient.cc
@@ -112,7 +112,7 @@ class Gradient {
 
  private:
   ExprPtr ContractionOp(const ExprPtr& dout, const std::shared_ptr<ContractionExpr>& expr, size_t idx) {
-    if (expr->use_default && idx == expr->inputs.size() - 1) {
+    if (expr->use_default && idx == expr->inputs.size()) {
       return DefaultOp(dout, expr);
     }
     if (expr->combo_op == CombinationOp::EQ) {
@@ -181,7 +181,10 @@ class Gradient {
     dop->constraints = op->constraints;
     // Anywhere the forward pass hits the default, the derivative w.r.t. any other tensor is 0;
     // thus, for the corresponding gradient, the default is everywhere zero i.e. the standard unspecified default
-    for (size_t i = 0; i < op->logical_input_size(); ++i) {
+    if (idx == op->inputs.size()) {
+      throw std::logic_error("A default tensor fell through to the SumOp case during Gradient");
+    }
+    for (size_t i = 0; i < op->inputs.size(); ++i) {
       if (idx == i) {
         dop->inputs.push_back(std::make_shared<TensorSpecExpr>(dout, op->output->index_spec));
       } else {


### PR DESCRIPTION
Adds (or in the case of var moves) operations to the shared EDSL op library. Currently adds abs, concatenate, expand_dims, squeeze, tile, transpose, and variance. Also adds or adjusts related Keras ops and the additional Keras backend ops softplus, softsign, stack, std, switch, and truncated_normal.

Note that concatenate is not working in most cases yet.