### PR TITLE
Fix type of contraction operations and assignments

### DIFF
--- a/plaidml/keras/backend.py
+++ b/plaidml/keras/backend.py
@@ -1141,7 +1141,7 @@ class OneHot(ptile.Operation):
             }}""".format(idim=', '.join(['I{}'.format(k) for k in range(indices.shape.ndims)]),
                          iidx=', '.join(['i{}'.format(k) for k in range(indices.shape.ndims)]))
 
-        outshape = ptile.Shape(plaidml.DType.BOOLEAN,
+        outshape = ptile.Shape(plaidml.DType.FLOAT32,
                                tuple(list(indices.shape.dims) + [num_classes]))
 
         super(OneHot, self).__init__(f, [('Idx', indices), ('Count', count)], [('O', outshape)])

--- a/tile/lang/gen_stripe.cc
+++ b/tile/lang/gen_stripe.cc
@@ -234,7 +234,6 @@ class StripeGenerator {
     auto agg_op = GetAggOp(cion.agg_op);
     kernel->set_tag("contraction");
     kernel->set_tag("agg_op_" + agg_op);
-
     std::vector<std::string> scalar_inputs;
     kernel->name += "(";
     std::string out_ref_name = "";
@@ -311,25 +310,22 @@ class StripeGenerator {
 
     // Combination Op
     auto output_type = GetShape(op.output).type;
+    tile::DataType input_based_type = tile::DataType::INVALID;
+    for (const auto& input : op.inputs) {
+      auto input_type = GetShape(input).type;
+      input_based_type = CommonSupertype(input_type, input_based_type);
+    }
     if (scalar_inputs.size() > 1) {
       if (cion.comb_op == CombinationOp::COND) {
         kernel.get()->stmts.push_back(std::make_shared<Constant>("$ZERO", INT64_C(0)));
-
-        tile::DataType eq_type = tile::DataType::INVALID;
-        for (const auto& input : op.inputs) {
-          scalar_inputs.push_back(ScalarName(input));
-          auto input_type = GetShape(input).type;
-          eq_type = CommonSupertype(input_type, eq_type);
-        }
-
-        AddIntrinsic(kernel.get(), Intrinsic::EQ, eq_type, {scalar_inputs[0], scalar_inputs[1]}, {"$IS_EQ"});
+        AddIntrinsic(kernel.get(), Intrinsic::EQ, input_based_type, {scalar_inputs[0], scalar_inputs[1]}, {"$IS_EQ"});
         AddIntrinsic(kernel.get(), Intrinsic::COND, output_type, {"$IS_EQ", scalar_inputs[2], "$ZERO"},
                      {ScalarName(op.output)});
         kernel->set_tag("comb_op_cond");
       } else {
         auto combo_op = GetComboOp(cion.comb_op);
         if (!combo_op.empty()) {
-          AddIntrinsic(kernel.get(), combo_op, output_type, scalar_inputs, {ScalarName(op.output)});
+          AddIntrinsic(kernel.get(), combo_op, input_based_type, scalar_inputs, {ScalarName(op.output)});
           kernel->set_tag("comb_op_" + combo_op);
           if (agg_op == Intrinsic::SUM && combo_op == Intrinsic::MUL) {
             total_macs_ += kernel->idxs_product();
@@ -337,7 +333,7 @@ class StripeGenerator {
         }
       }
     } else {
-      AddIntrinsic(kernel.get(), "assign", output_type, scalar_inputs, {ScalarName(op.output)});
+      AddIntrinsic(kernel.get(), "assign", input_based_type, scalar_inputs, {ScalarName(op.output)});
       // Mark including the agg_op
       kernel->set_tag("agg_op_" + agg_op + "_no_comb_op");
     }


### PR DESCRIPTION
Fix type of contraction operations and assignments to be based on the inputs.

Changed the type of one_hot from BOOLEAN to FLOAT32 (after talking to Tim). The result of this operation is always used in float calculations and TF's type for the operation is float32 as well.