### PR TITLE
Implement calls to XSMM for all Stripe types. Perf improvements.

### DIFF
--- a/plaidml/keras/backend_test.py
+++ b/plaidml/keras/backend_test.py
@@ -1733,6 +1733,15 @@ class TestBackendOps(unittest.TestCase):
         o = b.relu(c)
         return [o]
 
+    @opTest([[m(1, 8, 8, 16), m(3, 3, 16, 16)]],
+            do_grads=False,
+            num_iterations=10,
+            measure_eval_time=True)
+    def resnetLayer35(self, b, x, k):
+        c = b.conv2d(x, k, padding='same')
+        o = b.relu(c)
+        return [o]
+
     @opTest([[m(1, 96, 96, 192), m(8, 8, 192, 192)]],
             do_grads=False,
             num_iterations=10,

--- a/tile/targets/cpu/executable.cc
+++ b/tile/targets/cpu/executable.cc
@@ -149,6 +149,8 @@ llvm::JITSymbol Runtime::findSymbol(const std::string& name) {
       {"_libxsmm_dmmdispatch", symInfo(libxsmm_dmmdispatch)},
       {"RunTimeLogEntry", symInfo(rt::RunTimeLogEntry)},   // For debugging
       {"_RunTimeLogEntry", symInfo(rt::RunTimeLogEntry)},  // For debugging
+      {"libxsmm_wimmdispatch", symInfo(libxsmm_wimmdispatch)},
+      {"_libxsmm_wimmdispatch", symInfo(libxsmm_wimmdispatch)},
   };
   auto loc_rt = symbols.find(name);
   if (loc_rt != symbols.end()) {


### PR DESCRIPTION
This changes adds the libxsmm_wimmdispatch calls when needed to support GEMM of (int8, uint8)--->int32.
It also has changes to the memory handling that result perf improvements.
With these changes the PlaidML GEMM for matrix 56, 56, 64 is now 12-13 x faster.

With fusing and no XSMM
===================
OK
Evaluating tf took: 0.02387213706970215 sec.
Evaluating tf took: 0.0019199848175048828 sec.
Evaluating tf took: 0.0031540393829345703 sec.
Evaluating tf took: 0.0017769336700439453 sec.
Evaluating tf took: 0.0019960403442382812 sec.
Evaluating tf took: 0.0017399787902832031 sec.
Evaluating tf took: 0.003194093704223633 sec.
Evaluating tf took: 0.0055942535400390625 sec.
Evaluating tf took: 0.0032258033752441406 sec.
Evaluating tf took: 0.004317045211791992 sec.
Evaluating pldml took: 0.38541698455810547 sec.
Evaluating pldml took: 0.09659004211425781 sec.
Evaluating pldml took: 0.09834408760070801 sec.
Evaluating pldml took: 0.10050320625305176 sec.
Evaluating pldml took: 0.09867000579833984 sec.
Evaluating pldml took: 0.09192585945129395 sec.
Evaluating pldml took: 0.08640408515930176 sec.
Evaluating pldml took: 0.08695411682128906 sec.
Evaluating pldml took: 0.08470892906188965 sec.
Evaluating pldml took: 0.08933091163635254 sec.

With XSMM and fusing
=================
OK
Evaluating tf took: 0.021768808364868164 sec.
Evaluating tf took: 0.0020678043365478516 sec.
Evaluating tf took: 0.0034360885620117188 sec.
Evaluating tf took: 0.0018949508666992188 sec.
Evaluating tf took: 0.001901865005493164 sec.
Evaluating tf took: 0.00333404541015625 sec.
Evaluating tf took: 0.0018589496612548828 sec.
Evaluating tf took: 0.0044939517974853516 sec.
Evaluating tf took: 0.002611875534057617 sec.
Evaluating tf took: 0.0018718242645263672 sec.
Evaluating pldml took: 0.27568936347961426 sec.
Evaluating pldml took: 0.006665229797363281 sec.
Evaluating pldml took: 0.007693052291870117 sec.
Evaluating pldml took: 0.007191181182861328 sec.
Evaluating pldml took: 0.007227897644042969 sec.
Evaluating pldml took: 0.007186174392700195 sec.
Evaluating pldml took: 0.007190704345703125 sec.
Evaluating pldml took: 0.0074918270111083984 sec.
Evaluating pldml took: 0.0071637630462646484 sec.
Evaluating pldml took: 0.0070989131927490234 sec.