### PR TITLE
Add tests that demonstrate bad perf for the CPU jit

### DIFF
--- a/tile/codegen/codegen.proto
+++ b/tile/codegen/codegen.proto
@@ -385,8 +385,8 @@ message AutotilePass {
   // The maximum amount of memory use (in bytes) for each input read by
   // the inner block.  0 means no limit.
   optional int64 max_per_input_size = 11 [default = 0];
-  // The total size of all data used by the inner block.  Note, this is
-  // generally the place to put a memory limit, but in some architectures
+  // The total size (in bytes) of all data used by the inner block.  Note, this
+  // is generally the place to put a memory limit, but in some architectures
   // inputs are held in one memory and outputs are held in accumulation
   // registers in a separate memory.  0 means no limit.
   optional int64 max_total_size = 12 [default = 0];
@@ -411,6 +411,7 @@ message AutotilePass {
   optional string loc_name = 19 [default = ""];
   // Clear the tags of the original / outer block before adding outer_set
   optional bool clear_outer = 20 [default = false];
+  // Set to false to allow only parallel safe tilings
   optional bool acc_idxs = 21 [default = true];
   // Clear the location the original / outer block
   optional bool clear_location = 22 [default = false];

--- a/tile/targets/cpu/cpu.jsonnet
+++ b/tile/targets/cpu/cpu.jsonnet
@@ -64,16 +64,65 @@ local PARAMS = {
                   {
                     startup_cost: 32,
                     idxs: [
-                      { name: 'm', size: i, outs: [-1], ins: [-1, 0] },
-                      { name: 'n', size: j, outs: [1], ins: [0, 1] },
-                      { name: 'k', size: k, outs: [0], ins: [1, -1] },
+                      { name: 'm', size: 64, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 64, outs: [0], ins: [1, -1] },
                     ],
-                  } for i in [8, 16, 32, 48, 64, 80, 96] for j in [8, 16, 32, 64, 48, 80, 96] for k in [8, 16, 32, 48, 64, 80, 96]
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 64, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 16, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 64, outs: [0], ins: [1, -1] },
+                    ],
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 32, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 32, outs: [0], ins: [1, -1] },
+                    ],
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 16, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 16, outs: [0], ins: [1, -1] },
+                    ],
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 48, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 48, outs: [0], ins: [1, -1] },
+                    ],
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 80, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 80, outs: [0], ins: [1, -1] },
+                    ],
+                  },
+                  {
+                    startup_cost: 32,
+                    idxs: [
+                      { name: 'm', size: 96, outs: [1], ins: [0, 1] },
+                      { name: 'n', size: 8, outs: [-1], ins: [-1, 0] },
+                      { name: 'k', size: 96, outs: [0], ins: [1, -1] },
+                    ],
+                  },
                 ],
                 inputs_set: [{tags: ["A"]}, {tags: ["B"]}],
                 outputs_set: [{tags: ["C"]}],
               },
             },
+
             {
               name: 'tile_contract',
               pass: {


### PR DESCRIPTION
Also, added ability to measure from the backend tests.

Also removed the generation of CPU sencil for XSMM since it was causing a major perf problems. All the permutations are causing the stencil selection code to perform really poorly. Having handcoded set of values is much better here.