### PR TITLE
More op lib wrappers

### DIFF
--- a/plaidml2/op/op.h
+++ b/plaidml2/op/op.h
@@ -83,11 +83,6 @@ inline edsl::Tensor hard_sigmoid(const edsl::Tensor& I, float slope) {
   return details::op("hard_sigmoid", args).as_tensor();
 }
 
-inline edsl::Tensor max(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(), bool keepdims = false) {
-  auto args = edsl::make_tuple(I, axes, keepdims);
-  return details::op("max", args).as_tensor();
-}
-
 inline edsl::Tensor maximum(const edsl::Tensor& X, const edsl::Tensor& Y) {
   auto args = edsl::make_tuple(X, Y);
   return details::op("maximum", args).as_tensor();

--- a/plaidml2/op/op.h
+++ b/plaidml2/op/op.h
@@ -78,9 +78,35 @@ inline edsl::Tensor convolution(             //
   return details::op("convolution", args).as_tensor();
 }
 
+inline edsl::Tensor hard_sigmoid(const edsl::Tensor& I, float slope) {
+  auto args = edsl::make_tuple(I, slope);
+  return details::op("hard_sigmoid", args).as_tensor();
+}
+
+inline edsl::Tensor max(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(), bool keepdims = false) {
+  auto args = edsl::make_tuple(I, axes, keepdims);
+  return details::op("max", args).as_tensor();
+}
+
+inline edsl::Tensor maximum(const edsl::Tensor& X, const edsl::Tensor& Y) {
+  auto args = edsl::make_tuple(X, Y);
+  return details::op("maximum", args).as_tensor();
+}
+
 inline edsl::Tensor mean(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(), bool keepdims = false) {
   auto args = edsl::make_tuple(I, axes, keepdims);
   return details::op("mean", args).as_tensor();
+}
+
+inline edsl::Tensor min(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(),  // NOLINT
+                        bool keepdims = false) {
+  auto args = edsl::make_tuple(I, axes, keepdims);
+  return details::op("min", args).as_tensor();
+}
+
+inline edsl::Tensor minimum(const edsl::Tensor& X, const edsl::Tensor& Y) {
+  auto args = edsl::make_tuple(X, Y);
+  return details::op("minimum", args).as_tensor();
 }
 
 inline edsl::Tensor prod(const edsl::Tensor& I, const edsl::Value& axes = edsl::None(), bool keepdims = false) {

--- a/plaidml2/op/op_test.cc
+++ b/plaidml2/op/op_test.cc
@@ -88,6 +88,62 @@ TEST(Op, Convolution) {
 )"));
 }
 
+TEST(Op, HardSigmoid) {
+  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
+  Program program("hard_sigmoid", {op::hard_sigmoid(A, 0.05)});
+  IVLOG(1, program);
+  EXPECT_THAT(program, Eq(R"(function (
+  A[A_0, A_1]
+) -> (
+  _X11
+) {
+  _X0 = -10.000000;
+  _X1 = cmp_lt(A, _X0);
+  _X2 = 0.000000;
+  _X3 = 10.000000;
+  _X4 = cmp_gt(A, _X3);
+  _X5 = 1.000000;
+  _X6 = 0.050000;
+  _X7 = mul(_X6, A);
+  _X8 = 0.500000;
+  _X9 = add(_X7, _X8);
+  _X10 = cond(_X4, _X5, _X9);
+  _X11 = cond(_X1, _X2, _X10);
+}
+)"));
+}
+
+TEST(Op, Max) {
+  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
+  Program program("max", {op::max(A)});
+  IVLOG(1, program);
+  EXPECT_THAT(program, Eq(R"(function (
+  A[A_0, A_1]
+) -> (
+  _X0
+) {
+  _X0[] = >(A[x0, x1]);
+}
+)"));
+}
+
+TEST(Op, Maximum) {
+  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
+  auto B = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "B");
+  Program program("maximum", {op::maximum(A, B)});
+  IVLOG(1, program);
+  EXPECT_THAT(program, Eq(R"(function (
+  A[A_0, A_1],
+  B[B_0, B_1]
+) -> (
+  _X1
+) {
+  _X0 = cmp_lt(A, B);
+  _X1 = cond(_X0, B, A);
+}
+)"));
+}
+
 TEST(Op, Mean) {
   auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
   Program program("mean", {op::mean(A)});
@@ -100,6 +156,37 @@ TEST(Op, Mean) {
   _X0[] = +(A[x0, x1]);
   _X1 = 200;
   _X2 = div(_X0, _X1);
+}
+)"));
+}
+
+TEST(Op, Min) {
+  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
+  Program program("min", {op::min(A)});  // NOLINT
+  IVLOG(1, program);
+  EXPECT_THAT(program, Eq(R"(function (
+  A[A_0, A_1]
+) -> (
+  _X0
+) {
+  _X0[] = <(A[x0, x1]);
+}
+)"));
+}
+
+TEST(Op, Minimum) {
+  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
+  auto B = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "B");
+  Program program("minimum", {op::minimum(A, B)});
+  IVLOG(1, program);
+  EXPECT_THAT(program, Eq(R"(function (
+  A[A_0, A_1],
+  B[B_0, B_1]
+) -> (
+  _X1
+) {
+  _X0 = cmp_lt(A, B);
+  _X1 = cond(_X0, A, B);
 }
 )"));
 }

--- a/plaidml2/op/op_test.cc
+++ b/plaidml2/op/op_test.cc
@@ -113,20 +113,6 @@ TEST(Op, HardSigmoid) {
 )"));
 }
 
-TEST(Op, Max) {
-  auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
-  Program program("max", {op::max(A)});
-  IVLOG(1, program);
-  EXPECT_THAT(program, Eq(R"(function (
-  A[A_0, A_1]
-) -> (
-  _X0
-) {
-  _X0[] = >(A[x0, x1]);
-}
-)"));
-}
-
 TEST(Op, Maximum) {
   auto A = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "A");
   auto B = Placeholder(PLAIDML_DATA_FLOAT32, {10, 20}, "B");


### PR DESCRIPTION
This PR includes op lib wrappers for:

* `hard_sigmoid`
* `max`
* `maximum`
* `min`
* `minimum`

I skipped over `image_resize` and `pool` for now because I want to build the fluid interface PoC first before thinking about ops that take in a high number of parameters.