### PR TITLE
Refactor common loop generation code

### DIFF
--- a/tile/targets/cpu/compiler.cc
+++ b/tile/targets/cpu/compiler.cc
@@ -541,9 +541,9 @@ llvm::Function* Compiler::CompileBlock(const stripe::Block& block) {
   std::vector<Loop> loops(block.idxs.size());
   for (size_t i = 0; i < block.idxs.size(); ++i) {
     std::string name = block.idxs[i].name;
-    CreateLoop(&loops[i], name);
     llvm::Value* variable = indexes_[name].variable;
     llvm::Value* init = indexes_[name].init;
+    CreateLoop(&loops[i], name);
     EnterLoop(&loops[i], variable, init, limits[i]);
   }
 
@@ -1734,22 +1734,14 @@ void Compiler::CreateLoop(Loop* loop, std::string name) {
   builder_.CreateBr(loop->init);
 }
 
-void Compiler::InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* init) {
+void Compiler::EnterLoop(Loop* loop, llvm::Value* variable, llvm::Value* init, llvm::Value* limit) {
   builder_.SetInsertPoint(loop->init);
   builder_.CreateStore(init, variable);
   builder_.CreateBr(loop->test);
-}
-
-void Compiler::TestLoop(Loop* loop, llvm::Value* variable, llvm::Value* limit) {
   builder_.SetInsertPoint(loop->test);
   llvm::Value* idx_val = builder_.CreateLoad(variable);
   llvm::Value* go = builder_.CreateICmpULT(idx_val, limit);
   builder_.CreateCondBr(go, loop->body, loop->done);
-}
-
-void Compiler::EnterLoop(Loop* loop, llvm::Value* variable, llvm::Value* init, llvm::Value* limit) {
-  InitLoop(loop, variable, init);
-  TestLoop(loop, variable, limit);
   builder_.SetInsertPoint(loop->body);
 }
 

--- a/tile/targets/cpu/compiler.cc
+++ b/tile/targets/cpu/compiler.cc
@@ -541,7 +541,7 @@ llvm::Function* Compiler::CompileBlock(const stripe::Block& block) {
   std::vector<Loop> loops(block.idxs.size());
   for (size_t i = 0; i < block.idxs.size(); ++i) {
     std::string name = block.idxs[i].name;
-    CreateLoop(&loops[i], name, function);
+    CreateLoop(&loops[i], name);
     llvm::Value* variable = indexes_[name].variable;
     llvm::Value* init = indexes_[name].init;
     EnterLoop(&loops[i], variable, init, limits[i]);
@@ -1459,10 +1459,9 @@ void Compiler::AggInit(const Buffer& dest, std::string agg_op) {
 
   // Generate the initialization & limit test for each loop.
   std::vector<Loop> loops(dest_ndims);
-  llvm::Function* parent = builder_.GetInsertBlock()->getParent();
   for (size_t i = 0; i < dest_ndims; ++i) {
     std::string name = std::to_string(i);
-    CreateLoop(&loops[i], name, parent);
+    CreateLoop(&loops[i], name);
     EnterLoop(&loops[i], idx_vars[i], IndexConst(0), limits[i]);
   }
 
@@ -1563,10 +1562,9 @@ void Compiler::Scatter(const stripe::Special& scatter) {
 
   // Generate the initialization & limit test for each loop
   std::vector<Loop> loops(data_ndims);
-  llvm::Function* parent = builder_.GetInsertBlock()->getParent();
   for (size_t i = 0; i < data_ndims; ++i) {
     std::string name = std::to_string(i);
-    CreateLoop(&loops[i], name, parent);
+    CreateLoop(&loops[i], name);
     EnterLoop(&loops[i], idx_vars[i], IndexConst(0), limits[i]);
   }
 
@@ -1671,10 +1669,9 @@ void Compiler::Gather(const stripe::Special& gather) {
 
   // Generate the initialization & limit test for each loop
   std::vector<Loop> loops(dest_ndims);
-  llvm::Function* parent = builder_.GetInsertBlock()->getParent();
   for (size_t i = 0; i < dest_ndims; ++i) {
     std::string name = std::to_string(i);
-    CreateLoop(&loops[i], name, parent);
+    CreateLoop(&loops[i], name);
     EnterLoop(&loops[i], idx_vars[i], IndexConst(0), limits[i]);
   }
 
@@ -1728,7 +1725,8 @@ void Compiler::Gather(const stripe::Special& gather) {
   }
 }
 
-void Compiler::CreateLoop(Loop* loop, std::string name, llvm::Function* func) {
+void Compiler::CreateLoop(Loop* loop, std::string name) {
+  llvm::Function* func = builder_.GetInsertBlock()->getParent();
   loop->init = llvm::BasicBlock::Create(context_, "init_" + name, func);
   loop->test = llvm::BasicBlock::Create(context_, "test_" + name, func);
   loop->body = llvm::BasicBlock::Create(context_, "body_" + name, func);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -148,6 +148,7 @@ class Compiler : private stripe::ConstStmtVisitor {
  private:
   void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
   void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
+  void LeaveLoop(Loop* loop, llvm::Value* variable);
   Scalar Cast(Scalar, DataType);
   Scalar CheckBool(Scalar);
   llvm::Type* CType(DataType);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -146,7 +146,7 @@ class Compiler : private stripe::ConstStmtVisitor {
   };
 
  private:
-  void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
+  void CreateLoop(Loop* loop, std::string name);
   void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
   void TestLoop(Loop* loop, llvm::Value* variable, llvm::Value* limit);
   void EnterLoop(Loop* loop, llvm::Value* variable, llvm::Value* init, llvm::Value* limit);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -148,6 +148,7 @@ class Compiler : private stripe::ConstStmtVisitor {
  private:
   void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
   void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
+  void TestLoop(Loop* loop, llvm::Value* variable, llvm::Value* limit);
   void LeaveLoop(Loop* loop, llvm::Value* variable);
   Scalar Cast(Scalar, DataType);
   Scalar CheckBool(Scalar);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -147,8 +147,6 @@ class Compiler : private stripe::ConstStmtVisitor {
 
  private:
   void CreateLoop(Loop* loop, std::string name);
-  void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
-  void TestLoop(Loop* loop, llvm::Value* variable, llvm::Value* limit);
   void EnterLoop(Loop* loop, llvm::Value* variable, llvm::Value* init, llvm::Value* limit);
   void LeaveLoop(Loop* loop, llvm::Value* variable);
   Scalar Cast(Scalar, DataType);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -149,6 +149,7 @@ class Compiler : private stripe::ConstStmtVisitor {
   void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
   void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
   void TestLoop(Loop* loop, llvm::Value* variable, llvm::Value* limit);
+  void EnterLoop(Loop* loop, llvm::Value* variable, llvm::Value* init, llvm::Value* limit);
   void LeaveLoop(Loop* loop, llvm::Value* variable);
   Scalar Cast(Scalar, DataType);
   Scalar CheckBool(Scalar);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -146,6 +146,7 @@ class Compiler : private stripe::ConstStmtVisitor {
   };
 
  private:
+  void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
   Scalar Cast(Scalar, DataType);
   Scalar CheckBool(Scalar);
   llvm::Type* CType(DataType);

--- a/tile/targets/cpu/compiler.h
+++ b/tile/targets/cpu/compiler.h
@@ -147,6 +147,7 @@ class Compiler : private stripe::ConstStmtVisitor {
 
  private:
   void CreateLoop(Loop* loop, std::string name, llvm::Function* func);
+  void InitLoop(Loop* loop, llvm::Value* variable, llvm::Value* initializer);
   Scalar Cast(Scalar, DataType);
   Scalar CheckBool(Scalar);
   llvm::Type* CType(DataType);


### PR DESCRIPTION
After implementing scatter, gather, and agg_init, we had four different implementations of a ranged for loop. This change unifies loop generation code, for consistency & readability.