### PR TITLE
Turn on fixed EDSL defract tests

### DIFF
--- a/plaidml2/edsl/edsl_test.cc
+++ b/plaidml2/edsl/edsl_test.cc
@@ -692,8 +692,7 @@ TEST(CppEdsl, DefractLong) {
   TensorIndex n, x0, x1, k0, k1, co, ci;
   O(n, x0, x1, co) += I(n, (x0 + k0 - 1) / 2, (x1 + k1 - 1) / 2, ci) * K(2 - k0, 2 - k1, co, ci);
   Program program("defract_long", {O});
-  // This currently crashes when combined with the padding pass
-  // exec::Executable::compile(program, {I, K})->run();
+  exec::Executable::compile(program, {I, K})->run();
 }
 
 TEST(CppEdsl, DupOut) {

--- a/plaidml2/edsl/edsl_test.py
+++ b/plaidml2/edsl/edsl_test.py
@@ -444,8 +444,27 @@ class TestEdsl(unittest.TestCase):
   _X0[x0, x1, x3, x6 : 1, 5, 5, 1] = +(I[x0, -1/2 + 1/2*x1 + 1/2*x2, -1/2 + 1/2*x3 + 1/2*x4, x5] * K[2 - x2, 2 - x4, x6, x5]);
 }
 ''')
-        # out of bounds access occurs when implicit constraints are combined with the padding pass
-        # outputs = plaidml_exec.run(program, [(I, np.random.rand(1, 3, 3, 1)), (K, np.random.rand(1, 3, 3, 1))])
+        outputs = plaidml_exec.run(program, [
+            (I, np.array([[
+                [[1], [3], [-1]],
+                [[0], [2], [4]],
+                [[1], [-1], [-2]],
+            ]])),
+            (K, np.array([[
+                [[2], [3], [4]],
+                [[6], [-3], [-1]],
+                [[-1], [-2], [1]],
+            ]])),
+        ])
+        np.testing.assert_array_equal(
+            outputs[0],
+            np.array([[
+                [[0], [0], [0], [0], [0]],
+                [[0], [4], [12], [6], [24]],
+                [[0], [0], [0], [0], [0]],
+                [[6], [-3], [-6], [-3], [-12]],
+                [[0], [0], [0], [0], [0]],
+            ]]))
 
     def testFunkyLayerNames(self):
         '''Exercises fix for plaidml bug #241


### PR DESCRIPTION
Now that the padding pass is fixed, turn the tests we were skipping back on. Also add expected output in the python version (verified by hand).