### PR TITLE
Add the incorrect bit count to the error message.

### DIFF
--- a/tile/targets/cpu/compiler.cc
+++ b/tile/targets/cpu/compiler.cc
@@ -1219,7 +1219,9 @@ void Compiler::AsFloat(const stripe::Intrinsic& stmt) {
       type = DataType::FLOAT64;
     default:
       // TODO: Add bfloat16 when added to Stripe.
-      throw std::runtime_error("Invalid bit count for as_float for CPU jit.");
+      std::ostringstream oss;
+      oss << "Invalid bit count for as_float for CPU jit - " << bits;
+      throw std::runtime_error(oss.str());
   }
 
   Scalar ret = Cast(scalars_[stmt.inputs[0]], type);
@@ -1246,7 +1248,9 @@ void Compiler::AsInt(const stripe::Intrinsic& stmt) {
     case 64:
       type = DataType::INT64;
     default:
-      throw std::runtime_error("Invalid bit count for as_int for CPU jit.");
+      std::ostringstream oss;
+      oss << "Invalid bit count for as_int for CPU jit - " << bits;
+      throw std::runtime_error(oss.str());
   }
 
   Scalar ret = Cast(scalars_[stmt.inputs[0]], type);
@@ -1273,7 +1277,9 @@ void Compiler::AsUInt(const stripe::Intrinsic& stmt) {
     case 64:
       type = DataType::UINT64;
     default:
-      throw std::runtime_error("Invalid bit count for as_uint for CPU jit.");
+      std::ostringstream oss;
+      oss << "Invalid bit count for as_uint for CPU jit - " << bits;
+      throw std::runtime_error(oss.str());
   }
 
   Scalar ret = Cast(scalars_[stmt.inputs[0]], type);


### PR DESCRIPTION
For bad bit count of as_XXXXX functions add the number of bits that is incorrect to the error message.