### PR TITLE
Fix batch normalization with None for beta/gamma

### DIFF
--- a/plaidml2/bridge/keras/__init__.py
+++ b/plaidml2/bridge/keras/__init__.py
@@ -1077,8 +1077,10 @@ def normalize_batch_in_training(x, gamma, beta, reduction_axes, epsilon=1e-3):
     I.bind_dims(*dims)
     for ax in axes:
         dims[ax] = 1
-    beta = reshape(beta, dims)
-    gamma = reshape(gamma, dims)
+    if beta is not None:
+        beta = reshape(beta, dims)
+    if gamma is not None:
+        gamma = reshape(gamma, dims)
 
     normalized_tensor = batch_normalization(x=x,
                                             mean=m,

--- a/plaidml2/bridge/keras/backend_test.py
+++ b/plaidml2/bridge/keras/backend_test.py
@@ -1340,8 +1340,13 @@ class TestBackendOps(unittest.TestCase):
     def testNormalizeBatchInTrainingSimple(self, b, x, mov_avg, mov_var):
         return [(b.normalize_batch_in_training(x, mov_avg, mov_var, [2]))[0]]
 
-    @opTest([[n(2, 3), np.array([3., 4., .7]),
-              np.array([1.44, .99, .98])]],
+    @opTest([
+        [n(2, 3), np.array([3., 4., .7]),
+         np.array([1.44, .99, .98])],
+        [n(3, 2), None, None],
+        [n(1, 3), None, np.array([2., 3., .55])],
+        [n(1, 2), np.array([-2., 0.]), None],
+    ],
             skip_theano=True,
             skip_tensorflow=True)
     def testNormalizeBatchInTraining(self, b, x, beta, gamma):


### PR DESCRIPTION
Fix a crash when `None` is used for the `beta` or `gamma` parameter of batch normalization.