### PR TITLE
Implement K.is_placeholder() in plaidml2 keras backend

### DIFF
--- a/plaidml2/bridge/keras/__init__.py
+++ b/plaidml2/bridge/keras/__init__.py
@@ -932,7 +932,9 @@ def is_keras_tensor(x):
 
 @_log_call
 def is_placeholder(x):
-    _report_unimplemented('is_placeholder')
+    if not is_tensor(x):
+        return False
+    return x.opname == 'placeholder'
 
 
 @_log_call


### PR DESCRIPTION
This is an implementation of the `is_placeholder()` for the keras backend of plaidml2. It doesn't include unit tests, because there weren't in the unit tests of plaidml. But let me know if they should be added.