### PR TITLE
Update BatchDot to switch between TensorFlow/Theano Behavior

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,7 +38,7 @@ fixed).
 If you have existing Keras code that was written for the TensorFlow backend, 
 and it is running into this issue, you can enable experimental support for 
 TensorFlow-like `BatchDot` behavior by setting the environment variable 
-`PLAIDML_BATCHDOT_TF_BEHAVIOR` tto `True`.
+`PLAIDML_BATCHDOT_TF_BEHAVIOR` to `True`.
 
 `ERROR:plaidml:syntax error, unexpected -, expecting "," or )`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,22 @@ This error is caused by incorrect Tile syntax.
 
 ### PlaidML Exceptions
 
+`Applying function, tensor with mismatching dimensionality`
+
+This error may be caused by a known issue with the `BatchDot` operation, where 
+results are inconsistent across backends. The [Keras documentation for 
+BatchDot](https://keras.io/backend/#batch_dot) matches the Theano backend's 
+implemented behavior and the _default_ behavior within PlaidML. The TensorFlow 
+backend implements BatchDot in a different way, and this causes a mismatch in 
+the expected output shape (there is an [open issue against 
+TensorFlow](https://github.com/tensorflow/tensorflow/issues/30846) to get this 
+fixed).
+
+If you have existing Keras code that was written for the TensorFlow backend, 
+and it is running into this issue, you can enable experimental support for 
+TensorFlow-like `BatchDot` behavior by setting the environment variable 
+`PLAIDML_BATCHDOT_TF_BEHAVIOR` tto `True`.
+
 `ERROR:plaidml:syntax error, unexpected -, expecting "," or )`
 
 This error may be caused by special characters, such as `-`, that are used in

--- a/plaidml/keras/backend_test.py
+++ b/plaidml/keras/backend_test.py
@@ -463,17 +463,13 @@ class TestBackendOps(unittest.TestCase):
     def testDot(self, b, x, y):
         return [b.dot(x, y)]
 
-    # TODO(T1046): Once Keras is updated beyond 2.0.8, re-enable TF on batch_dot tests
-    @opTest(
-        [
-            [m(1, 2), m(1, 3, 2), (1, 2)],
-            #[m(2, 3, 4, 5), m(2, 3, 5, 1), None],
-            #[m(1, 2, 6, 2), m(1, 2, 2, 3), (3, 1)],
-            #[m(2, 3, 3, 2), m(2, 3, 4, 3), (1, 3)],
-            [m(2, 5), m(2, 5), 1],
-            #[m(2, 4, 5), m(2, 5, 1), None],
-        ],
-        skip_tensorflow=False)
+    @opTest([
+        [m(1, 2), m(1, 3, 2), (1, 2)],
+        [m(2, 5), m(2, 5), 1],
+        [m(2, 4, 5), m(2, 5, 1), None],
+    ],
+            skip_tensorflow=not bool(os.getenv('PLAIDML_BATCHDOT_TF_BEHAVIOR')),
+            skip_theano=bool(os.getenv('PLAIDML_BATCHDOT_TF_BEHAVIOR')))
     def testBatchDot(self, b, x, y, ax):
         if ax is None:
             return [b.batch_dot(x, y)]

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <stack>
 
 #include "tile/lang/builtins.h"
 #include "tile/lang/fpconv.h"
@@ -904,7 +905,10 @@ void FunctionApplication::SetInput(const std::string& name, const std::shared_pt
   if (pi.tag == Input::FIXED) {
     if (val->num_dims() != pi.dims.size()) {
       throw std::runtime_error("Applying function, tensor with mismatching dimensionality: " + name +
-                               ", expected=" + to_string(pi.dims.size()) + ", got=" + to_string(val->num_dims()));
+                               ", expected=" + to_string(pi.dims.size()) + ", got=" + to_string(val->num_dims()) +
+                               "\n Check the \"Common Issues\" section on our troubleshooting documentation to see if "
+                               "this issue has previously been sourced.\n" +
+                               "https://github.com/plaidml/plaidml/blob/master/docs/troubleshooting.md#common-issues");
     }
     for (size_t d = 0; d < pi.dims.size(); d++) {
       bindings_[pi.dims[d]] = val->dim_value(d);
@@ -952,7 +956,11 @@ void FunctionApplication::SetDone() {
     const std::shared_ptr<Value> val = func_->in_bound().at(pi.name);
     if (pi.tag == Input::FIXED) {
       if (val->num_dims() != pi.dims.size()) {
-        throw std::runtime_error("Applying function, tensor with mismatching dimensionality: " + pi.name);
+        throw std::runtime_error(
+            "Applying function, tensor with mismatching dimensionality: " + pi.name +
+            "\n Check the \"Common Issues\" section on our troubleshooting documentation to see if this issue has "
+            "previously been sourced.\n" +
+            "https://github.com/plaidml/plaidml/blob/master/docs/troubleshooting.md#common-issues");
       }
       for (size_t d = 0; d < pi.dims.size(); d++) {
         bindings_[pi.dims[d]] = val->dim_value(d);


### PR DESCRIPTION
- Updated the plaidml backend code to check for the environment variable `PLAIDML_BATCHDOT_TF_BEHAVIOR` and switch between Theano (default) and TensorFlow-like behaviors.
- Updated the plaidml backend tests to set `skip_tensorflow` and `skip_theano` based on the environment variable from above
- Updated the troubleshooting docs to add instructions for using the environment variable `PLAIDML_BATCHDOT_TF_BEHAVIOR` and which runtime error it's typically associated with
- Updated the runtime message typically associated with `BatchDot` issues to direct users to the troubleshooting docs