### PR TITLE
Use right target after splitting cpu into llvm_cpu and opencl_cpu

### DIFF
--- a/tile/platform/stripejit/platform.cc
+++ b/tile/platform/stripejit/platform.cc
@@ -30,7 +30,7 @@ std::unique_ptr<tile::Program> Platform::MakeProgram(  //
   runinfo.input_shapes = FromProto(program.inputs());
   runinfo.output_shapes = FromProto(program.outputs());
   runinfo.program_name = "stripe_program";
-  return std::make_unique<Program>("cpu", runinfo, const_bufs);
+  return std::make_unique<Program>("llvm_cpu", runinfo, const_bufs);
 }
 
 std::shared_ptr<tile::Program> Platform::MakeProgram(const context::Context& ctx,   //


### PR DESCRIPTION
Use llvm_cpu when running NNs.
The target/deviceID got changed from "cpu" to "llvm_cpu" and "opencl_cpu", but the platform config script didn't change.
This results in the following error when trying to run resnet50 NN.
  [libprotobuf FATAL external/com_google_protobuf/src/google/protobuf/map.h:1060] CHECK failed: it != end(): key not found: cpu
  CHECK failed: it != end(): key not found: cpu

This change sets the target/device used for the NN run to be llvm_cpu.