### PR TITLE
[MLIR] Minor fixes to PopulateTensorRefShapeAnalysis

### DIFF
--- a/pmlc/dialect/stripe/dialect.cc
+++ b/pmlc/dialect/stripe/dialect.cc
@@ -36,7 +36,7 @@ struct OpAsmInterface : public mlir::OpAsmDialectInterface {
     }
   }
 
-  void getRegionArgumentName(mlir::BlockArgument* arg, llvm::raw_ostream& os) const final {
+  void getRegionArgumentName(mlir::BlockArgument* arg, llvm::raw_ostream& os) const {
     Operation* op = arg->getOwner()->getParentOp();
     if (auto vec = op->getAttrOfType<ArrayAttr>("idx_names")) {
       if (vec.size() > arg->getArgNumber()) {

--- a/pmlc/dialect/stripe/populate_tensor_ref_shape_analysis.cc
+++ b/pmlc/dialect/stripe/populate_tensor_ref_shape_analysis.cc
@@ -22,7 +22,8 @@ namespace dialect {
 namespace stripe {
 
 PopulateTensorRefShape::PopulateTensorRefShape(mlir::Operation* op) : operation(op) {
-  assert(llvm::isa<FuncOp>(op) && "Only FuncOp is supported in PopulateTensorRefShape");
+  assert(isa<FuncOp>(op) && "Only FuncOp is supported in PopulateTensorRefShape");
+  recompute();
 }
 
 // Retrieve the layout information for each Value in `valueList` with a 'tensor_ref' type and replace the type with a
@@ -38,7 +39,7 @@ static void populateValuesWithShapes(Range valueRange) {
 }
 
 void PopulateTensorRefShape::recompute() {
-  FuncOp func = llvm::cast<FuncOp>(operation);
+  FuncOp func = cast<FuncOp>(operation);
 
   // Visit types in block arguments.
   for (auto& block : func.getBody().getBlocks()) {

--- a/pmlc/dialect/stripe/populate_tensor_ref_shape_analysis.h
+++ b/pmlc/dialect/stripe/populate_tensor_ref_shape_analysis.h
@@ -23,6 +23,7 @@ namespace stripe {
 // more cases than the Stripe->Affine dialect conversion.
 class PopulateTensorRefShape {
  public:
+  /// Constructor for analysis manager. Only FuncOp is supported.
   explicit PopulateTensorRefShape(mlir::Operation* op);
 
   /// Recompute shape information for 'tensor_ref' types.


### PR DESCRIPTION
Analysis was not computed when retrieved using MLIR analysis manager.