### PR TITLE
[MLIR] Rename stripe::Dialect to StripeOpsDialect

### DIFF
--- a/plaidml2/exec/ffi.cc
+++ b/plaidml2/exec/ffi.cc
@@ -23,8 +23,8 @@
 using plaidml::core::ffi_wrap;
 using plaidml::core::ffi_wrap_void;
 using plaidml::core::GetPlatform;
-using pmlc::dialect::stripe::Dialect;
 using pmlc::dialect::stripe::FromMLIR;
+using pmlc::dialect::stripe::StripeOpsDialect;
 using pmlc::dialect::tile::LowerIntoStripe;
 using vertexai::context::Context;
 using vertexai::tile::Allocator;
@@ -139,7 +139,7 @@ plaidml_executable* plaidml_compile(  //
           throw std::runtime_error("Input expected BlockArgument");
         }
         auto argNumber = arg->getArgNumber();
-        auto attrName = Dialect::getDialectAttrName("name");
+        auto attrName = StripeOpsDialect::getDialectAttrName("name");
         auto attr = stripeFuncOp.getArgAttrOfType<mlir::StringAttr>(argNumber, attrName);
         if (!attr) {
           throw std::runtime_error("Missing expected argument attribute");
@@ -158,7 +158,7 @@ plaidml_executable* plaidml_compile(  //
       for (size_t i = 0; i < noutputs; i++) {
         IVLOG(1, "Output[" << i << "]: ");
         auto argNumber = numInputs + i;
-        auto attrName = Dialect::getDialectAttrName("name");
+        auto attrName = StripeOpsDialect::getDialectAttrName("name");
         auto attr = stripeFuncOp.getArgAttrOfType<mlir::StringAttr>(argNumber, attrName);
         if (!attr) {
           throw std::runtime_error("Missing expected argument attribute");

--- a/pmlc/dialect/stripe/analysis.cc
+++ b/pmlc/dialect/stripe/analysis.cc
@@ -157,7 +157,7 @@ FlatTensorAccess ComputeAccess(Value* tensor) {
     if (!funcOp) {
       throw std::runtime_error("Invalid tensor value: block argument not contained by FuncOp");
     }
-    auto attrName = stripe::Dialect::getDialectAttrName("layout");
+    auto attrName = StripeOpsDialect::getDialectAttrName("layout");
     auto attr = funcOp.getArgAttrOfType<mlir::TypeAttr>(arg->getArgNumber(), attrName);
     ret.base = tensor;
     ret.base_type = attr.getValue().cast<TensorType>();

--- a/pmlc/dialect/stripe/dialect.cc
+++ b/pmlc/dialect/stripe/dialect.cc
@@ -34,9 +34,9 @@ struct OpAsmInterface : public mlir::OpAsmDialectInterface {
   }
 };
 
-static mlir::DialectRegistration<Dialect> StripeOps;
+static mlir::DialectRegistration<StripeOpsDialect> StripeOps;
 
-Dialect::Dialect(mlir::MLIRContext* ctx) : mlir::Dialect(getDialectNamespace(), ctx) {
+StripeOpsDialect::StripeOpsDialect(mlir::MLIRContext* ctx) : mlir::Dialect(getDialectNamespace(), ctx) {
   addTypes<          //
       AffineType,    //
       ExecutorType,  //
@@ -49,7 +49,7 @@ Dialect::Dialect(mlir::MLIRContext* ctx) : mlir::Dialect(getDialectNamespace(), 
   addInterfaces<OpAsmInterface>();
 }
 
-mlir::Type Dialect::parseTensor(llvm::StringRef tyData, mlir::Location loc) const {
+mlir::Type StripeOpsDialect::parseTensor(llvm::StringRef tyData, mlir::Location loc) const {
   static llvm::Regex re{R"(([[:alnum:]_]+)\[([[:digit:]]+):([[:digit:]]+)\])"};
   bool is_const = tyData.consume_back("const");
   StringRef typeSpec, sizeSpec;
@@ -80,7 +80,7 @@ mlir::Type Dialect::parseTensor(llvm::StringRef tyData, mlir::Location loc) cons
   return TensorType::get(t, odims, OffsetsMap(), is_const);
 }
 
-mlir::Type Dialect::parseTensorRef(llvm::StringRef tyData, mlir::Location loc) const {
+mlir::Type StripeOpsDialect::parseTensorRef(llvm::StringRef tyData, mlir::Location loc) const {
   bool is_const = tyData.consume_back("const");
   StringRef typeSpec, ndimSpec;
   std::tie(typeSpec, ndimSpec) = tyData.rsplit(':');
@@ -97,11 +97,11 @@ mlir::Type Dialect::parseTensorRef(llvm::StringRef tyData, mlir::Location loc) c
   return TensorRefType::get(t, ndims, is_const);
 }
 
-std::string Dialect::getDialectAttrName(llvm::StringRef name) {
-  return llvm::formatv("{0}.{1}", stripe::Dialect::getDialectNamespace(), name).str();
+std::string StripeOpsDialect::getDialectAttrName(llvm::StringRef name) {
+  return llvm::formatv("{0}.{1}", StripeOpsDialect::getDialectNamespace(), name).str();
 }
 
-mlir::Type Dialect::parseType(llvm::StringRef tyData, mlir::Location loc) const {
+mlir::Type StripeOpsDialect::parseType(llvm::StringRef tyData, mlir::Location loc) const {
   if (tyData == "affine") {
     return AffineType::get(getContext());
   } else if (tyData == "executor") {
@@ -144,7 +144,7 @@ static void print(TensorRefType type, llvm::raw_ostream& os) {
   }
 }
 
-void Dialect::printType(mlir::Type type, llvm::raw_ostream& os) const {
+void StripeOpsDialect::printType(mlir::Type type, llvm::raw_ostream& os) const {
   if (auto affineType = type.dyn_cast<AffineType>()) {
     print(affineType, os);
   } else if (auto executorType = type.dyn_cast<ExecutorType>()) {

--- a/pmlc/dialect/stripe/dialect.h
+++ b/pmlc/dialect/stripe/dialect.h
@@ -10,9 +10,9 @@ namespace pmlc {
 namespace dialect {
 namespace stripe {
 
-class Dialect : public mlir::Dialect {
+class StripeOpsDialect : public mlir::Dialect {
  public:
-  explicit Dialect(mlir::MLIRContext* ctx);
+  explicit StripeOpsDialect(mlir::MLIRContext* ctx);
 
   static llvm::StringRef getDialectNamespace() { return "stripe"; }
   static std::string getDialectAttrName(llvm::StringRef name);

--- a/pmlc/dialect/stripe/from_mlir.cc
+++ b/pmlc/dialect/stripe/from_mlir.cc
@@ -130,14 +130,14 @@ StripeBuilder::StripeBuilder(mlir::FuncOp func) {
   // Construct the block and put it in the table
   cur_ = std::make_shared<stripe::Block>();
   cur_->name = func.getName();
-  auto attrs = func.getAttrOfType<DictionaryAttr>(Dialect::getStripeAttrsName());
+  auto attrs = func.getAttrOfType<DictionaryAttr>(StripeOpsDialect::getStripeAttrsName());
   add_attributes(cur_.get(), attrs.getValue());
   Block& oblock = func.front();
   BlockInfo blockInfo(cur_.get());
   for (size_t i = 0; i < func.getNumArguments(); i++) {
     // add refinement for each arg
     auto arg = func.getArgument(i);
-    auto attrName = Dialect::getDialectAttrName("name");
+    auto attrName = StripeOpsDialect::getDialectAttrName("name");
     auto name = func.getArgAttrOfType<StringAttr>(i, attrName).getValue();
     // Compute all the info about the tensor
     auto ti = ComputeAccessAndLoc(arg).first;
@@ -298,7 +298,7 @@ std::string StripeBuilder::add_refinements(  //
     }
     // If op matches the block, move the op up, also attributes
     while (op && op->getBlock() == block && mlir::isa<RefineOp>(op)) {
-      if (auto attrs = op->getAttrOfType<DictionaryAttr>(Dialect::getStripeAttrsName())) {
+      if (auto attrs = op->getAttrOfType<DictionaryAttr>(StripeOpsDialect::getStripeAttrsName())) {
         add_attributes(ref, attrs.getValue());
       }
       op = mlir::cast<RefineOp>(op).in()->getDefiningOp();
@@ -387,7 +387,7 @@ void StripeBuilder::visit(ParallelForOp op) {
     }
   }
   // Add the attributes
-  if (auto attrs = op.getAttrOfType<DictionaryAttr>(Dialect::getStripeAttrsName())) {
+  if (auto attrs = op.getAttrOfType<DictionaryAttr>(StripeOpsDialect::getStripeAttrsName())) {
     add_attributes(cur_.get(), attrs.getValue());
   }
   // Add the location (if any) by checking the inputs to the block's terminator.

--- a/pmlc/dialect/stripe/into_mlir.cc
+++ b/pmlc/dialect/stripe/into_mlir.cc
@@ -321,7 +321,7 @@ static void BlockIntoMLIR(OpBuilder* builder, const SymbolTable& outer, const st
     refOp.setAttr("name", builder->getStringAttr(ref.into()));
     auto attrs = TagsToDict(builder, ref);
     if (attrs.size()) {
-      refOp.setAttr(Dialect::getStripeAttrsName(), attrs);
+      refOp.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
     }
     locals.refs.emplace(ref.into(), refOp.result());
   }
@@ -351,7 +351,7 @@ static void BlockIntoMLIR(OpBuilder* builder, const SymbolTable& outer, const st
         auto op = builder->create<LoadOp>(unknownLoc, intoType, from);
         auto attrs = TagsToDict(builder, *load);
         if (attrs.size()) {
-          op.setAttr(Dialect::getStripeAttrsName(), attrs);
+          op.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
         }
         op.setAttr("scalar_name", builder->getStringAttr(load->into));
         locals.scalars.emplace(load->into, op);
@@ -375,7 +375,7 @@ static void BlockIntoMLIR(OpBuilder* builder, const SymbolTable& outer, const st
           // Simple case, just an assignment
           auto op = builder->create<StoreOp>(unknownLoc, into, from);
           if (attrs.size()) {
-            op.setAttr(Dialect::getStripeAttrsName(), attrs);
+            op.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
           }
         } else {
           // Aggregation case
@@ -387,7 +387,7 @@ static void BlockIntoMLIR(OpBuilder* builder, const SymbolTable& outer, const st
           IntegerAttr agg_attr = builder->getI64IntegerAttr(agg_int);
           auto op = builder->create<AggregateOp>(unknownLoc, into, from, agg_attr);
           if (attrs.size()) {
-            op.setAttr(Dialect::getStripeAttrsName(), attrs);
+            op.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
           }
         }
       } break;
@@ -436,7 +436,7 @@ static void BlockIntoMLIR(OpBuilder* builder, const SymbolTable& outer, const st
   loop_op.setAttr("comments", builder->getStringAttr(block.comments));
   auto attrs = TagsToDict(builder, block);
   if (attrs.size()) {
-    loop_op.setAttr(Dialect::getStripeAttrsName(), attrs);
+    loop_op.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
   }
   for (const auto& kvp : argAttrs) {
     loop_op.setAttr(kvp.first, kvp.second);
@@ -481,15 +481,15 @@ static mlir::FuncOp ProgramIntoMLIR(MLIRContext* ctx, const stripe::Block& block
       initial.refs.emplace(ref.into(), arg);
     }
     // Only 'dialect attrs' are allowed on function arguments
-    auto attrName = Dialect::getDialectAttrName("name");
+    auto attrName = StripeOpsDialect::getDialectAttrName("name");
     func.setArgAttr(argIndex, attrName, builder.getStringAttr(ref.into()));
-    auto attrLayout = Dialect::getDialectAttrName("layout");
+    auto attrLayout = StripeOpsDialect::getDialectAttrName("layout");
     func.setArgAttr(argIndex, attrLayout, builder.getTypeAttr(tensorTypes[argIndex]));
   }
 
   auto attrs = TagsToDict(&builder, block);
   if (attrs.size()) {
-    func.setAttr(Dialect::getStripeAttrsName(), attrs);
+    func.setAttr(StripeOpsDialect::getStripeAttrsName(), attrs);
   }
 
   BlockIntoMLIR(&builder, initial, *block.SubBlock(0));


### PR DESCRIPTION
This is only a query/learning PR to know if you would consider renaming `stripe::Dialect` to `StripeOpsDialect`. `*OpsDialect` seems to be the naming convention for dialects in MLIR and the current name collisions with eltwise::Dialect, both very likely to be used together.

Please, let me know what you think. If it makes sense to you, feel free to authorize this PR if you feel strong about src line history.

Thanks,
Diego