### PR TITLE
Fix PlaidML2 Setup (via exec.run fix)

### DIFF
--- a/plaidml2/exec/__init__.py
+++ b/plaidml2/exec/__init__.py
@@ -74,5 +74,5 @@ class Executable(ForeignObject):
 
 
 def run(program, inputs, device=None, target=None):
-    exe = compile(program, [x for x, y in inputs], device=device, target=target)
+    exe = Executable(program, [x for x, y in inputs], device=device, target=target)
     return [x.as_ndarray() for x in exe([y for x, y in inputs])]


### PR DESCRIPTION
`plaidml2.exec.run` was calling Python's built in `compile` function, which seemed wrong (and was causing plaidml2 setup to crash)