### PR TITLE
Fix the Metal compilation error on Catalina

### DIFF
--- a/tile/codegen/codegen.proto
+++ b/tile/codegen/codegen.proto
@@ -270,6 +270,8 @@ message FusionPass {
   repeated string a_inner_set = 11;
   // New tags for the second inner block
   repeated string b_inner_set = 12;
+  // Limit of number of refinements
+  optional uint32 max_refs = 13 [default = 1024];
 }
 
 // A localize pass detects allocations (refinements with dir = None)

--- a/tile/codegen/fuse.cc
+++ b/tile/codegen/fuse.cc
@@ -533,6 +533,10 @@ void FusionInner(const AliasMap& scope, Block* block, TagFusionStrategy* strateg
       if (!block2) {
         break;
       }
+      if (block1->refs.size() + block2->refs.size() - 1 > strategy->Options().max_refs()) {
+        // Too many refinements in a block for the particular platform
+        break;
+      }
       // Get the list of outputs for this block
       std::set<std::string> outs_for_fuse;
       // Do not use block1->ref_outs() because we need also InOut refs

--- a/tile/lang/gen_stripe.cc
+++ b/tile/lang/gen_stripe.cc
@@ -317,7 +317,7 @@ class StripeGenerator {
     }
     if (scalar_inputs.size() > 1) {
       if (cion.comb_op == CombinationOp::COND) {
-        kernel.get()->stmts.push_back(std::make_shared<Constant>("$ZERO", INT64_C(0)));
+        kernel.get()->stmts.push_back(std::make_shared<Constant>("$ZERO", 0.0));
         AddIntrinsic(kernel.get(), Intrinsic::EQ, input_based_type, {scalar_inputs[0], scalar_inputs[1]}, {"$IS_EQ"});
         AddIntrinsic(kernel.get(), Intrinsic::COND, output_type, {"$IS_EQ", scalar_inputs[2], "$ZERO"},
                      {ScalarName(op.output)});

--- a/tile/targets/gpu/amd.jsonnet
+++ b/tile/targets/gpu/amd.jsonnet
@@ -8,7 +8,8 @@ local PARAMS = {
     REG_MEM_LAT: 1,
     LOCAL_MEM_LAT: 30,
     GLOBAL_MEM_LAT: 100,
-    ALIGN_SIZE_B: 64
+    ALIGN_SIZE_B: 64,
+    MAX_REFS: 1024,
   },
   amd_metal: {
     LOCAL_MEM_KIB: 64,
@@ -19,7 +20,8 @@ local PARAMS = {
     REG_MEM_LAT: 1,
     LOCAL_MEM_LAT: 30,
     GLOBAL_MEM_LAT: 100,
-    ALIGN_SIZE_B: 128
+    ALIGN_SIZE_B: 128,
+    MAX_REFS: 31,
   },
 };
 
@@ -141,6 +143,7 @@ local PARAMS = {
                 b_reqs: ['eltwise'],
                 inner_remove_set: ['kernel'],
                 output_match: true,
+                max_refs: PARAMS[cfg].MAX_REFS,
               }
             },
 
@@ -152,6 +155,7 @@ local PARAMS = {
                 b_reqs: ['eltwise'],
                 inner_remove_set: ['kernel'],
                 b_inner_set: ['eltwise_middle'],
+                max_refs: PARAMS[cfg].MAX_REFS,
               }
             },
 
@@ -213,6 +217,7 @@ local PARAMS = {
                 fused_set: ['cache', 'eltwise'],
                 exclude: ['contract_middle'],
                 no_inner: true,
+                max_refs: PARAMS[cfg].MAX_REFS,
               }
             },
 

--- a/tile/targets/gpu/intel_gen9.jsonnet
+++ b/tile/targets/gpu/intel_gen9.jsonnet
@@ -8,6 +8,7 @@ local PARAMS = {
     MEM_BOUNDED_THRESHOLD: 14,
     CACHE_SIZE: 3 * 768 * 1024,
     INNER_STMTS_LIMIT: 1250,
+    MAX_REFS: 1024,
   },
   intel_gen9_metal: {
     CACHE_WIDTH: 64,
@@ -18,6 +19,7 @@ local PARAMS = {
     MEM_BOUNDED_THRESHOLD: 14,
     CACHE_SIZE: 3 * 768 * 1024,
     INNER_STMTS_LIMIT: 1200,
+    MAX_REFS: 31,
   },
 };
 
@@ -186,6 +188,7 @@ local PARAMS = {
                 a_reqs: ['subgroup_outer'],
                 b_reqs: ['eltwise'],
                 no_constraints: true,
+                max_refs: PARAMS[cfg].MAX_REFS, 
               },
             },
 
@@ -195,6 +198,7 @@ local PARAMS = {
                 '@type': 'type.vertex.ai/vertexai.tile.codegen.proto.FusionPass',
                 a_reqs: ['subgroup_thread'],
                 b_reqs: ['eltwise'],
+                max_refs: PARAMS[cfg].MAX_REFS,
               },
             },
 
@@ -205,6 +209,7 @@ local PARAMS = {
                 a_reqs: ['subgroup_write'],
                 b_reqs: ['eltwise'],
                 no_inner: true,
+                max_refs: PARAMS[cfg].MAX_REFS,
               },
             },
 
@@ -233,6 +238,7 @@ local PARAMS = {
                 a_reqs: ['eltwise'],
                 b_reqs: ['eltwise'],
                 output_match: true,
+                max_refs: PARAMS[cfg].MAX_REFS,
               },
             },
 


### PR DESCRIPTION
1) Walkaround about the limit (31) of the kernel buffer arguments
2) Set the ZERO value as float type, consistent with the usual case