### PR TITLE
Downgrade to keras 2.2.4

### DIFF
--- a/conda/unix.yml
+++ b/conda/unix.yml
@@ -16,7 +16,7 @@ dependencies:
     - defaultlist
     - graphviz
     - humanize
-    - keras==2.2.5
+    - keras==2.2.4
     - keras-applications==1.0.8
     - matplotlib
     - networkx

--- a/conda/windows.yml
+++ b/conda/windows.yml
@@ -15,7 +15,7 @@ dependencies:
     - defaultlist
     - graphviz
     - humanize
-    - keras==2.2.5
+    - keras==2.2.4
     - keras-applications==1.0.8
     - networkx
     - pandas


### PR DESCRIPTION
Trying to run plaidbench on common models causes issues on plaidml2 bridge (and possibly on plaidml)