### PR TITLE
stripejit configurability

### DIFF
--- a/tile/cpu/main.cc
+++ b/tile/cpu/main.cc
@@ -58,8 +58,8 @@ int main(int argc, char* argv[]) {
   io["C"] = c_data.data();
 
   targets::cpu::Native native;
-  std::map<std::string, targets::cpu::External> externals;
-  native.compile(*program->entry, externals);
+  targets::cpu::Config config;
+  native.compile(*program->entry, config);
 
   for (int i = 0; i < 10; i++) {
     for (auto& f : c_data) {

--- a/tile/platform/stripejit/program.cc
+++ b/tile/platform/stripejit/program.cc
@@ -33,8 +33,8 @@ Program::Program(                  //
   codegen::CompilerState state(stripe);
   state.const_bufs = const_bufs;
   codegen::Optimize(&state, stage.passes(), options);
-  std::map<std::string, targets::cpu::External> externals;
-  executable_->compile(*stripe->entry, externals);
+  targets::cpu::Config config;
+  executable_->compile(*stripe->entry, config);
 }
 
 Program::~Program() {}

--- a/tile/pmlc/pmlc.cc
+++ b/tile/pmlc/pmlc.cc
@@ -2,6 +2,8 @@
 
 #include "tile/pmlc/pmlc.h"
 
+#include <string>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
@@ -117,8 +119,8 @@ std::shared_ptr<Program> DefaultStage(const App& app,                      //
 #ifdef ENABLE_LLVM_BITCODE
   if (app.args.count("llvm")) {
     targets::cpu::Native native;
-    std::map<std::string, targets::cpu::External> externals;
-    native.compile(*program->entry, externals);
+    targets::cpu::Config config;
+    native.compile(*program->entry, config);
     native.save((out_dir / "stripe.bc").string());
   }
 #endif

--- a/tile/targets/cpu/jit.cc
+++ b/tile/targets/cpu/jit.cc
@@ -1553,6 +1553,9 @@ llvm::Value* Compiler::ReadCycleCounter(void) {
 }
 
 void Compiler::ProfileBlockEnter(const stripe::Block& block) {
+  if (!config_.profile_block_execution) {
+    return;
+  }
   // allocate counter variable
   std::string profile_count_name = profile_count_name_ + block.name;
   module_->getOrInsertGlobal(profile_count_name, IndexType());
@@ -1576,6 +1579,9 @@ void Compiler::ProfileBlockEnter(const stripe::Block& block) {
 }
 
 void Compiler::ProfileBlockLeave(const stripe::Block& block) {
+  if (!config_.profile_block_execution) {
+    return;
+  }
   // Add the current rdtsc back into the elapsed time counter, which both
   // corrects for the bias we introduced on function entry and accumulates
   // the elapsed time into the running total.
@@ -1757,6 +1763,7 @@ void JitExecute(const stripe::Block& program, const Config& config, const std::m
 void JitProfile(stripe::Block* program, const std::map<std::string, void*>& buffers) {
   llvm::LLVMContext context;
   Config config;
+  config.profile_block_execution = true;
   Compiler compiler(&context, config);
   auto module = compiler.CompileProgram(*program);
   Executable executable(std::move(module));

--- a/tile/targets/cpu/jit.h
+++ b/tile/targets/cpu/jit.h
@@ -20,6 +20,10 @@ namespace cpu {
 //
 typedef std::function<void*(std::vector<DataType>*, DataType*)> External;
 
+struct Config {
+  std::map<std::string, External> externals;
+};
+
 class Native {
   struct Impl;
   std::unique_ptr<Impl> m_impl;
@@ -28,15 +32,14 @@ class Native {
   Native();
   ~Native();
 
-  void compile(const stripe::Block& program, const std::map<std::string, External>& externals);
+  void compile(const stripe::Block& program, const Config& config);
   void run(const std::map<std::string, void*>& buffers);
   void save(const std::string& filename);
   void set_perf_attrs(stripe::Block* program);
 };
 
 void JitExecute(const stripe::Block& program, const std::map<std::string, void*>& buffers);
-void JitExecute(const stripe::Block& program, const std::map<std::string, External>& externals,
-                const std::map<std::string, void*>& buffers);
+void JitExecute(const stripe::Block& program, const Config& config, const std::map<std::string, void*>& buffers);
 void JitProfile(stripe::Block* program, const std::map<std::string, void*>& buffers);
 
 }  // namespace cpu

--- a/tile/targets/cpu/jit.h
+++ b/tile/targets/cpu/jit.h
@@ -21,6 +21,7 @@ namespace cpu {
 typedef std::function<void*(std::vector<DataType>*, DataType*)> External;
 
 struct Config {
+  bool profile_block_execution = false;
   std::map<std::string, External> externals;
 };
 

--- a/tile/targets/cpu/test/jit.cc
+++ b/tile/targets/cpu/test/jit.cc
@@ -568,7 +568,9 @@ TEST(Jit, JitExternalMUL_F32) {
                                                *output = DataType::FLOAT32;
                                                return reinterpret_cast<void*>(&foo_impl);
                                              }}};
-  JitExecute(*block, externals, buffers);
+  Config config;
+  config.externals = externals;
+  JitExecute(*block, config, buffers);
 
   EXPECT_THAT(b2[0], Eq(6.0));
 }


### PR DESCRIPTION
Add configuration struct to stripejit API, containing the externals definition map. Add a flag controlling the generation of block-execution profiling code, so we don't have to clutter up the IR with all that overhead unless we need it.