### PR TITLE
Fix Transfer Learning Demo

### DIFF
--- a/demos/TransferLearning/requirements.txt
+++ b/demos/TransferLearning/requirements.txt
@@ -4,3 +4,5 @@ plaidml-keras
 pillow
 matplotlib
 jupyter
+IPython
+argparse


### PR DESCRIPTION
I've fixed a few things and added a few things to the demo:
* fixed missing imports
* changed the `verbose` argument to `gui` to more properly reflect what it is doing
* added a `training` option to access training from the command line
* added argparse
* added a default program to execute upon calling `python3 TransferLearningDemo.py`

I'd like to refine the arguments that are available to the user at the command line, but this is the bare minimum that's necessary for the nGraph team to be able to include this in their CI.