### PR TITLE
Use the outer named out refinement to initialize the inner aggr buffer

### DIFF
--- a/tile/codegen/aggrinit.cc
+++ b/tile/codegen/aggrinit.cc
@@ -26,7 +26,7 @@ void AggregationBlockOutputInitialization(const stripe::Block* const block,
   // do not emit duplicated local declarations.
   std::set<std::string> dup_ref;
 
-  // Now, add any new locals
+  // Now, add any new locals that have agg_op.
   for (const auto& ref : block->refs) {
     if (ref.dir == stripe::RefDir::None && dup_ref.find(ref.into()) == dup_ref.end() && !ref.has_tag("user")) {
       std::string aggOp = ref.agg_op;
@@ -63,7 +63,7 @@ void AggregationBlockOutputInitialization(const stripe::Block* const block,
 
   if (prevRefIter->agg_op == "" || prevRefIter->agg_op == "assign") {
     const_cast<AggregationBlockOutputInitializationPass*>(aggregationPass)
-        ->AddRefinementToInit(const_cast<stripe::Block*>(prevBlock), dest, block, aggOp);
+        ->AddRefinementToInit(const_cast<stripe::Block*>(prevBlock), &(*prevRefIter), block, aggOp);
   } else {
     if (prevRefIter->agg_op != aggOp) {
       // TODO: Create a temp buffer here.

--- a/tile/targets/cpu/llvm_cpu.jsonnet
+++ b/tile/targets/cpu/llvm_cpu.jsonnet
@@ -230,17 +230,26 @@ local PARAMS = {
                 alignment: 16,
               },
             },
+
+            // Remove unused refinements after fusing, scalarization, and program placement
+            {
+              name: 'prune_refs',
+              pass: {
+                '@type': 'type.vertex.ai/vertexai.tile.codegen.proto.PruneRefinementsPass',
+                reqs: ['program'],
+              },
+            },
+
             // Init aggregation outputs
             // Keet this towards the end since other passes are generating intermediate blocks and the initialization 
             // on aggregation transition could break in such cases.
-            // TODO: Enable this when we handle the initialization of the bool type and the right agg_init_* functions are defined in the runtime.
-            // {
-            //   name: 'init_aggregation_outputs',
-            //   pass: {
-            //     '@type': 'type.vertex.ai/vertexai.tile.codegen.proto.AggregationBlockOutputInitializationPass',
-            //     reqs: ['program'],
-            //   },
-            // },
+            {
+              name: 'init_aggregation_outputs',
+              pass: {
+                '@type': 'type.vertex.ai/vertexai.tile.codegen.proto.AggregationBlockOutputInitializationPass',
+                reqs: ['program'],
+              },
+            },
           ],
         },
       },


### PR DESCRIPTION
Added also a prone_unused_refinement pass to remove unused efinments that might have been created during fusion, etc.