### PR TITLE
Fix Program::Run race condition

### DIFF
--- a/plaidml2/edsl/edsl_test.cc
+++ b/plaidml2/edsl/edsl_test.cc
@@ -342,6 +342,9 @@ TEST(CppEdsl, RepeatElements) {
 }
 
 TEST(CppEdsl, UseDefault) {
+  if (vertexai::env::Get("PLAIDML_MLIR") == "1") {
+    FAIL() << "[MLIR] NYI: use_default";
+  }
   auto P = Placeholder(PLAIDML_DATA_FLOAT32, {1, 7, 10, 10});
   auto I = Placeholder(PLAIDML_DATA_FLOAT32, {1, 10, 10});
   TensorDim B, N1, N2;

--- a/tile/base/platform.h
+++ b/tile/base/platform.h
@@ -32,7 +32,7 @@ class Platform {
       std::uint64_t size) = 0;
 
   // Builds (pre-compiling if possible) a program for executing the supplied Program
-  virtual std::unique_ptr<Program> MakeProgram(  //
+  virtual std::shared_ptr<Program> MakeProgram(  //
       const context::Context& ctx,               //
       const proto::Program& program,             //
       ConstBufferManager* const_bufs) = 0;

--- a/tile/base/platform_test.cc
+++ b/tile/base/platform_test.cc
@@ -25,7 +25,7 @@ void PlatformTest::SetUp() {
   platform_ = param.factory();
 }
 
-std::unique_ptr<Program> PlatformTest::MakeProgram(tile::proto::TileScanningParameters* params,  //
+std::shared_ptr<Program> PlatformTest::MakeProgram(tile::proto::TileScanningParameters* params,  //
                                                    const char* code,                             //
                                                    const TensorShape& shape) {
   proto::Program pb_program;

--- a/tile/base/platform_test.h
+++ b/tile/base/platform_test.h
@@ -57,7 +57,7 @@ class PlatformTest : public ::testing::TestWithParam<FactoryParam> {
  protected:
   void SetUp() final;
 
-  std::unique_ptr<Program> MakeProgram(proto::TileScanningParameters* params,  //
+  std::shared_ptr<Program> MakeProgram(proto::TileScanningParameters* params,  //
                                        const char* code,                       //
                                        const TensorShape& shape);
   std::shared_ptr<Buffer> MakeInput(const TensorShape& shape,  //

--- a/tile/platform/local_machine/platform.cc
+++ b/tile/platform/local_machine/platform.cc
@@ -220,7 +220,7 @@ std::shared_ptr<tile::Buffer> Platform::MakeBuffer(const context::Context& ctx, 
   return std::make_shared<Buffer>(platform_dev.devinfo, platform_dev.mem_strategy, size);
 }
 
-std::unique_ptr<tile::Program> Platform::MakeProgram(  //
+std::shared_ptr<tile::Program> Platform::MakeProgram(  //
     const context::Context& ctx,                       //
     const tile::proto::Program& program,               //
     ConstBufferManager* const_bufs) {
@@ -231,11 +231,11 @@ std::unique_ptr<tile::Program> Platform::MakeProgram(  //
     runinfo.input_shapes = FromProto(program.inputs());
     runinfo.output_shapes = FromProto(program.outputs());
     runinfo.program_name = "stripe_program";
-    return std::make_unique<CpuProgram>("llvm_cpu", runinfo, const_bufs);
+    return std::make_shared<CpuProgram>("llvm_cpu", runinfo, const_bufs);
   }
   const auto& platform_dev = LookupDevice(program.dev_id());
   auto tmp_strategy = std::make_shared<TmpMemStrategy>(platform_dev.devinfo, platform_dev.tmp_mem_source);
-  return std::make_unique<Program>(  //
+  return std::make_shared<Program>(  //
       ctx,                           //
       program,                       //
       platform_dev.devinfo,          //
@@ -254,7 +254,7 @@ std::shared_ptr<tile::Program> Platform::MakeProgram(  //
     const std::shared_ptr<stripe::Program>& program,   //
     ConstBufferManager* const_bufs) {
   if (device == kCpuDevice) {
-    return std::make_unique<CpuProgram>(target, program, const_bufs);
+    return std::make_shared<CpuProgram>(target, program, const_bufs);
   }
   const auto& platform_dev = LookupDevice(device);
   auto tmp_strategy = std::make_shared<TmpMemStrategy>(platform_dev.devinfo, platform_dev.tmp_mem_source);

--- a/tile/platform/local_machine/platform.h
+++ b/tile/platform/local_machine/platform.h
@@ -43,7 +43,7 @@ class Platform : public tile::Platform {
       const std::string& device,             //
       std::uint64_t size) final;
 
-  std::unique_ptr<tile::Program> MakeProgram(  //
+  std::shared_ptr<tile::Program> MakeProgram(  //
       const context::Context& ctx,             //
       const tile::proto::Program& program,     //
       ConstBufferManager* const_bufs) final;

--- a/tile/platform/local_machine/program.cc
+++ b/tile/platform/local_machine/program.cc
@@ -323,7 +323,7 @@ boost::future<void> Program::Run(const context::Context& ctx,
   for (const auto& kvp : const_bufs_) {
     inputs[kvp.first] = kvp.second;
   }
-  return RunRequest::Run(ctx, this, std::move(inputs), std::move(rewrite_outputs));
+  return RunRequest::Run(ctx, shared_from_this(), std::move(inputs), std::move(rewrite_outputs));
 }
 
 std::size_t Program::MaxAvailableMemory() { return memory_->size_goal() * kGoalMemPercentage; }

--- a/tile/platform/local_machine/program.h
+++ b/tile/platform/local_machine/program.h
@@ -30,7 +30,7 @@ namespace local_machine {
 // TODO: Either autotune this, or move it to the per-device configuration.
 constexpr float kGoalMemPercentage = .85;
 
-class Program final : public tile::Program {
+class Program final : public tile::Program, public std::enable_shared_from_this<Program> {
  public:
   Program(const context::Context& ctx, const tile::proto::Program& program, const std::shared_ptr<DevInfo>& devinfo,
           const std::shared_ptr<Scheduler>& scheduler, const std::shared_ptr<MemStrategy>& output_mem_strategy,

--- a/tile/platform/local_machine/run_request.cc
+++ b/tile/platform/local_machine/run_request.cc
@@ -14,8 +14,8 @@ namespace local_machine {
 namespace {
 
 // Runs the schedule for a particular program.
-boost::future<std::vector<std::shared_ptr<hal::Result>>> RunSchedule(const context::Context& ctx, RunRequest* req,
-                                                                     Shim* shim) {
+boost::future<std::vector<std::shared_ptr<hal::Result>>> RunSchedule(  //
+    const context::Context& ctx, RunRequest* req, Shim* shim) {
   std::vector<std::shared_ptr<hal::Event>> deps;
   deps.resize(req->program()->schedule().steps.size());
   std::unordered_set<std::shared_ptr<hal::Event>> dep_set;
@@ -109,9 +109,11 @@ boost::future<std::vector<std::shared_ptr<hal::Result>>> RunSchedule(const conte
 
 }  // namespace
 
-boost::future<void> RunRequest::Run(const context::Context& ctx, const Program* program,
-                                    std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
-                                    std::map<std::string, std::shared_ptr<tile::Buffer>> outputs) {
+boost::future<void> RunRequest::Run(          //
+    const context::Context& ctx,              //
+    const std::shared_ptr<Program>& program,  //
+    std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
+    std::map<std::string, std::shared_ptr<tile::Buffer>> outputs) {
   LogRequest(program, inputs, outputs);
 
   RunRequest req{program};
@@ -140,11 +142,15 @@ boost::future<void> RunRequest::Run(const context::Context& ctx, const Program* 
   // Keep the shim and activity referenced until the program is complete.
   // N.B. It's important to keep the shim referenced because it's the thing that's actually holding
   // onto all of our chunk references; if those go away, unfortunate things happen.
-  return complete.then([shim = std::move(shim), running = std::move(running)](decltype(complete) fut) { fut.get(); });
+  return complete.then([shim = std::move(shim), running = std::move(running)](decltype(complete) fut) {  //
+    fut.get();
+  });
 }
 
-void RunRequest::LogRequest(const Program* program, const std::map<std::string, std::shared_ptr<tile::Buffer>>& inputs,
-                            const std::map<std::string, std::shared_ptr<tile::Buffer>>& outputs) {
+void RunRequest::LogRequest(                  //
+    const std::shared_ptr<Program>& program,  //
+    const std::map<std::string, std::shared_ptr<tile::Buffer>>& inputs,
+    const std::map<std::string, std::shared_ptr<tile::Buffer>>& outputs) {
   VLOG(1) << "Running program " << program;
   if (VLOG_IS_ON(2)) {
     for (const auto& it : inputs) {
@@ -172,8 +178,9 @@ void RunRequest::LogRequest(const Program* program, const std::map<std::string, 
   }
 }
 
-boost::future<void> RunRequest::LogResults(const context::Context& ctx,
-                                           boost::future<std::vector<std::shared_ptr<hal::Result>>> results) {
+boost::future<void> RunRequest::LogResults(  //
+    const context::Context& ctx,             //
+    boost::future<std::vector<std::shared_ptr<hal::Result>>> results) {
   context::Context ctx_copy{ctx};
   return results.then([ctx = std::move(ctx_copy)](decltype(results) future) {
     auto results = future.get();

--- a/tile/platform/local_machine/run_request.h
+++ b/tile/platform/local_machine/run_request.h
@@ -19,13 +19,15 @@ namespace local_machine {
 // Represents the state of a Program::Run request.
 class RunRequest {
  public:
-  static boost::future<void> Run(const context::Context& ctx, const Program* program,
-                                 std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
-                                 std::map<std::string, std::shared_ptr<tile::Buffer>> outputs);
+  static boost::future<void> Run(               //
+      const context::Context& ctx,              //
+      const std::shared_ptr<Program>& program,  //
+      std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
+      std::map<std::string, std::shared_ptr<tile::Buffer>> outputs);
 
   void AddProgramDoneDep(const std::shared_ptr<hal::Event>& event);
 
-  const Program* program() const { return program_; }
+  const Program* program() const { return program_.get(); }
 
  private:
   struct KernelLogInfo {
@@ -35,15 +37,18 @@ class RunRequest {
     std::size_t tot_flops;
   };
 
-  explicit RunRequest(const Program* program) : program_{program} {}
+  explicit RunRequest(const std::shared_ptr<Program>& program) : program_{program} {}
 
-  static void LogRequest(const Program* program, const std::map<std::string, std::shared_ptr<tile::Buffer>>& inputs,
-                         const std::map<std::string, std::shared_ptr<tile::Buffer>>& outputs);
+  static void LogRequest(                       //
+      const std::shared_ptr<Program>& program,  //
+      const std::map<std::string, std::shared_ptr<tile::Buffer>>& inputs,
+      const std::map<std::string, std::shared_ptr<tile::Buffer>>& outputs);
 
-  boost::future<void> LogResults(const context::Context& ctx,
-                                 boost::future<std::vector<std::shared_ptr<hal::Result>>> results);
+  boost::future<void> LogResults(   //
+      const context::Context& ctx,  //
+      boost::future<std::vector<std::shared_ptr<hal::Result>>> results);
 
-  const Program* program_;
+  const std::shared_ptr<Program> program_;
 };
 
 }  // namespace local_machine

--- a/tile/platform/local_machine/shim.cc
+++ b/tile/platform/local_machine/shim.cc
@@ -3,6 +3,7 @@
 #include "tile/platform/local_machine/shim.h"
 
 #include <unordered_set>
+#include <utility>
 
 #include "base/util/error.h"
 #include "tile/platform/local_machine/buffer.h"
@@ -71,11 +72,13 @@ std::pair<std::vector<std::shared_ptr<MemChunk>>, std::list<Shim::AliasUpdate>> 
 
 }  // namespace
 
-Shim::Shim(const context::Context& ctx, const Program* program,
-           std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
-           std::map<std::string, std::shared_ptr<tile::Buffer>> outputs):
-           program_{const_cast<Program*>(program)} {
-  std::tie(chunk_infos_, updates_) = BuildChunkMap(ctx, program, inputs, outputs);
+Shim::Shim(                                   //
+    const context::Context& ctx,              //
+    const std::shared_ptr<Program>& program,  //
+    std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
+    std::map<std::string, std::shared_ptr<tile::Buffer>> outputs)
+    : program_{program} {
+  std::tie(chunk_infos_, updates_) = BuildChunkMap(ctx, program.get(), inputs, outputs);
 }
 
 Shim::~Shim() {

--- a/tile/platform/local_machine/shim.h
+++ b/tile/platform/local_machine/shim.h
@@ -32,8 +32,11 @@ class Shim {
 
   // Construct the Shim.  This should be done at the start of queueing
   // the program's steps.
-  Shim(const context::Context& ctx, const Program* program, std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
-       std::map<std::string, std::shared_ptr<tile::Buffer>> outputs);
+  Shim(                                         //
+      const context::Context& ctx,              //
+      const std::shared_ptr<Program>& program,  //
+      std::map<std::string, std::shared_ptr<tile::Buffer>> inputs,
+      std::map<std::string, std::shared_ptr<tile::Buffer>> outputs);
 
   // Destroys the Shim.  Note that this does not apply side-effects;
   // OnLaunchSuccess must be invoked in order to remap program output buffers.
@@ -52,7 +55,7 @@ class Shim {
  private:
   std::vector<std::shared_ptr<MemChunk>> chunk_infos_;
   std::list<AliasUpdate> updates_;
-  Program* program_;
+  std::shared_ptr<Program> program_;
 };
 
 }  // namespace local_machine


### PR DESCRIPTION
The `Shim` was holding onto a `Program` that might have been freed. If the user decides not to wait on the `Program::Run` future (totally valid), then it's possible that the user might free the `Program` (indirectly) before the future has completed.

This ensures that the `Program` is pinned down by anything using it asynchronously.
