### PR TITLE
Create external CI integration documentation

### DIFF
--- a/docs/integrating_into_ci.md
+++ b/docs/integrating_into_ci.md
@@ -1,0 +1,15 @@
+# Integrating PlaidML into your project's CI infrastructure
+
+# Instantiating PlaidML Programmatically
+
+If you want to instantiate PlaidML from the command line, you can set the following environment variables to select the proper configurations for your device. This is equivalent to running `plaidml-setup` and selecting these settings when prompted.
+
+    - `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable experimental mode in PlaidML
+    - `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use with PlaidML (to see a list of devices, run `plaidml-setup`)
+
+Below is an example of how to set the device configuration environment variables for PlaidML.
+
+```
+export PLAIDML_EXPERIMENTAL=true
+export PLAIDML_DEVICE_IDS=opencl_intel_uhd_graphics_630.0
+```

--- a/docs/integrating_into_ci.md
+++ b/docs/integrating_into_ci.md
@@ -7,7 +7,7 @@ following environment variables to select the proper configurations for your
 device. This is equivalent to running `plaidml-setup` and selecting these
 settings when prompted.
 
-  * `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable
+  * `PLAIDML_EXPERIMENTAL` - int (0 or 1) which determines whether to enable
      experimental mode in PlaidML 
   * `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use
      with PlaidML (to see a list of devices, run `plaidml-setup`)
@@ -16,6 +16,6 @@ Below is an example of how to set the device configuration environment variables
 for PlaidML.
 
 ```
-export PLAIDML_EXPERIMENTAL=true
+export PLAIDML_EXPERIMENTAL=1
 export PLAIDML_DEVICE_IDS=opencl_intel_uhd_graphics_630.0
 ```

--- a/docs/integrating_into_ci.md
+++ b/docs/integrating_into_ci.md
@@ -4,8 +4,8 @@
 
 If you want to instantiate PlaidML from the command line, you can set the following environment variables to select the proper configurations for your device. This is equivalent to running `plaidml-setup` and selecting these settings when prompted.
 
-    - `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable experimental mode in PlaidML
-    - `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use with PlaidML (to see a list of devices, run `plaidml-setup`)
+  * `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable experimental mode in PlaidML
+  * `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use with PlaidML (to see a list of devices, run `plaidml-setup`)
 
 Below is an example of how to set the device configuration environment variables for PlaidML.
 

--- a/docs/integrating_into_ci.md
+++ b/docs/integrating_into_ci.md
@@ -2,12 +2,18 @@
 
 # Instantiating PlaidML Programmatically
 
-If you want to instantiate PlaidML from the command line, you can set the following environment variables to select the proper configurations for your device. This is equivalent to running `plaidml-setup` and selecting these settings when prompted.
+If you want to instantiate PlaidML from the command line, you can set the
+following environment variables to select the proper configurations for your
+device. This is equivalent to running `plaidml-setup` and selecting these
+settings when prompted.
 
-  * `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable experimental mode in PlaidML
-  * `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use with PlaidML (to see a list of devices, run `plaidml-setup`)
+  * `PLAIDML_EXPERIMENTAL` - boolean which determines whether to enable
+     experimental mode in PlaidML 
+  * `PLAIDML_DEVICE_IDS` - string which contains the name of the device to use
+     with PlaidML (to see a list of devices, run `plaidml-setup`)
 
-Below is an example of how to set the device configuration environment variables for PlaidML.
+Below is an example of how to set the device configuration environment variables
+for PlaidML.
 
 ```
 export PLAIDML_EXPERIMENTAL=true


### PR DESCRIPTION
As requested by nGraph, I've created a piece of documentation that contains information that people integrating PlaidML into their own CI infrastructure might want to know. Let me know if you think anything else should be added.