### PR TITLE
Fix bug in RandomUniform Bias Initializer #417

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,36 @@
+---
+bazel: 0.28.1
+tasks:
+  ubuntu1604:
+    name: ":linux:"
+    shell_commands:
+    - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    - bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
+    build_targets:
+    - "//plaidml/keras:wheel"
+    build_flags:
+    - "--config=linux_x86_64"
+    test_targets:
+    - "..."
+  macos:
+    name: ":apple:"
+    shell_commands:
+    - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh 
+    - sh ./Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda
+    build_targets:
+    - "//plaidml/keras:wheel"
+    build_flags:
+    - "--config=macos_x86_64"
+    test_targets:
+    - "..."
+  windows:
+    name: ":window:"
+    batch_commands:
+    - curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -OutFile .\miniconda.exe
+    - start /wait "" .\miniconda.exe /InstallationType=JustMe /S /D=%UserProfile%\Miniconda3
+    build_targets:
+    - "//plaidml/keras:wheel"
+    build_flags:
+    - "--config=windows_x86_64"
+    test_targets:
+    - "..."

--- a/demos/TransferLearning/README.md
+++ b/demos/TransferLearning/README.md
@@ -1,0 +1,24 @@
+# Transfer Learning Demo
+
+## Getting Started
+Use of a virtual enviornment is highly recommended although not required.
+```bash
+virtualenv .venv
+source .venv/bin/activate
+```
+
+`pip install -r requirements.txt` will install the following packages necessary for this demo to run.
+- ngraph_tensorflow_bridge
+- tensorflow==1.14.0
+- plaidml-keras
+- pillow
+- matplotlib
+- jupyter
+
+## Other details
+Menu Bar --> Cell --> Current Outputs --> Toggle Scrolling to stop Jupyter Notebook from creating scrollable boxes when the images appear.
+
+Instantiation of `TransferLearningDemo` with `verbose=1` will create a third output box where training and testing functions will output their loss and accuracy figures, along with how long the training took.
+```python
+d = TransferLearningDemo.Demo(verbose=1)
+```

--- a/demos/TransferLearning/TransferLearningDemo.ipynb
+++ b/demos/TransferLearning/TransferLearningDemo.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transfer Learning Demo\n",
+    "\n",
+    "## Getting Started\n",
+    "Use of a virtual enviornment is highly recommended although not required. \n",
+    "```bash\n",
+    "virtualenv .venv\n",
+    "source .venv/bin/activate\n",
+    "```\n",
+    "\n",
+    "`pip install -r requirements.txt` will install the following packages necessary for this demo to run.\n",
+    "- ngraph_tensorflow_bridge\n",
+    "- tensorflow==1.14.0\n",
+    "- plaidml-keras\n",
+    "- pillow\n",
+    "- matplotlib\n",
+    "- jupyter\n",
+    "\n",
+    "## Other details\n",
+    "Menu Bar --> Cell --> Current Outputs --> Toggle Scrolling to stop Jupyter Notebook from creating scrollable boxes when the images appear.\n",
+    "\n",
+    "Instantiation of `TransferLearningDemo` with `verbose=1` will create a third output box where training and testing functions will output their loss and accuracy figures, along with how long the training took. \n",
+    "```python\n",
+    "d = TransferLearningDemo.Demo(verbose=1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e1ea3309e3a44683addb5038c424fa16",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Tab(children=(VBox(children=(Dropdown(description='Model:', options=('ResNet50', 'MobileNet v2'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import TransferLearningDemo as demo\n",
+    "\n",
+    "d = demo.Demo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "d = demo.Demo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demos/TransferLearning/TransferLearningDemo.py
+++ b/demos/TransferLearning/TransferLearningDemo.py
@@ -1,0 +1,454 @@
+import warnings
+warnings.simplefilter('ignore')
+
+import ngraph_bridge
+ngraph_bridge.enable()
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.image as mpimg
+import os
+import random
+
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras.applications import ResNet50
+from tensorflow.keras.applications import MobileNetV2
+from tensorflow.keras.models import Sequential
+from tensorflow.python.keras import optimizers
+
+from keras.applications.resnet50 import preprocess_input
+from keras.preprocessing.image import ImageDataGenerator
+
+import ipywidgets as widgets
+
+from IPython.display import clear_output
+
+
+class ProgressBar(tf.keras.callbacks.Callback):
+
+    def __init__(self, demo):
+        self.demo = demo
+        self.epoch = 0
+        self.train_value = 0
+        self.train_steps_per_epoch = demo.train_generator.n // demo.batch_size
+
+    def on_train_begin(self, logs=None):
+        self.demo.progress_bar.value = self.demo.progress_bar.min
+        self.demo.progress_bar.max = self.train_steps_per_epoch * self.demo.epochs
+        self.demo.progress_text.value = "Training"
+        self.train_value = 0
+
+    def on_train_end(self, logs=None):
+        self.demo.progress_bar.value = self.demo.progress_bar.max
+        self.demo.progress_text.value = "Training Complete"
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self.epoch = epoch
+        self.demo.progress_text.value = "Training epoch " + str(epoch + 1)
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.demo.epoch_text.value = "Epoch " + str(epoch + 1) + " val_acc: " + str(
+            logs.get('val_acc'))
+
+    def on_train_batch_begin(self, batch, logs=None):
+        pass
+
+    def on_train_batch_end(self, batch, logs=None):
+        self.demo.progress_bar.value = self.epoch * self.train_steps_per_epoch + batch
+        if logs:
+            self.demo.progress_text.value = 'Training epoch ' + str(self.epoch +
+                                                                    1) + ' loss: ' + str(
+                                                                        logs.get('loss'))
+
+    def on_test_begin(self, logs=None):
+        self.demo.progress_text.value = "Validating epoch " + str(self.epoch + 1)
+
+    def on_test_batch_begin(self, batch, logs=None):
+        pass
+
+    def on_test_batch_end(self, batch, logs=None):
+        pass
+
+    def on_predict_begin(self, logs=None):
+        self.demo.progress_text.value = "Classifying"
+
+    def on_predict_batch_begin(self, batch, logs=None):
+        pass
+
+    def on_predict_batch_end(self, batch, logs=None):
+        self.demo.progress_bar.value = batch
+
+    def on_predict_end(self, batch, logs=None):
+        self.demo.progress_bar.value = self.demo.progress_bar.max
+        self.demo.progress_text.value = "Classification Complete"
+
+
+class Demo:
+    # Cats & Dogs classes
+    NUM_CLASSES = 2
+
+    # RGB
+    CHANNELS = 3
+
+    RESNET50_POOLING_AVERAGE = 'avg'
+    DENSE_LAYER_ACTIVATION = 'softmax'
+    OBJECTIVE_FUNCTION = 'categorical_crossentropy'
+
+    # Common accuracy metric for all outputs, but can use different metrics for different output
+    LOSS_METRICS = ['accuracy']
+
+    IMAGE_SIZE = 160  # All images will be resized to 160x160
+    IMAGE_SHAPE = (IMAGE_SIZE, IMAGE_SIZE, 3)
+
+    batch_size = 32
+    epochs = 2
+    fine_tune_at = 100
+
+    ngraph_backends = ngraph_bridge.list_backends()
+    ngraph_backends.append('DISABLED')
+    ngraph_bridge.set_backend(ngraph_backends[0])
+
+    base_model = None
+    model = None
+
+    # GUI Elements
+    out = widgets.Output(layout={'border': '1px solid black'})
+    out_initial = widgets.Output(layout={'border': '1px solid black'})
+    out_stats = widgets.Output(layout={'border': '1px solid black'})
+
+    model_dropdown = widgets.Dropdown(options=['ResNet50', 'MobileNet v2'],
+                                      value='ResNet50',
+                                      description='Model:')
+    ngraph_dropdown = widgets.Dropdown(options=ngraph_backends,
+                                       value=ngraph_backends[0],
+                                       description='nGraph:')
+
+    progress_bar = widgets.IntProgress()
+    progress_text = widgets.Label()
+    epoch_text = widgets.Label()
+    progress_box = widgets.HBox([progress_bar, progress_text, epoch_text])
+
+    batch_slider = widgets.IntSlider(min=1, max=100, value=batch_size, description='Batch Size:')
+    epoch_slider = widgets.IntSlider(min=1, max=16, value=epochs, description='Epochs:')
+    fine_tune_slider = widgets.IntSlider(min=1,
+                                         max=500,
+                                         value=fine_tune_at,
+                                         description='Fine Tune at Layer:')
+
+    train_button = widgets.Button(description='Train', disabled=True)
+    classify_button = widgets.Button(description='Classify', disabled=True)
+    fine_tune_button = widgets.Button(description='Fine Tune', disable=True)
+    shuffle_button = widgets.Button(description='Shuffle')
+
+    training_tab = widgets.VBox(children=[
+        model_dropdown, ngraph_dropdown, batch_slider, epoch_slider, train_button, classify_button,
+        shuffle_button
+    ])
+    fine_tuning_tab = widgets.VBox(children=[
+        batch_slider, epoch_slider, fine_tune_slider, fine_tune_button, classify_button,
+        shuffle_button
+    ])
+    tab = widgets.Tab(children=[training_tab, fine_tuning_tab])
+    tab.set_title(0, 'Training')
+    tab.set_title(1, 'Fine Tuning')
+    gui = widgets.VBox(children=[tab, progress_box, out_initial, out])
+
+    def __init__(self, verbose=0, test=0):
+        self.verbose = verbose
+        self.test = test
+
+        if verbose:
+            self.gui = widgets.VBox(
+                children=[self.tab, self.progress_box, self.out_initial, self.out, self.out_stats])
+
+        # Images
+        self.test_class_indices = []
+        self.test_dir = None
+        self.init_images()
+
+        self.sgd = optimizers.SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+        self.predicted_class_indices_init = []
+        self.wrong_guesses = []
+
+        if not test:
+            display(self.init_gui())
+
+        self.train_button.disabled = False
+        self.fine_tune_button.disabled = False
+
+        self.init_model()
+
+    def init_images(self):
+        zip_file = tf.keras.utils.get_file(
+            origin="https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip",
+            fname="cats_and_dogs_filtered.zip",
+            extract=True)
+        base_dir, _ = os.path.splitext(zip_file)
+        train_dir = os.path.join(base_dir, 'train')
+        validation_dir = os.path.join(base_dir, 'validation')
+        self.test_dir = os.path.join(base_dir, 'test')
+        if not os.path.exists(self.test_dir):
+            os.makedirs(self.test_dir)
+
+        # Directory with our training cat pictures
+        train_cats_dir = os.path.join(train_dir, 'cats')
+
+        # Directory with our training dog pictures
+        train_dogs_dir = os.path.join(train_dir, 'dogs')
+
+        # Directory with our validation cat pictures
+        validation_cats_dir = os.path.join(validation_dir, 'cats')
+
+        # Directory with our validation dog pictures
+        validation_dogs_dir = os.path.join(validation_dir, 'dogs')
+
+        # Directory with our test cat pictures
+        test_cats_dir = os.path.join(self.test_dir, 'cats')
+        if not os.path.exists(test_cats_dir):
+            os.makedirs(test_cats_dir)
+            for i in range(900, 1000):
+                os.rename(train_cats_dir + '/cat.' + str(i) + '.jpg',
+                          test_cats_dir + '/cat.' + str(i) + '.jpg')
+
+        # Directory with our test dog pictures
+        test_dogs_dir = os.path.join(self.test_dir, 'dogs')
+        if not os.path.exists(test_dogs_dir):
+            os.makedirs(test_dogs_dir)
+            for i in range(900, 1000):
+                os.rename(train_dogs_dir + '/dog.' + str(i) + '.jpg',
+                          test_dogs_dir + '/dog.' + str(i) + '.jpg')
+
+        # Preprocess images
+        train_datagen = ImageDataGenerator(preprocessing_function=preprocess_input)
+        validation_datagen = ImageDataGenerator(preprocessing_function=preprocess_input)
+
+        with self.out_stats:
+            # Flow training images in batches of 20 using train_datagen generator
+            self.train_generator = train_datagen.flow_from_directory(
+                train_dir,  # Source directory for the training images
+                target_size=(self.IMAGE_SIZE, self.IMAGE_SIZE),
+                batch_size=self.batch_size,
+                class_mode='categorical')
+
+            # Flow validation images in batches of 20 using test_datagen generator
+            self.validation_generator = validation_datagen.flow_from_directory(
+                validation_dir,  # Source directory for the validation images
+                target_size=(self.IMAGE_SIZE, self.IMAGE_SIZE),
+                batch_size=self.batch_size,
+                class_mode='categorical')
+
+            # Flow validation images in batches of 20 using test_datagen generator
+            self.test_generator = validation_datagen.flow_from_directory(
+                self.test_dir,  # Source directory for the test images
+                target_size=(self.IMAGE_SIZE, self.IMAGE_SIZE),
+                batch_size=self.batch_size,
+                class_mode=None,
+                shuffle=False,
+                seed=42)
+
+        # Test Correct Values (0 Cat, 1 Dog)
+        for file in self.test_generator.filenames:
+            if "cat" in file:
+                self.test_class_indices.append(0)
+            elif "dog" in file:
+                self.test_class_indices.append(1)
+            else:
+                print("Error, unclassifiable image " + file)
+
+    def init_model(self, b=None):
+        self.out_initial.clear_output()
+        self.out.clear_output()
+        self.out_stats.clear_output()
+
+        # Initial prediction
+        self.progress_bar.max = 13
+        self.progress_text.value = "Calculating Initital Predictions"
+
+        with self.out:
+            self.compile_model(self.model_dropdown.value)
+        predictions_initial = self.model.predict_generator(self.test_generator,
+                                                           verbose=0,
+                                                           callbacks=[ProgressBar(self)])
+        self.predicted_class_indices_init = np.argmax(predictions_initial, axis=1)
+
+        # ~ operator is equivalent to -x-1; so 0 becomes -1, 1 becomes -2; add 2 to implement xnor
+        guesses = ~(self.predicted_class_indices_init ^ self.test_class_indices) + 2
+
+        # Randomly select 9 images that guessed incorrectly
+        self.wrong_guesses = []
+        while len(self.wrong_guesses) < 9:
+            randomIndex = random.randint(0, len(self.predicted_class_indices_init) - 1)
+            if not guesses[randomIndex]:
+                self.wrong_guesses.append(randomIndex)
+
+        with self.out_initial:
+            f, ax = plt.subplots(3, 3, figsize=(15, 15))
+
+            for i in range(0, 9):
+                test_image = os.path.join(self.test_dir,
+                                          self.test_generator.filenames[self.wrong_guesses[i]])
+                imgRGB = mpimg.imread(test_image)
+
+                predicted_class = "Dog" if self.predicted_class_indices_init[
+                    self.wrong_guesses[i]] else "Cat"
+
+                ax[i // 3, i % 3].imshow(imgRGB)
+                ax[i // 3, i % 3].axis('off')
+                ax[i // 3, i % 3].set_title("Predicted:{}".format(predicted_class), color='r')
+
+                if predicted_class.lower() in self.test_generator.filenames[self.wrong_guesses[i]]:
+                    ax[i // 3, i % 3].set_title("Predicted:{}".format(predicted_class), color='g')
+            plt.show()
+
+    def on_model_change(self, change):
+        if change['type'] == 'change' and change['name'] == 'value':
+            self.classify_button.disabled = True
+
+            if change['new'] == 'ResNet50':
+                self.epoch_slider.min = 1
+                self.epoch_slider.max = 16
+                self.epoch_slider.value = 2
+            if change['new'] == 'MobileNet v2':
+                self.epoch_slider.min = 2
+                self.epoch_slider.max = 50
+                self.epoch_slider.value = 10
+
+    def on_ngraph_change(self, change):
+        if change['type'] == 'change' and change['name'] == 'value':
+            i = self.ngraph_backends.index(change['new'])
+
+            if self.ngraph_backends[i] == 'DISABLED':
+                self.use_ngraph = False
+                ngraph_bridge.disable()
+            else:
+                self.use_ngraph = True
+                ngraph_bridge.enable()
+                ngraph_bridge.set_backend(self.ngraph_backends[i])
+
+    def init_gui(self):
+        self.model_dropdown.observe(self.on_model_change)
+        self.ngraph_dropdown.observe(self.on_ngraph_change)
+        self.train_button.on_click(self.train_model)
+        self.shuffle_button.on_click(self.init_model)
+        self.classify_button.on_click(self.classify)
+        self.fine_tune_button.on_click(self.train_model)
+
+        return self.gui
+
+    def train_model(self, b=None, epochs=1, batch_size=32, model='ResNet50', fine_tune_at=0):
+        if not self.test:
+            self.train_button.disabled = True
+            self.epochs = self.epoch_slider.value
+            self.batch_size = self.batch_slider.value
+            model = self.model_dropdown.value
+            self.progress_text.value = ''
+        else:
+            self.epochs = epochs
+            self.batch_size = batch_size
+
+        self.out.clear_output()
+
+        if b == self.fine_tune_button:
+            fine_tune_at = self.fine_tune_slider.value
+        else:
+            fine_tune_at = 0
+
+        self.compile_model(model, fine=fine_tune_at)
+        steps_per_epoch = self.train_generator.n // self.batch_size
+        validation_steps = self.validation_generator.n // self.batch_size
+
+        with self.out_stats:
+            history = self.model.fit_generator(self.train_generator,
+                                               steps_per_epoch=steps_per_epoch,
+                                               epochs=self.epochs,
+                                               workers=8,
+                                               validation_data=self.validation_generator,
+                                               validation_steps=validation_steps,
+                                               verbose=self.verbose,
+                                               callbacks=[ProgressBar(self)])
+        self.classify_button.disabled = False
+        # Test model immediately after training
+        self.classify(b)
+
+        self.train_button.disabled = False
+
+        return history
+
+    def compile_model(self, modelName, fine=0):
+        if modelName == 'ResNet50':
+            self.base_model = ResNet50(input_shape=self.IMAGE_SHAPE,
+                                       include_top=False,
+                                       weights='imagenet')
+        elif modelName == 'MobileNet v2':
+            self.base_model = MobileNetV2(input_shape=self.IMAGE_SHAPE,
+                                          include_top=False,
+                                          weights='imagenet')
+
+        # GUI element update
+        self.fine_tune_slider.max = len(self.base_model.layers)
+
+        with self.out_stats:
+            print('Setting base model to ' + modelName)
+
+        # Fine Tuning
+        if fine:
+            self.base_model.trainable = True
+            # Fine tune from this layer onwards
+            self.fine_tune_at = fine
+
+            # Freeze all the layers before the `fine_tune_at` layer
+            for layer in self.base_model.layers[:self.fine_tune_at]:
+                layer.trainable = False
+
+            with self.out_stats:
+                print('Fine tuning at layer ' + str(fine))
+
+        # Training
+        else:
+            self.base_model.trainable = False
+
+        # Add layers
+        self.model = tf.keras.Sequential([
+            self.base_model,
+            keras.layers.GlobalAveragePooling2D(),
+            keras.layers.Dense(self.NUM_CLASSES, activation=self.DENSE_LAYER_ACTIVATION)
+        ])
+        self.model.compile(optimizer=self.sgd,
+                           loss=self.OBJECTIVE_FUNCTION,
+                           metrics=self.LOSS_METRICS)
+
+    def classify(self, b):
+        if b and b.description == 'Classify':
+            out.clear_output()
+
+        with self.out_stats:
+            probabilities = self.model.predict_generator(self.test_generator,
+                                                         verbose=self.verbose,
+                                                         callbacks=[ProgressBar(self)])
+
+        predicted_class_indices = np.argmax(probabilities, axis=1)
+
+        with self.out:
+            f, ax = plt.subplots(3, 3, figsize=(15, 15))
+
+            for i in range(0, 9):
+                test_image = os.path.join(self.test_dir,
+                                          self.test_generator.filenames[self.wrong_guesses[i]])
+                imgRGB = mpimg.imread(test_image)
+
+                predicted_class = "Dog" if predicted_class_indices[
+                    self.wrong_guesses[i]] else "Cat"
+
+                ax[i // 3, i % 3].imshow(imgRGB)
+                ax[i // 3, i % 3].axis('off')
+                ax[i // 3, i % 3].set_title("Predicted:{}".format(predicted_class), color='r')
+
+                if predicted_class.lower() in self.test_generator.filenames[self.wrong_guesses[i]]:
+                    ax[i // 3, i % 3].set_title("Predicted:{}".format(predicted_class), color='g')
+            plt.show()
+
+        with self.out_stats:
+            wrong = ~(predicted_class_indices ^ self.test_class_indices) + 2
+            print("Correct Matrix")
+            print(wrong)

--- a/demos/TransferLearning/requirements.txt
+++ b/demos/TransferLearning/requirements.txt
@@ -1,0 +1,6 @@
+ngraph_tensorflow_bridge
+tensorflow == 1.14.0
+plaidml-keras
+pillow
+matplotlib
+jupyter

--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -1188,6 +1188,9 @@ def random_normal_variable(shape, mean, scale, dtype=None, name=None, seed=None)
 
 
 def random_uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
+    if minval == maxval:
+        return constant(minval, dtype, shape)
+
     dtype = dtype or floatx()
     rng_state = _make_rng_state(seed)
     shape_inputs = []

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -168,7 +168,6 @@ std::shared_ptr<Value> FunctionValue::make(std::string fn, std::vector<std::shar
       return inputs[0];
     }
   }
-  
   if (fn == "mul") {
     if (inputs[0] == zeroi || inputs[0] == zerof) {
       return inputs[0];
@@ -182,7 +181,7 @@ std::shared_ptr<Value> FunctionValue::make(std::string fn, std::vector<std::shar
     if (inputs[1] == onei || inputs[1] == onef) {
       return inputs[0];
     }
-	}
+  }
   if (fn == "match" && inputs[0] == inputs[1]) {
     return inputs[0];
   }

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -168,20 +168,6 @@ std::shared_ptr<Value> FunctionValue::make(std::string fn, std::vector<std::shar
       return inputs[0];
     }
   }
-  if (fn == "mul") {
-    if (inputs[0] == zeroi || inputs[0] == zerof) {
-      return inputs[0];
-    }
-    if (inputs[1] == zeroi || inputs[1] == zerof) {
-      return inputs[1];
-    }
-    if (inputs[0] == onei || inputs[0] == onef) {
-      return inputs[1];
-    }
-    if (inputs[1] == onei || inputs[1] == onef) {
-      return inputs[0];
-    }
-  }
   if (fn == "match" && inputs[0] == inputs[1]) {
     return inputs[0];
   }

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <sstream>
-#include <stack>
 
 #include "tile/lang/builtins.h"
 #include "tile/lang/fpconv.h"

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -905,10 +905,7 @@ void FunctionApplication::SetInput(const std::string& name, const std::shared_pt
   if (pi.tag == Input::FIXED) {
     if (val->num_dims() != pi.dims.size()) {
       throw std::runtime_error("Applying function, tensor with mismatching dimensionality: " + name +
-                               ", expected=" + to_string(pi.dims.size()) + ", got=" + to_string(val->num_dims()) +
-                               "\n Check the \"Common Issues\" section on our troubleshooting documentation to see if "
-                               "this issue has previously been sourced.\n" +
-                               "https://github.com/plaidml/plaidml/blob/master/docs/troubleshooting.md#common-issues");
+                               ", expected=" + to_string(pi.dims.size()) + ", got=" + to_string(val->num_dims()));
     }
     for (size_t d = 0; d < pi.dims.size(); d++) {
       bindings_[pi.dims[d]] = val->dim_value(d);
@@ -957,10 +954,7 @@ void FunctionApplication::SetDone() {
     if (pi.tag == Input::FIXED) {
       if (val->num_dims() != pi.dims.size()) {
         throw std::runtime_error(
-            "Applying function, tensor with mismatching dimensionality: " + pi.name +
-            "\n Check the \"Common Issues\" section on our troubleshooting documentation to see if this issue has "
-            "previously been sourced.\n" +
-            "https://github.com/plaidml/plaidml/blob/master/docs/troubleshooting.md#common-issues");
+            "Applying function, tensor with mismatching dimensionality: " + pi.name);
       }
       for (size_t d = 0; d < pi.dims.size(); d++) {
         bindings_[pi.dims[d]] = val->dim_value(d);

--- a/tile/lang/compose.cc
+++ b/tile/lang/compose.cc
@@ -168,6 +168,21 @@ std::shared_ptr<Value> FunctionValue::make(std::string fn, std::vector<std::shar
       return inputs[0];
     }
   }
+  
+  if (fn == "mul") {
+    if (inputs[0] == zeroi || inputs[0] == zerof) {
+      return inputs[0];
+    }
+    if (inputs[1] == zeroi || inputs[1] == zerof) {
+      return inputs[1];
+    }
+    if (inputs[0] == onei || inputs[0] == onef) {
+      return inputs[1];
+    }
+    if (inputs[1] == onei || inputs[1] == onef) {
+      return inputs[0];
+    }
+	}
   if (fn == "match" && inputs[0] == inputs[1]) {
     return inputs[0];
   }

--- a/tile/targets/cpu/jit.cc
+++ b/tile/targets/cpu/jit.cc
@@ -42,6 +42,7 @@ const char invoker_name_[] = "__invoke_";
 const char arena_name_[] = "__arena";
 const char profile_count_name_[] = "__profile_count_";
 const char profile_ticks_name_[] = "__profile_ticks_";
+const char profile_loop_body_name_[] = "__profile_loop_body_";
 }  // namespace
 
 struct ProgramModule {
@@ -186,6 +187,8 @@ class Compiler : private stripe::ConstStmtVisitor {
   llvm::Value* ReadCycleCounter();
   void ProfileBlockEnter(const stripe::Block& block);
   void ProfileBlockLeave(const stripe::Block& block);
+  void ProfileLoopEnter(const stripe::Block& block);
+  void ProfileLoopLeave(const stripe::Block& block);
   bool isXSMMSuppotedDataType(DataType dataType);
   const DataType GetBlockRefsDataType(const stripe::Block& block);
   llvm::Value* RunTimeLogEntry(void);
@@ -688,12 +691,16 @@ llvm::Function* Compiler::CompileBlock(const stripe::Block& block) {
   builder_.CreateCondBr(go, block_body, block_done);
   builder_.SetInsertPoint(block_body);
 
+  ProfileLoopEnter(block);
+
   // process each statement in the block body, generating code to modify the
   // parameter buffer contents
   std::shared_ptr<stripe::Block> pBlock = std::make_shared<stripe::Block>(block);
   for (const auto& stmt : block.stmts) {
     stmt->Accept(this);
   }
+
+  ProfileLoopLeave(block);
 
   // rejoin instruction flow after the constraint check
   builder_.CreateBr(block_done);
@@ -1628,6 +1635,32 @@ void Compiler::ProfileBlockLeave(const stripe::Block& block) {
   builder_.CreateStore(profile_ticks, profile_ticks_gval);
 }
 
+void Compiler::ProfileLoopEnter(const stripe::Block& block) {
+  if (!config_.profile_loop_body) {
+    return;
+  }
+  // Count the time spent in the loop body, excluding increment/condition
+  // overhead
+  std::string profile_name = profile_loop_body_name_ + block.name;
+  module_->getOrInsertGlobal(profile_name, IndexType());
+  auto profile_gval = module_->getNamedGlobal(profile_name);
+  profile_gval->setInitializer(llvm::Constant::getNullValue(IndexType()));
+  llvm::Value* profile_ticks = builder_.CreateLoad(profile_gval);
+  profile_ticks = builder_.CreateSub(profile_ticks, ReadCycleCounter());
+  builder_.CreateStore(profile_ticks, profile_gval);
+}
+
+void Compiler::ProfileLoopLeave(const stripe::Block& block) {
+  if (!config_.profile_loop_body) {
+    return;
+  }
+  std::string profile_name = profile_loop_body_name_ + block.name;
+  auto profile_gval = module_->getNamedGlobal(profile_name);
+  llvm::Value* profile_ticks = builder_.CreateLoad(profile_gval);
+  profile_ticks = builder_.CreateAdd(profile_ticks, ReadCycleCounter());
+  builder_.CreateStore(profile_ticks, profile_gval);
+}
+
 Executable::Executable(const ProgramModule& module) : parameters_(module.parameters) {
   std::string errStr;
   std::unique_ptr<llvm::LegacyJITSymbolResolver> rez(new Runtime(module.externals));
@@ -1669,6 +1702,11 @@ void Executable::SetPerfAttrs(stripe::Block* block) {
   uint64_t ticks_addr = engine_->getGlobalValueAddress(ticks_name);
   if (ticks_addr) {
     block->set_attr("execution_ticks", *reinterpret_cast<int64_t*>(ticks_addr));
+  }
+  std::string loop_body_name = profile_loop_body_name_ + block->name;
+  uint64_t loop_ticks_addr = engine_->getGlobalValueAddress(loop_body_name);
+  if (loop_ticks_addr) {
+    block->set_attr("loop_body_ticks", *reinterpret_cast<int64_t*>(loop_ticks_addr));
   }
   // Recurse through nested blocks.
   for (const auto& stmt : block->stmts) {

--- a/tile/targets/cpu/jit.h
+++ b/tile/targets/cpu/jit.h
@@ -22,6 +22,7 @@ typedef std::function<void*(std::vector<DataType>*, DataType*)> External;
 
 struct Config {
   bool profile_block_execution = false;
+  bool profile_loop_body = false;
   std::map<std::string, External> externals;
 };
 


### PR DESCRIPTION
The bug is mainly caused by calling random_uniform with minval == maxval.

rseed = 12345
model = keras.Sequential()
b = keras.initializers.RandomUniform(minval=-1.0, maxval=-1.0, seed=rseed)·
model.add(layers.Dense(16,
                            input_shape=(1,1000),
                            activation=keras.activations.elu,
                            use_bias=True,
                            bias_initializer=b,
                            )) 
print (model.layers[0].get_weights())

When minval = maxval, the tile language does the constant propagation and return a scalar.
However, the returned scalar is always zero no matter the value.
The reason is that we should return a tensor with broadcast zero when doing constant folding.

Below shows the aggressive optimization for the "mul" operation.
Here is an example of the compiled tile code with error:
The RevMul function only has one scalar operand.
 
DEBUG:plaidml:Doing a compilation of:
function (
 X_I_0[X_I_0_0, X_I_0_1]
 ) -> (
 X_T2,
 X_T3
 ) {
 X_T0 = 16;
 [[pid(PrngStep)]] X_T1 = prng_step(X_I_0, X_T0);
 [[pid(PrngState)]] X_T2 = prng_state(X_T1);
 [[pid(RevMul)]] X_T3 = -1.0;
}

DEBUG:plaidml:Compiling: function (
X_I_0[X_I_0_0, X_I_0_1]) -> (
X_T2,
X_T3
) {
X_T0 = 16;
[[pid(PrngStep)]] X_T1 = prng_step(X_I_0, X_T0);
[[pid(PrngState)]] X_T2 = prng_state(X_T1);
[[pid(Add)]] X_T3 = -1.0;
}

Here is the right tile code after the optimization:
X_I_0[X_I_0_0, X_I_0_1]
 ) -> (
X_T2,
X_T7
) {
X_T0 = 16;
[[pid(PrngStep)]] X_T1 = prng_step(X_I_0, X_T0);
[[pid(PrngState)]] X_T2 = prng_state(X_T1);
X_T3 = -1.0;
X_T4 = 0.0;
[[pid(PrngValue)]] X_T5 = prng_value(X_T1);
[[pid(RevMul)]] X_T6 = mul(X_T4, X_T5);
[[pid(Add)]] X_T7 = add(X_T3, X_T6);
}
