### PR TITLE
pin xcode on bazelci hosted machines

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,6 +19,7 @@ tasks:
     - "..."
   macos:
     name: "PlaidML MacOS"
+    xcode_version: "11.2"
     shell_commands:
     - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh 
     - sh ./Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda


### PR DESCRIPTION
Let's see if this works.

https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md#macos-using-a-specific-version-of-xcode