### PR TITLE
add conda PATH to the presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,7 @@ tasks:
     shell_commands:
     - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     - bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
+    - export PATH=$HOME/miniconda/bin:$PATH
     build_targets:
     - "//plaidml/keras:wheel"
     build_flags:
@@ -17,6 +18,7 @@ tasks:
     shell_commands:
     - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh 
     - sh ./Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda
+    - export PATH=$HOME/miniconda/bin:$PATH
     build_targets:
     - "//plaidml/keras:wheel"
     build_flags:


### PR DESCRIPTION
For our miniconda install to work properly, we need to set the `PATH` environment variable to include the miniconda install location.