### PR TITLE
Better printing

### DIFF
--- a/pmlc/dialect/stripe/ops.cc
+++ b/pmlc/dialect/stripe/ops.cc
@@ -9,8 +9,7 @@ namespace stripe {
 
 #include "pmlc/dialect/stripe/opinterfaces.cpp.inc"
 
-/*
-void PrintSimple(Operation* op, OpAsmPrinter* p, ArrayRef<StringRef> fixed, Type otype) {
+void PrintSimple(Operation* op, OpAsmPrinter* p, ArrayRef<StringRef> fixed, Type otype = Type()) {
   *p << op->getName() << " ";
   bool first = true;
   for (size_t i = 0; i < op->getNumOperands(); i++) {
@@ -28,41 +27,41 @@ void PrintSimple(Operation* op, OpAsmPrinter* p, ArrayRef<StringRef> fixed, Type
     *p << op->getAttrOfType<IntegerAttr>(name).getValue();
   }
   if (otype) {
-    *p << " : ";
-    p->printType(otype);
+    *p << " : " << otype;
   }
-  p->printOptionalAttrDict(op->getAttrs(), fixed);
+  llvm::SmallVector<StringRef, 4> ignore(fixed.begin(), fixed.end());
+  // ignore.push_back("name");
+  // ignore.push_back("scalar_name");
+  p->printOptionalAttrDict(op->getAttrs(), ignore);
 }
 
-Type ParseSimple(OpAsmParser* p, OperationState *res, ArrayRef<StringRef> fixed, bool with_type) {
+template <typename T, size_t N>
+bool ParseSimple(OpAsmParser* p, OperationState* res, std::array<OpAsmParser::OperandType, N>* ops,
+                 ArrayRef<StringRef> fixed, T* out_type) {
   bool first = true;
-  Type out_type;
-  ParseResult r;
-  for (size_t i = 0; i < op->getNumOperands(); i++) {
+  bool r = false;
+  for (size_t i = 0; i < N; i++) {
     if (!first) {
       r = r || p->parseComma();
     }
     first = false;
-    OperandType op;
-    r = r || p->parseOperand(op);
-    r = r || p->resolveOperand(op, Type(), res->operands);
+    r = r || p->parseOperand((*ops)[i]);
   }
   for (StringRef name : fixed) {
     if (!first) {
       r = r || p->parseComma();
+      Attribute dont_care;
+      r = r || p->parseAttribute(dont_care, name, res->attributes);
     }
     first = false;
-    r->attributes.
-    *p << op->getAttrOfType<IntegerAttr>(name).getValue();
   }
-  if (with_type) {
+  if (out_type) {
     r = r || p->parseColon();
-    r = r || p->parseType(out_type);
+    r = r || p->parseType(*out_type);
   }
   r = r || p->parseOptionalAttributeDict(res->attributes);
   return r;
 }
-*/
 
 #define GET_OP_CLASSES
 #include "pmlc/dialect/stripe/ops.cpp.inc"

--- a/pmlc/dialect/stripe/ops.cc
+++ b/pmlc/dialect/stripe/ops.cc
@@ -9,16 +9,13 @@ namespace stripe {
 
 #include "pmlc/dialect/stripe/ops_interfaces.cpp.inc"
 
-void PrintSimple(Operation* op, OpAsmPrinter* p, ArrayRef<StringRef> fixed, Type otype = Type()) {
+void PrintSimple(Operation* op, OpAsmPrinter* p, size_t count, ArrayRef<StringRef> fixed, Type otype, bool vararg) {
+  // Print the op name
   *p << op->getName() << " ";
-  bool first = true;
-  for (size_t i = 0; i < op->getNumOperands(); i++) {
-    if (!first) {
-      *p << ", ";
-    }
-    first = false;
-    p->printOperand(op->getOperand(i));
-  }
+  // Pring the normal (fixed) operands
+  p->printOperands(op->operand_begin(), op->operand_begin() + count);
+  // Print the fixed attributes (which are always integers in our case)
+  bool first = (count == 0);
   for (StringRef name : fixed) {
     if (!first) {
       *p << ", ";
@@ -26,39 +23,58 @@ void PrintSimple(Operation* op, OpAsmPrinter* p, ArrayRef<StringRef> fixed, Type
     first = false;
     *p << op->getAttrOfType<IntegerAttr>(name).getValue();
   }
+  // If we can have varargs, print them wrapped in ()'s
+  if (vararg) {
+    if (count > 0) {
+      *p << " ";
+    }
+    *p << "(";
+    p->printOperands(op->operand_begin() + count, op->operand_end());
+    *p << ")";
+  }
+  // Print a type (if needed)
   if (otype) {
     *p << " : " << otype;
   }
-  llvm::SmallVector<StringRef, 4> ignore(fixed.begin(), fixed.end());
-  // ignore.push_back("name");
-  // ignore.push_back("scalar_name");
-  p->printOptionalAttrDict(op->getAttrs(), ignore);
+  // Print any additional attributes
+  p->printOptionalAttrDict(op->getAttrs(), fixed);
 }
 
-template <typename T, size_t N>
-bool ParseSimple(OpAsmParser* p, OperationState* res, std::array<OpAsmParser::OperandType, N>* ops,
-                 ArrayRef<StringRef> fixed, T* out_type) {
-  bool first = true;
+template <typename T>
+bool ParseSimple(OpAsmParser* p, OperationState* res, llvm::SmallVectorImpl<OpAsmParser::OperandType>* ops,
+                 size_t count, ArrayRef<StringRef> fixed, T* out_type, bool vararg) {
   bool r = false;
-  for (size_t i = 0; i < N; i++) {
+  // Parse the normal operands, annoyingly parseOperandList doesn't
+  // have an option to read exactly N operands, only to read all and verify
+  bool first = true;
+  for (size_t i = 0; i < count; i++) {
     if (!first) {
       r = r || p->parseComma();
     }
     first = false;
-    r = r || p->parseOperand((*ops)[i]);
+    OpAsmParser::OperandType op;
+    r = r || p->parseOperand(op);
+    ops->push_back(op);
   }
+  // Parse the fixed attributes
   for (StringRef name : fixed) {
     if (!first) {
       r = r || p->parseComma();
-      Attribute dont_care;
-      r = r || p->parseAttribute(dont_care, name, res->attributes);
     }
+    Attribute dont_care;
+    r = r || p->parseAttribute(dont_care, name, res->attributes);
     first = false;
   }
+  // If we can have varargs, parse them wrapped in ()'s
+  if (vararg) {
+    r = r || p->parseOperandList(*ops, -1, OpAsmParser::Delimiter::Paren);
+  }
+  // Parse a type if needed
   if (out_type) {
     r = r || p->parseColon();
     r = r || p->parseType(*out_type);
   }
+  // Parse any additional attributes
   r = r || p->parseOptionalAttributeDict(res->attributes);
   return r;
 }

--- a/pmlc/dialect/stripe/ops.td
+++ b/pmlc/dialect/stripe/ops.td
@@ -24,36 +24,41 @@ def TensorRefOp : StripeOp<"ref", [NoSideEffect]> {
   let summary = "Create a default tensor_ref from a tensor";
   let arguments = (ins TensorType:$in);
   let results = (outs TensorRefType:$result);
-  //let extraClassDeclaration = [{
-  //  typedef 
-  //}];
-  // typedef 
 }
 
 def RefineOp : StripeOp<"refine", [NoSideEffect]> {
   let summary = "Modify the offset into a tensor in an affine way";
   let arguments = (ins TensorRefType:$in, Variadic<AffineType>:$offsets);
   let results = (outs TensorRefType:$result);
-  
-  // Serialization format: %xp = refine %x[%i, %j] : $type
+  let printer = [{ PrintSimple(getOperation(), p, 1, {}, in()->getType(), true); }];
+  let parser = [{
+    TensorRefType refType;
+    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    llvm::SmallVector<OpAsmParser::OperandType, 8> operands;
+    bool r = ParseSimple(parser, result, &operands, 1, {}, &refType, true);
+    r = r || parser->resolveOperand(operands[0], refType, result->operands);
+    for (size_t i = 1; i < operands.size(); i++) {
+      r = r || parser->resolveOperand(operands[i], aff_type, result->operands);
+    }
+    r = r || parser->addTypeToList(refType, result->types);
+    return mlir::failure(r); 
+  }];
 }
 
 def LoadOp : StripeOp<"load"> {
   let summary = "Load from a tensor";
   let arguments = (ins TensorRefType:$from);
   let results = (outs Eltwise_AnyTensor:$into);
-  let printer = [{ PrintSimple(getOperation(), p, {}, from()->getType()); }];
+  let printer = [{ PrintSimple(getOperation(), p, 1, {}, from()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
-    std::array<OpAsmParser::OperandType, 1> operands;
-    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    llvm::SmallVector<OpAsmParser::OperandType, 1> operands;
+    bool r = ParseSimple(parser, result, &operands, 1, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
     r = r || parser->resolveOperand(operands[0], refType, result->operands);
     r = r || parser->addTypeToList(eltType, result->types);
     return mlir::failure(r); 
   }];
-  
-  // Serialization format: %s = load %t : $type
 }
 
 def LoadIndexOp : StripeOp<"load_index"> {
@@ -65,11 +70,11 @@ def LoadIndexOp : StripeOp<"load_index"> {
 def StoreOp : StripeOp<"store"> {
   let summary = "Store into a tensor";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from);
-  let printer = [{ PrintSimple(getOperation(), p, {}, into()->getType()); }];
+  let printer = [{ PrintSimple(getOperation(), p, 2, {}, into()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
-    std::array<OpAsmParser::OperandType, 2> operands;
-    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    llvm::SmallVector<OpAsmParser::OperandType, 2> operands;
+    bool r = ParseSimple(parser, result, &operands, 2, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
     r = r || parser->resolveOperand(operands[0], refType, result->operands);
     r = r || parser->resolveOperand(operands[1], eltType, result->operands);
@@ -81,11 +86,11 @@ def AggregateOp : StripeOp<"aggregate"> {
   let summary = "A accumulating store with a commutative, associative accumulation";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from, AggregationKind:$agg);
   let results = (outs);
-  let printer = [{ PrintSimple(getOperation(), p, {}, into()->getType()); }];
+  let printer = [{ PrintSimple(getOperation(), p, 2, {}, into()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
-    std::array<OpAsmParser::OperandType, 2> operands;
-    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    llvm::SmallVector<OpAsmParser::OperandType, 2> operands;
+    bool r = ParseSimple(parser, result, &operands, 2, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
     r = r || parser->resolveOperand(operands[0], refType, result->operands);
     r = r || parser->resolveOperand(operands[1], eltType, result->operands);
@@ -100,16 +105,42 @@ class AffineOp<string mnemonic> : StripeOp<mnemonic, [NoSideEffect]> {
 def AffineConstOp : AffineOp<"affine_const"> {
   let summary = "A constant affine value";
   let arguments = (ins I64Attr:$value);
+  let printer = [{ PrintSimple(getOperation(), p, 0, {"value"}, Type(), false); }];
+  let parser = [{
+    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    llvm::SmallVector<OpAsmParser::OperandType, 0> operands;
+    bool r = ParseSimple(parser, result, &operands, 0, {"value"}, static_cast<Type*>(nullptr), false);
+    r = r || parser->addTypeToList(aff_type, result->types);
+    return mlir::failure(r); 
+  }];
 }
 
 def AffineMulOp : AffineOp<"affine_mul"> {
   let summary = "Multiply an affine by a constant value";
   let arguments = (ins AffineType:$input, I64Attr:$scale);
+  let printer = [{ PrintSimple(getOperation(), p, 1, {"scale"}, Type(), false); }];
+  let parser = [{
+    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    llvm::SmallVector<OpAsmParser::OperandType, 1> operands;
+    bool r = ParseSimple(parser, result, &operands, 1, {"scale"}, static_cast<Type*>(nullptr), false);
+    r = r || parser->resolveOperand(operands[0], aff_type, result->operands);
+    r = r || parser->addTypeToList(aff_type, result->types);
+    return mlir::failure(r); 
+  }];
 }
 
 def AffineAddOp : AffineOp<"affine_add"> {
   let summary = "Add multiple affines together";
-  let arguments = (ins Variadic<AffineType>:$inputs);
+  let arguments = (ins Variadic<AffineType>:$inputs); 
+  let printer = [{ PrintSimple(getOperation(), p, 0, {}, Type(), true); }];
+  let parser = [{
+    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    llvm::SmallVector<OpAsmParser::OperandType, 4> operands;
+    bool r = ParseSimple(parser, result, &operands, 0, {}, static_cast<Type*>(nullptr), true);
+    r = r || parser->resolveOperands(operands, aff_type, result->operands);
+    r = r || parser->addTypeToList(aff_type, result->types);
+    return mlir::failure(r); 
+  }];
 }
 
 def ParallelForOp : StripeOp<"parallel_for"> {

--- a/pmlc/dialect/stripe/ops.td
+++ b/pmlc/dialect/stripe/ops.td
@@ -23,18 +23,36 @@ def TensorRefOp : StripeOp<"ref", [NoSideEffect]> {
   let summary = "Create a default tensor_ref from a tensor";
   let arguments = (ins TensorType:$in);
   let results = (outs TensorRefType:$result);
+  //let extraClassDeclaration = [{
+  //  typedef 
+  //}];
+  // typedef 
 }
 
 def RefineOp : StripeOp<"refine", [NoSideEffect]> {
   let summary = "Modify the offset into a tensor in an affine way";
   let arguments = (ins TensorRefType:$in, Variadic<AffineType>:$offsets);
   let results = (outs TensorRefType:$result);
+  
+  // Serialization format: %xp = refine %x[%i, %j] : $type
 }
 
 def LoadOp : StripeOp<"load"> {
   let summary = "Load from a tensor";
   let arguments = (ins TensorRefType:$from);
   let results = (outs Eltwise_AnyTensor:$into);
+  let printer = [{ PrintSimple(getOperation(), p, {}, from()->getType()); }];
+  let parser = [{
+    TensorRefType refType;
+    std::array<OpAsmParser::OperandType, 1> operands;
+    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    Type eltType = RankedTensorType::get({}, refType.getElementType());
+    r = r || parser->resolveOperand(operands[0], refType, result->operands);
+    r = r || parser->addTypeToList(eltType, result->types);
+    return mlir::failure(r); 
+  }];
+  
+  // Serialization format: %s = load %t : $type
 }
 
 def LoadIndexOp : StripeOp<"load_index"> {
@@ -46,6 +64,16 @@ def LoadIndexOp : StripeOp<"load_index"> {
 def StoreOp : StripeOp<"store"> {
   let summary = "Store into a tensor";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from);
+  let printer = [{ PrintSimple(getOperation(), p, {}, into()->getType()); }];
+  let parser = [{
+    TensorRefType refType;
+    std::array<OpAsmParser::OperandType, 2> operands;
+    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    Type eltType = RankedTensorType::get({}, refType.getElementType());
+    r = r || parser->resolveOperand(operands[0], refType, result->operands);
+    r = r || parser->resolveOperand(operands[1], eltType, result->operands);
+    return mlir::failure(r); 
+  }];
 }
 
 def AggTypeEnum : I64EnumAttr<
@@ -63,6 +91,16 @@ def AggregateOp : StripeOp<"aggregate"> {
   let summary = "A accumulating store with a commutative, associative accumulation";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from, AggTypeEnum:$agg_type);
   let results = (outs);
+  let printer = [{ PrintSimple(getOperation(), p, {}, into()->getType()); }];
+  let parser = [{
+    TensorRefType refType;
+    std::array<OpAsmParser::OperandType, 2> operands;
+    bool r = ParseSimple(parser, result, &operands, {}, &refType);
+    Type eltType = RankedTensorType::get({}, refType.getElementType());
+    r = r || parser->resolveOperand(operands[0], refType, result->operands);
+    r = r || parser->resolveOperand(operands[1], eltType, result->operands);
+    return mlir::failure(r); 
+  }];
 }
 
 class AffineOp<string mnemonic> : StripeOp<mnemonic, [NoSideEffect]> {

--- a/pmlc/dialect/stripe/ops.td
+++ b/pmlc/dialect/stripe/ops.td
@@ -30,17 +30,20 @@ def RefineOp : StripeOp<"refine", [NoSideEffect]> {
   let summary = "Modify the offset into a tensor in an affine way";
   let arguments = (ins TensorRefType:$in, Variadic<AffineType>:$offsets);
   let results = (outs TensorRefType:$result);
-  let printer = [{ PrintSimple(getOperation(), p, 1, {}, in()->getType(), true); }];
+  let printer = [{ 
+    PrintSimple(getOperation(), &p, 1, {}, in()->getType(), true);
+    p << " // This is a test comment";
+  }];
   let parser = [{
     TensorRefType refType;
-    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    auto aff_type = AffineType::get(parser.getBuilder().getContext());
     llvm::SmallVector<OpAsmParser::OperandType, 8> operands;
-    bool r = ParseSimple(parser, result, &operands, 1, {}, &refType, true);
-    r = r || parser->resolveOperand(operands[0], refType, result->operands);
+    bool r = ParseSimple(&parser, &result, &operands, 1, {}, &refType, true);
+    r = r || parser.resolveOperand(operands[0], refType, result.operands);
     for (size_t i = 1; i < operands.size(); i++) {
-      r = r || parser->resolveOperand(operands[i], aff_type, result->operands);
+      r = r || parser.resolveOperand(operands[i], aff_type, result.operands);
     }
-    r = r || parser->addTypeToList(refType, result->types);
+    r = r || parser.addTypeToList(refType, result.types);
     return mlir::failure(r); 
   }];
 }
@@ -49,14 +52,14 @@ def LoadOp : StripeOp<"load"> {
   let summary = "Load from a tensor";
   let arguments = (ins TensorRefType:$from);
   let results = (outs Eltwise_AnyTensor:$into);
-  let printer = [{ PrintSimple(getOperation(), p, 1, {}, from()->getType(), false); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 1, {}, from()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
     llvm::SmallVector<OpAsmParser::OperandType, 1> operands;
-    bool r = ParseSimple(parser, result, &operands, 1, {}, &refType, false);
+    bool r = ParseSimple(&parser, &result, &operands, 1, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
-    r = r || parser->resolveOperand(operands[0], refType, result->operands);
-    r = r || parser->addTypeToList(eltType, result->types);
+    r = r || parser.resolveOperand(operands[0], refType, result.operands);
+    r = r || parser.addTypeToList(eltType, result.types);
     return mlir::failure(r); 
   }];
 }
@@ -70,14 +73,14 @@ def LoadIndexOp : StripeOp<"load_index"> {
 def StoreOp : StripeOp<"store"> {
   let summary = "Store into a tensor";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from);
-  let printer = [{ PrintSimple(getOperation(), p, 2, {}, into()->getType(), false); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 2, {}, into()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
     llvm::SmallVector<OpAsmParser::OperandType, 2> operands;
-    bool r = ParseSimple(parser, result, &operands, 2, {}, &refType, false);
+    bool r = ParseSimple(&parser, &result, &operands, 2, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
-    r = r || parser->resolveOperand(operands[0], refType, result->operands);
-    r = r || parser->resolveOperand(operands[1], eltType, result->operands);
+    r = r || parser.resolveOperand(operands[0], refType, result.operands);
+    r = r || parser.resolveOperand(operands[1], eltType, result.operands);
     return mlir::failure(r); 
   }];
 }
@@ -86,14 +89,14 @@ def AggregateOp : StripeOp<"aggregate"> {
   let summary = "A accumulating store with a commutative, associative accumulation";
   let arguments = (ins TensorRefType:$into, Eltwise_AnyTensor:$from, AggregationKind:$agg);
   let results = (outs);
-  let printer = [{ PrintSimple(getOperation(), p, 2, {}, into()->getType(), false); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 2, {}, into()->getType(), false); }];
   let parser = [{
     TensorRefType refType;
     llvm::SmallVector<OpAsmParser::OperandType, 2> operands;
-    bool r = ParseSimple(parser, result, &operands, 2, {}, &refType, false);
+    bool r = ParseSimple(&parser, &result, &operands, 2, {}, &refType, false);
     Type eltType = RankedTensorType::get({}, refType.getElementType());
-    r = r || parser->resolveOperand(operands[0], refType, result->operands);
-    r = r || parser->resolveOperand(operands[1], eltType, result->operands);
+    r = r || parser.resolveOperand(operands[0], refType, result.operands);
+    r = r || parser.resolveOperand(operands[1], eltType, result.operands);
     return mlir::failure(r); 
   }];
 }
@@ -105,12 +108,12 @@ class AffineOp<string mnemonic> : StripeOp<mnemonic, [NoSideEffect]> {
 def AffineConstOp : AffineOp<"affine_const"> {
   let summary = "A constant affine value";
   let arguments = (ins I64Attr:$value);
-  let printer = [{ PrintSimple(getOperation(), p, 0, {"value"}, Type(), false); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 0, {"value"}, Type(), false); }];
   let parser = [{
-    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    auto aff_type = AffineType::get(parser.getBuilder().getContext());
     llvm::SmallVector<OpAsmParser::OperandType, 0> operands;
-    bool r = ParseSimple(parser, result, &operands, 0, {"value"}, static_cast<Type*>(nullptr), false);
-    r = r || parser->addTypeToList(aff_type, result->types);
+    bool r = ParseSimple(&parser, &result, &operands, 0, {"value"}, static_cast<Type*>(nullptr), false);
+    r = r || parser.addTypeToList(aff_type, result.types);
     return mlir::failure(r); 
   }];
 }
@@ -118,13 +121,13 @@ def AffineConstOp : AffineOp<"affine_const"> {
 def AffineMulOp : AffineOp<"affine_mul"> {
   let summary = "Multiply an affine by a constant value";
   let arguments = (ins AffineType:$input, I64Attr:$scale);
-  let printer = [{ PrintSimple(getOperation(), p, 1, {"scale"}, Type(), false); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 1, {"scale"}, Type(), false); }];
   let parser = [{
-    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    auto aff_type = AffineType::get(parser.getBuilder().getContext());
     llvm::SmallVector<OpAsmParser::OperandType, 1> operands;
-    bool r = ParseSimple(parser, result, &operands, 1, {"scale"}, static_cast<Type*>(nullptr), false);
-    r = r || parser->resolveOperand(operands[0], aff_type, result->operands);
-    r = r || parser->addTypeToList(aff_type, result->types);
+    bool r = ParseSimple(&parser, &result, &operands, 1, {"scale"}, static_cast<Type*>(nullptr), false);
+    r = r || parser.resolveOperand(operands[0], aff_type, result.operands);
+    r = r || parser.addTypeToList(aff_type, result.types);
     return mlir::failure(r); 
   }];
 }
@@ -132,13 +135,13 @@ def AffineMulOp : AffineOp<"affine_mul"> {
 def AffineAddOp : AffineOp<"affine_add"> {
   let summary = "Add multiple affines together";
   let arguments = (ins Variadic<AffineType>:$inputs); 
-  let printer = [{ PrintSimple(getOperation(), p, 0, {}, Type(), true); }];
+  let printer = [{ PrintSimple(getOperation(), &p, 0, {}, Type(), true); }];
   let parser = [{
-    auto aff_type = AffineType::get(parser->getBuilder().getContext());
+    auto aff_type = AffineType::get(parser.getBuilder().getContext());
     llvm::SmallVector<OpAsmParser::OperandType, 4> operands;
-    bool r = ParseSimple(parser, result, &operands, 0, {}, static_cast<Type*>(nullptr), true);
-    r = r || parser->resolveOperands(operands, aff_type, result->operands);
-    r = r || parser->addTypeToList(aff_type, result->types);
+    bool r = ParseSimple(&parser, &result, &operands, 0, {}, static_cast<Type*>(nullptr), true);
+    r = r || parser.resolveOperands(operands, aff_type, result.operands);
+    r = r || parser.addTypeToList(aff_type, result.types);
     return mlir::failure(r); 
   }];
 }

--- a/pmlc/dialect/stripe/ops.td
+++ b/pmlc/dialect/stripe/ops.td
@@ -30,10 +30,7 @@ def RefineOp : StripeOp<"refine", [NoSideEffect]> {
   let summary = "Modify the offset into a tensor in an affine way";
   let arguments = (ins TensorRefType:$in, Variadic<AffineType>:$offsets);
   let results = (outs TensorRefType:$result);
-  let printer = [{ 
-    PrintSimple(getOperation(), &p, 1, {}, in()->getType(), true);
-    p << " // This is a test comment";
-  }];
+  let printer = [{ PrintSimple(getOperation(), &p, 1, {}, in()->getType(), true); }];
   let parser = [{
     TensorRefType refType;
     auto aff_type = AffineType::get(parser.getBuilder().getContext());


### PR DESCRIPTION
Currently awaiting changes to refs/allocs to clean those up, as well as Frank's shared util directory to add eltwise ops to he mix.  Blocks are more complex to fix, as are argument names, due to minor limitations in MLIR's parser.  TODO: consider make a PR against MLIR, how would we stage this?  
