### PR TITLE
Enable symbolic EDSL PRNG shape

### DIFF
--- a/plaidml2/bridge/keras/__init__.py
+++ b/plaidml2/bridge/keras/__init__.py
@@ -722,7 +722,8 @@ def dropout(x, level, noise_shape=None, seed=None):
     if noise_shape is not None and len(noise_shape) != I.shape.ndims:
         raise ValueError('noise_shape ndims doesn\'t match input ndims')
     if noise_shape is None:
-        shape = I.shape.dims
+        shape = edsl.TensorDims(I.shape.ndims)
+        I.bind_dims(*shape)
     else:
         shape = noise_shape
     rng_state = _make_rng_state(seed)

--- a/tile/lang/ast/ast_ops.cc
+++ b/tile/lang/ast/ast_ops.cc
@@ -229,10 +229,17 @@ struct PrngOp : PrimitiveOp {
     std::vector<std::shared_ptr<DimExpr>> dims;
     for (size_t i = 1; i < args.size(); i++) {
       auto int_expr = std::dynamic_pointer_cast<IntConst>(args[i]);
-      if (!int_expr) {
-        throw std::runtime_error("'prng' requires additional arguments to be integers.");
+      if (int_expr) {
+        dims.push_back(std::make_shared<DimIntExpr>(int_expr->value));
+      } else {
+        auto dim_expr_expr = std::dynamic_pointer_cast<DimExprExpr>(args[i]);
+        if (dim_expr_expr) {
+          dims.push_back(dim_expr_expr->expr);
+        } else {
+          throw std::runtime_error(
+              "'prng' requires additional arguments to be tensor dimensions (integer or symbolic).");
+        }
       }
-      dims.push_back(std::make_shared<DimIntExpr>(int_expr->value));
     }
     return LogicalShape(DataType::FLOAT32, dims);
   }


### PR DESCRIPTION
This also extends the functionality of the EDSL Keras dropout op