### PR TITLE
Enable symbolic shape forward pass testing

### DIFF
--- a/plaidml2/bridge/keras/backend_test.py
+++ b/plaidml2/bridge/keras/backend_test.py
@@ -214,7 +214,8 @@ def opTest(in_data,
             funcs = test_func(self, b, *(xv + ps + list(run_args)))
             tf_session.run(tensorflow.global_variables_initializer())
             for gf, f in zip(grad_funcs, funcs):
-                fr = f.eval()
+                fr_fn = b.function(x, [f])
+                fr = fr_fn([t for t in data if hasattr(t, 'shape')])
                 if do_grads:
                     df = b.gradients(b.mean(gf), x)
                     gfn = b.function(x, df, updates=[])
@@ -1170,13 +1171,13 @@ class TestBackendOps(unittest.TestCase):
     def testReshapeMatchDim(self):
         a = pkb.variable(m(1, 1, 60))
         output = pkb.reshape(a, (2, 0, 30))
-        self.assertEqual(str(output)[:len('reshape_')], 'reshape_')
+        self.assertEqual(str(output)[:len('reshape/')], 'reshape/')
         self.assertEqual(str(output)[-len('|fp32(2, 1, 30)'):], '|fp32(2, 1, 30)')
         output = pkb.reshape(a, (2, 0, -1))
-        self.assertEqual(str(output)[:len('reshape_')], 'reshape_')
+        self.assertEqual(str(output)[:len('reshape/')], 'reshape/')
         self.assertEqual(str(output)[-len('|fp32(2, 1, 30)'):], '|fp32(2, 1, 30)')
         output = pkb.reshape(a, (0, 0, 0))
-        self.assertEqual(str(output)[:len('reshape_')], 'reshape_')
+        self.assertEqual(str(output)[:len('reshape/')], 'reshape/')
         self.assertEqual(str(output)[-len('|fp32(1, 1, 60)'):], '|fp32(1, 1, 60)')
         #throw runtime exceptions
         with self.assertRaises(plaidml2.Error) as cm:


### PR DESCRIPTION
This enables the use of input_shapes for the forward passes of backend_test (previously it had only affected the gradient portion of tests)