### PR TITLE
Lower 1-sided constraints in Tile->Stripe

### DIFF
--- a/pmlc/dialect/tile/contraction.cc
+++ b/pmlc/dialect/tile/contraction.cc
@@ -368,12 +368,13 @@ Contraction::Contraction(ContractionOp op) {
     accesses.emplace_back(ConvertAffineMap(op, map));
   }
 
-  // TODO: enable this once we can use SimpleConstraints directly
-  // if (op.cons().hasValue()) {
-  //   for (auto cons : op.cons().getValue().getConstraints()) {
-  //     constraints.emplace_back(MakePoly(op, cons), 0);
-  //   }
-  // }
+  if (op.cons().hasValue()) {
+    for (auto cons : op.cons().getValue().getConstraints()) {
+      // MLIR AffineConstraints are [poly] >= 0, and simple constraints are [poly] <= [const]
+      // So we use 0 as the constant and negate the constraint
+      constraints.emplace_back(MakePoly(op, -cons), 0);
+    }
+  }
 }
 
 void Contraction::GatherConstraints(llvm::ArrayRef<stripe::TensorType> shapes) {

--- a/pmlc/dialect/tile/contraction.h
+++ b/pmlc/dialect/tile/contraction.h
@@ -17,12 +17,6 @@ namespace pmlc::dialect::tile {
 
 namespace math = vertexai::tile::math;
 
-// A range [min, max], ie min <= x <= max
-struct Bound {
-  int64_t min;  // Smallest value inclusive
-  int64_t max;  // Largest value inclusive
-};
-
 using IndexPoly = math::Polynomial<math::Rational>;
 using IndexAccess = std::vector<IndexPoly>;
 using SimpleConstraints = std::vector<math::SimpleConstraint>;

--- a/pmlc/dialect/tile/contraction.h
+++ b/pmlc/dialect/tile/contraction.h
@@ -25,10 +25,9 @@ struct Bound {
 
 using IndexPoly = math::Polynomial<math::Rational>;
 using IndexAccess = std::vector<IndexPoly>;
-using IndexBounds = std::map<std::string, Bound>;
 using SimpleConstraints = std::vector<math::SimpleConstraint>;
 using RangeConstraints = std::vector<math::RangeConstraint>;
-using BoundsAndConstraints = std::tuple<IndexBounds, SimpleConstraints>;
+using BoundsAndConstraints = std::tuple<math::IndexBounds, SimpleConstraints>;
 
 struct Constraints {
   RangeConstraints constraints;
@@ -73,6 +72,6 @@ struct Contraction {
   void Defractionalize();
 };
 
-math::Affine Integerize(const IndexPoly& poly, const IndexBounds& bounds);
+math::Affine Integerize(const IndexPoly& poly, const math::IndexBounds& bounds);
 
 }  // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/contraction.h
+++ b/pmlc/dialect/tile/contraction.h
@@ -27,11 +27,11 @@ using IndexPoly = math::Polynomial<math::Rational>;
 using IndexAccess = std::vector<IndexPoly>;
 using IndexBounds = std::map<std::string, Bound>;
 using SimpleConstraints = std::vector<math::SimpleConstraint>;
-using SimpleConstraints = std::vector<math::RangedConstraint>;
-using BoundsAndConstraints = std::tuple<IndexBounds, RangedConstraints>;
+using RangeConstraints = std::vector<math::RangeConstraint>;
+using BoundsAndConstraints = std::tuple<IndexBounds, SimpleConstraints>;
 
 struct Constraints {
-  RangedConstraints constraints;
+  RangeConstraints constraints;
 
   void AddTensor(const IndexAccess& access, stripe::TensorType tensorType);
 
@@ -50,27 +50,27 @@ struct Contraction {
   explicit Contraction(ContractionOp op);
 
   BoundsAndConstraints ComputeBounds(llvm::ArrayRef<stripe::TensorType> shapes, bool no_reduce);
+  void DeduceRangeConstraints();
 
   std::vector<IndexAccess> accesses;
   SimpleConstraints constraints;
-  // During lowering, will transform all constraints to ranged constraints, which we track in ranged_constraints
-  Constraints ranged_constraints;
+  // During lowering, will transform all constraints to range constraints, which we track in range_constraints
+  Constraints range_constraints;
 
  private:
   std::set<std::string> getIndexVars() const;
 
   // Gathers boths explicit and implied constraints, and removes dups.
-  Constraints GatherConstraints(llvm::ArrayRef<stripe::TensorType> shapes) const;
+  void GatherConstraints(llvm::ArrayRef<stripe::TensorType> shapes);
 
-  // Adds constraints to the contraction forcing every variable used to be an
-  // integer
+  // Adds constraints to the contraction forcing every variable used to be an integer
   void ConstrainIndexVarsToInts();
 
   bool NeedReduce() const;
-  void ReduceOutputPolynomials(const Constraints& order);
+  void ReduceOutputPolynomials();
 
   // Remove any fractional polynomial multipliers (IE, any non-integers).
-  void Defractionalize(const Constraints& order);
+  void Defractionalize();
 };
 
 math::Affine Integerize(const IndexPoly& poly, const IndexBounds& bounds);

--- a/pmlc/dialect/tile/contraction.h
+++ b/pmlc/dialect/tile/contraction.h
@@ -27,10 +27,11 @@ using IndexPoly = math::Polynomial<math::Rational>;
 using IndexAccess = std::vector<IndexPoly>;
 using IndexBounds = std::map<std::string, Bound>;
 using SimpleConstraints = std::vector<math::SimpleConstraint>;
-using BoundsAndConstraints = std::tuple<IndexBounds, SimpleConstraints>;
+using SimpleConstraints = std::vector<math::RangedConstraint>;
+using BoundsAndConstraints = std::tuple<IndexBounds, RangedConstraints>;
 
 struct Constraints {
-  SimpleConstraints constraints;
+  RangedConstraints constraints;
 
   void AddTensor(const IndexAccess& access, stripe::TensorType tensorType);
 
@@ -52,6 +53,8 @@ struct Contraction {
 
   std::vector<IndexAccess> accesses;
   SimpleConstraints constraints;
+  // During lowering, will transform all constraints to ranged constraints, which we track in ranged_constraints
+  Constraints ranged_constraints;
 
  private:
   std::set<std::string> getIndexVars() const;

--- a/pmlc/dialect/tile/contraction.h
+++ b/pmlc/dialect/tile/contraction.h
@@ -26,12 +26,11 @@ struct Bound {
 using IndexPoly = math::Polynomial<math::Rational>;
 using IndexAccess = std::vector<IndexPoly>;
 using IndexBounds = std::map<std::string, Bound>;
-using RangeConstraints = std::vector<math::RangeConstraint>;
 using SimpleConstraints = std::vector<math::SimpleConstraint>;
 using BoundsAndConstraints = std::tuple<IndexBounds, SimpleConstraints>;
 
 struct Constraints {
-  RangeConstraints constraints;
+  SimpleConstraints constraints;
 
   void AddTensor(const IndexAccess& access, stripe::TensorType tensorType);
 
@@ -52,7 +51,7 @@ struct Contraction {
   BoundsAndConstraints ComputeBounds(llvm::ArrayRef<stripe::TensorType> shapes, bool no_reduce);
 
   std::vector<IndexAccess> accesses;
-  std::vector<math::RangeConstraint> constraints;
+  SimpleConstraints constraints;
 
  private:
   std::set<std::string> getIndexVars() const;

--- a/tile/bilp/BUILD
+++ b/tile/bilp/BUILD
@@ -8,7 +8,6 @@ plaidml_cc_library(
         "tableau.cc",
         "tableau.h",
     ],
-    alwayslink = 1,
     visibility = ["//visibility:public"],
     deps = [
         "//base/util",

--- a/tile/bilp/BUILD
+++ b/tile/bilp/BUILD
@@ -8,6 +8,7 @@ plaidml_cc_library(
         "tableau.cc",
         "tableau.h",
     ],
+    alwayslink = 1,
     visibility = ["//visibility:public"],
     deps = [
         "//base/util",
@@ -21,7 +22,7 @@ plaidml_cc_test(
     srcs = [
         "test.cc",
     ],
-    tags = ["large"],
+    # tags = ["large"],
     timeout = "eternal",
     deps = [
         ":bilp",

--- a/tile/bilp/ilp_solver.cc
+++ b/tile/bilp/ilp_solver.cc
@@ -198,8 +198,8 @@ Tableau ILPSolver::addGomoryCut(const Tableau& t, size_t row) {
   return ret;
 }
 
-Tableau ILPSolver::makeStandardFormTableau(const std::vector<math::SimpleConstraint>& constraints,
-                                           const math::Polynomial<math::Rational> objective) {
+Tableau makeStandardFormTableau(const std::vector<math::SimpleConstraint>& constraints,
+                                const math::Polynomial<math::Rational> objective) {
   // Create the standard form linear program for minimizing objective subject to constraints
 
   std::vector<Polynomial<Rational>> lp_constraints;  // The represented constraint is poly == 0
@@ -288,8 +288,7 @@ Tableau ILPSolver::makeStandardFormTableau(const std::vector<math::SimpleConstra
   return tableau;
 }
 
-Tableau ILPSolver::makeStandardFormTableau(const std::vector<RangeConstraint>& constraints,
-                                           const Polynomial<Rational> objective) {
+Tableau makeStandardFormTableau(const std::vector<RangeConstraint>& constraints, const Polynomial<Rational> objective) {
   // Create the standard form linear program for minimizing objective subject to the given constraints
   std::vector<math::SimpleConstraint> simple_constraints;
 
@@ -298,7 +297,7 @@ Tableau ILPSolver::makeStandardFormTableau(const std::vector<RangeConstraint>& c
     simple_constraints.emplace_back(c.upperBound());
   }
 
-  return ILPSolver::makeStandardFormTableau(simple_constraints, objective);
+  return makeStandardFormTableau(simple_constraints, objective);
 }
 
 void ILPSolver::clean() {

--- a/tile/bilp/ilp_solver.h
+++ b/tile/bilp/ilp_solver.h
@@ -63,8 +63,15 @@ class ILPSolver {
   // Transform constraints & objective to the tableau representing them
   // Can omit objective to set up just the constraints; this tableau can then be
   // copied to solve multiple problems with the same constraints
-  Tableau makeStandardFormTableau(
+  static Tableau makeStandardFormTableau(
       const std::vector<math::RangeConstraint>& constraints,
+      const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
+  // Transform constraints & objective to the tableau representing them
+  // Can omit objective to set up just the constraints; this tableau can then be
+  // copied to solve multiple problems with the same constraints
+  // The simple constraints used here also assert that the constrained polynomial must evaluate to an integer
+  static Tableau makeStandardFormTableau(
+      const std::vector<math::SimpleConstraint>& constraints,
       const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
   // Add an additional constraint that reduces the real feasible region but that
   // leaves the integral feasible region unchanged

--- a/tile/bilp/ilp_solver.h
+++ b/tile/bilp/ilp_solver.h
@@ -66,20 +66,6 @@ class ILPSolver {
 
   // Returns the solver to a neutral state to prepare to solve another problem
   void clean();
-
-  // Transform constraints & objective to the tableau representing them
-  // Can omit objective to set up just the constraints; this tableau can then be
-  // copied to solve multiple problems with the same constraints
-  static Tableau makeStandardFormTableau(
-      const std::vector<math::RangeConstraint>& constraints,
-      const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
-  // Transform constraints & objective to the tableau representing them
-  // Can omit objective to set up just the constraints; this tableau can then be
-  // copied to solve multiple problems with the same constraints
-  // The simple constraints used here also assert that the constrained polynomial must evaluate to an integer
-  static Tableau makeStandardFormTableau(
-      const std::vector<math::SimpleConstraint>& constraints,
-      const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
   // Add an additional constraint that reduces the real feasible region but that
   // leaves the integral feasible region unchanged
   Tableau addGomoryCut(const Tableau& t, size_t row);
@@ -88,6 +74,19 @@ class ILPSolver {
   // solution, or find a noninteger feasible solution, add a cut, and iterate)
   void solve_step(Tableau& tableau, bool already_canonical = false);  // NOLINT(runtime/references)
 };
+
+// Transform constraints & objective to the tableau representing them
+// Can omit objective to set up just the constraints; this tableau can then be
+// copied to solve multiple problems with the same constraints
+Tableau makeStandardFormTableau(const std::vector<math::RangeConstraint>& constraints,
+                                const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
+
+// Transform constraints & objective to the tableau representing them
+// Can omit objective to set up just the constraints; this tableau can then be
+// copied to solve multiple problems with the same constraints
+// The simple constraints used here also assert that the constrained polynomial must evaluate to an integer
+Tableau makeStandardFormTableau(const std::vector<math::SimpleConstraint>& constraints,
+                                const math::Polynomial<math::Rational> objective = math::Polynomial<math::Rational>());
 
 }  // namespace bilp
 }  // namespace tile

--- a/tile/bilp/ilp_solver.h
+++ b/tile/bilp/ilp_solver.h
@@ -30,10 +30,17 @@ class ILPSolver {
   // every variable and every constraint value being an integer)
   ILPResult solve(const std::vector<math::RangeConstraint>& constraints,
                   const math::Polynomial<math::Rational> objective);
+  ILPResult solve(const std::vector<math::SimpleConstraint>& constraints,
+                  const math::Polynomial<math::Rational> objective);
   // Returns a solution for each objective, all subject to the same constraints
+  std::map<math::Polynomial<math::Rational>, ILPResult> batch_solve(
+      const std::vector<math::SimpleConstraint>& constraints,
+      const std::vector<math::Polynomial<math::Rational>>& objectives);
   std::map<math::Polynomial<math::Rational>, ILPResult> batch_solve(
       const std::vector<math::RangeConstraint>& constraints,
       const std::vector<math::Polynomial<math::Rational>>& objectives);
+  std::map<math::Polynomial<math::Rational>, ILPResult> batch_solve(
+      Tableau* tableau, const std::vector<math::Polynomial<math::Rational>>& objectives);
 
   void set_throw_infeasible(bool b) { throw_infeasible = b; }
 

--- a/tile/bilp/test.cc
+++ b/tile/bilp/test.cc
@@ -19,7 +19,7 @@ TEST(BilpTest, BasicTableauTest) {
   constraints.emplace_back(Polynomial<Rational>("x") + 4, 4);
   Polynomial<Rational> obj = Polynomial<Rational>("x", 3);
   ILPSolver solver;
-  Tableau t = solver.makeStandardFormTableau(constraints, obj);
+  Tableau t = ILPSolver::makeStandardFormTableau(constraints, obj);
 
   EXPECT_EQ(t.mat().size1(), 3);
   EXPECT_EQ(t.mat().size2(), 6);

--- a/tile/bilp/test.cc
+++ b/tile/bilp/test.cc
@@ -19,7 +19,7 @@ TEST(BilpTest, BasicTableauTest) {
   constraints.emplace_back(Polynomial<Rational>("x") + 4, 4);
   Polynomial<Rational> obj = Polynomial<Rational>("x", 3);
   ILPSolver solver;
-  Tableau t = ILPSolver::makeStandardFormTableau(constraints, obj);
+  Tableau t = makeStandardFormTableau(constraints, obj);
 
   EXPECT_EQ(t.mat().size1(), 3);
   EXPECT_EQ(t.mat().size2(), 6);
@@ -90,8 +90,7 @@ TEST(BilpTest, SimpleOptimizeTest) {
   std::vector<RangeConstraint> constraints;
   constraints.emplace_back(Polynomial<Rational>("x") + 4, 4);
   Polynomial<Rational> obj = 3 * Polynomial<Rational>("x");
-  ILPSolver solver;
-  Tableau t = solver.makeStandardFormTableau(constraints, obj);
+  Tableau t = makeStandardFormTableau(constraints, obj);
   EXPECT_EQ(t.makeOptimal(), true);
 
   std::vector<Rational> soln = t.getSymbolicSolution();
@@ -108,8 +107,7 @@ TEST(BilpTest, OptimizeTest2D) {
   constraints.emplace_back(Polynomial<Rational>("x") + 1, 4);
   constraints.emplace_back(Polynomial<Rational>("y") + 2, 5);
   Polynomial<Rational> obj = -3 * Polynomial<Rational>("x") + 2 * Polynomial<Rational>("y");
-  ILPSolver solver;
-  Tableau t = solver.makeStandardFormTableau(constraints, obj);
+  Tableau t = makeStandardFormTableau(constraints, obj);
   EXPECT_EQ(t.makeOptimal(), true);
 
   std::vector<Rational> soln = t.getSymbolicSolution();
@@ -131,7 +129,7 @@ TEST(BilpTest, TrivialILPTest) {
   constraints.emplace_back(Polynomial<Rational>("y") + 2, 5);
   Polynomial<Rational> obj = -3 * Polynomial<Rational>("x") + 2 * Polynomial<Rational>("y");
   ILPSolver solver;
-  Tableau t = solver.makeStandardFormTableau(constraints, obj);
+  Tableau t = makeStandardFormTableau(constraints, obj);
   ILPResult res = solver.solve(t);
 
   EXPECT_EQ(res.soln["x"], 2);

--- a/tile/lang/bound.cc
+++ b/tile/lang/bound.cc
@@ -79,22 +79,6 @@ std::vector<RangeConstraint> GatherConstraints(const Contraction& c, const std::
   return out;
 }
 
-bool IsImplied(const SimpleConstraint& c, const IndexBounds& b) {
-  const Polynomial<Rational>& p = c.poly;
-  Rational worst = p.constant();
-  for (const auto& kvp : p.getMap()) {
-    if (kvp.first == "") {
-      continue;
-    }
-    if (kvp.second < 0) {
-      worst += kvp.second * b.find(kvp.first)->second.min;
-    } else {
-      worst += kvp.second * b.find(kvp.first)->second.max;
-    }
-  }
-  return (worst <= c.rhs);
-}
-
 void MergeParallelConstraints(std::vector<RangeConstraint>* constraints) {
   auto i = constraints->begin();
   while (i != constraints->end()) {

--- a/tile/lang/bound.h
+++ b/tile/lang/bound.h
@@ -13,20 +13,6 @@ namespace vertexai {
 namespace tile {
 namespace lang {
 
-// A range [min, max], ie min <= x <= max
-struct Bound {
-  int64_t min;  // Smallest value inclusive
-  int64_t max;  // Largest value inclusive
-};
-
-inline MAKE_LOGGABLE(Bound, b, os) {
-  os << "Bound[" << b.min << ", " << b.max << "]";
-  return os;
-}
-
-// A range for each index
-typedef std::map<std::string, Bound> IndexBounds;
-
 // Adds constraints to the contraction forcing every variable used to be an int
 Contraction ConstrainIndexVarsToInts(const Contraction& c);
 
@@ -36,21 +22,10 @@ std::vector<math::RangeConstraint> GatherConstraints(const Contraction& c, const
 // Searches for any parallel constraints and merges them
 void MergeParallelConstraints(std::vector<math::RangeConstraint>* constraints);
 
-// Given two parallel constraints, returns a constraint satisfied by exactly
-// those vectors which satisfy both given constraints
-math::RangeConstraint IntersectParallelConstraintPair(const math::RangeConstraint& constraint1,
-                                                      const math::RangeConstraint& constraint2);
-
 // Computes the bounds implied by the contraints, and also rewrites remaining contraints
 // to be minimal presuming the new set of bounds.  Throws on failure (ie Unbounded)
-std::tuple<IndexBounds, std::vector<math::SimpleConstraint>> ComputeBounds(
+std::tuple<math::IndexBounds, std::vector<math::SimpleConstraint>> ComputeBounds(
     const std::vector<math::RangeConstraint>& constraints);
-
-// Given polys n1*q + c1 and n2*q + c2 with gcd(n1, n2) = 1, compute d such that
-// q + d is integral if and only if n1*q + c1 and n2*q + c2 are both integral
-// (or throw if the polys are never both integral).
-math::Rational UnifiedOffset(const math::Rational& c1, const math::Rational& c2, const math::Integer& n1,
-                             const math::Integer& n2);
 
 }  // namespace lang
 }  // namespace tile

--- a/tile/math/math_test.cc
+++ b/tile/math/math_test.cc
@@ -104,18 +104,42 @@ TEST_CASE("Inversion Test (Singular)", "[matrix][invert]") {
   REQUIRE(m.invert() == false);
 }
 
-TEST_CASE("Basic Polynomial<Rational> compilation", "[]") {
+TEST_CASE("Basic Polynomial<Rational> compilation", "[poly]") {
   Polynomial<Rational> i("i"), j("j"), k("k");
   Polynomial<Rational> x = 3 * i - j + 17;
   Polynomial<Rational> y = -x / 3 + k;
   REQUIRE(to_string(y) == "-17/3 - i + 1/3*j + k");
 }
 
-TEST_CASE("Basic Polynomial<Rational> evaluation", "[]") {
+TEST_CASE("Basic Polynomial<Rational> evaluation", "[poly]") {
   Polynomial<Rational> a0("a0"), a1("a1");
   Polynomial<Rational> r = a0 + 3 * a1 + 1;
   REQUIRE(to_string(r) == "1 + a0 + 3*a1");
   REQUIRE(r.eval({{"a0", 5}, {"a1", 9}}) == 33);
+}
+
+TEST_CASE("IntersectParallelConstraintPair", "[poly]") {
+  Polynomial<Rational> i("i"), j("j");
+  RangeConstraint c1{2 * i + j + 1, 8};
+  RangeConstraint c2{-4 * i - 2 * j - 2, 2};
+  auto intersection = IntersectParallelConstraintPair(c1, c2);
+  REQUIRE(to_string(intersection) == "0 <= -1 - 2*i - j < 1");
+}
+
+TEST_CASE("IntersectOpposedSimpleConstraints", "[poly]") {
+  Polynomial<Rational> i("i"), j("j");
+  SimpleConstraint c1{2 * i + j + 1, 4};
+  SimpleConstraint c2{-6 * i - 3 * j, 2};
+  auto intersection = IntersectOpposedSimpleConstraints(c1, c2);
+  REQUIRE(to_string(intersection) == "0 <= 2*i + j < 4");
+}
+
+TEST_CASE("IntersectOpposedSimpleConstraintsBasic", "[poly]") {
+  Polynomial<Rational> x("x");
+  SimpleConstraint c1{x + 1, 4};
+  SimpleConstraint c2{-3 * x, 2};
+  auto intersection = IntersectOpposedSimpleConstraints(c1, c2);
+  REQUIRE(to_string(intersection) == "0 <= x < 4");
 }
 
 TEST_CASE("HNFMatrix", "[hnf]") {

--- a/tile/math/math_test.cc
+++ b/tile/math/math_test.cc
@@ -126,7 +126,7 @@ TEST_CASE("IntersectParallelConstraintPair", "[poly]") {
   REQUIRE(to_string(intersection) == "0 <= -1 - 2*i - j < 1");
 }
 
-TEST_CASE("IntersectOpposedSimpleConstraints", "[poly]") {
+TEST_CASE("IntersectOpposedSimpleConstraintsMultivar", "[poly]") {
   Polynomial<Rational> i("i"), j("j");
   SimpleConstraint c1{2 * i + j + 1, 4};
   SimpleConstraint c2{-6 * i - 3 * j, 2};
@@ -134,12 +134,20 @@ TEST_CASE("IntersectOpposedSimpleConstraints", "[poly]") {
   REQUIRE(to_string(intersection) == "0 <= 2*i + j < 4");
 }
 
-TEST_CASE("IntersectOpposedSimpleConstraintsBasic", "[poly]") {
+TEST_CASE("IntersectOpposedSimpleConstraints", "[poly]") {
   Polynomial<Rational> x("x");
   SimpleConstraint c1{x + 1, 4};
   SimpleConstraint c2{-3 * x, 2};
   auto intersection = IntersectOpposedSimpleConstraints(c1, c2);
   REQUIRE(to_string(intersection) == "0 <= x < 4");
+}
+
+TEST_CASE("IntersectOpposedSimpleBasic", "[poly]") {
+  Polynomial<Rational> x("x");
+  SimpleConstraint c1{x, 10};
+  SimpleConstraint c2{-x, 0};
+  auto intersection = IntersectOpposedSimpleConstraints(c1, c2);
+  REQUIRE(to_string(intersection) == "0 <= x < 11");
 }
 
 TEST_CASE("HNFMatrix", "[hnf]") {

--- a/tile/math/polynomial.cc
+++ b/tile/math/polynomial.cc
@@ -8,6 +8,82 @@ namespace vertexai {
 namespace tile {
 namespace math {
 
+namespace {
+
+Rational UnifiedOffset(const Rational& c1, const Rational& c2, const Integer& n1, const Integer& n2) {
+  std::set<Rational> offsets;
+  if (n1 > std::numeric_limits<std::size_t>::max() || n2 > std::numeric_limits<std::size_t>::max()) {
+    throw std::out_of_range("Cannot unify offset when relative quotient exceeds size_t.");
+  }
+  for (size_t i = 0; i < math::Abs(n1); ++i) {
+    offsets.insert(std::end(offsets), math::FracPart((c1 + i) / n1));
+  }
+  for (size_t j = 0; j < math::Abs(n2); ++j) {
+    Rational offset = math::FracPart((c2 + j) / n2);
+    if (offsets.count(offset)) {
+      return offset;
+    }
+  }
+  IVLOG(1, "Failed to compute UnifiedOffset(" << c1 << ", " << c2 << ", " << n1 << ", " << n2 << ").");
+  throw std::runtime_error("Merging constraints with empty intersection.");
+}
+
+RangeConstraint IntersectParallelConstraintPairInner(  //
+    const RangeConstraint& constraint1,                //
+    const RangeConstraint& constraint2) {
+  // The primary algorithm for combining two parallel constraints into one. See
+  // merge-parallel.tex in /tile/lang for more details.
+  // Assumes the RangeConstraints have been validated to have positive ranges, _or_ that
+  // for constraint2 specifically it represents a one sided constraint by having an
+  // infinite range parameter represented as a range value of -1
+  Rational ratio = constraint1.poly.tryDivide(constraint2.poly, true);
+  if (ratio == 0) {
+    throw std::invalid_argument("Parameters of IntersectParallelConstraintPair must be parallel");
+  }
+  Integer n1 = numerator(ratio);
+  Integer n2 = denominator(ratio);
+  Rational c1 = constraint1.poly.constant();
+  Rational c2 = constraint2.poly.constant();
+  // d is the fractional part of the offset of merged constraint polynomial
+  Rational d = UnifiedOffset(c1, c2, n1, n2);
+  // Range unification requires solving the following equations for q:
+  //    n1*q + c1 = 0           n2*q + c2 = 0
+  //    n1*q + c1 = r1 - 1      n2*q + c2 = r2 - 1
+  Rational q1_low = math::Min(-c1 / n1, (constraint1.range - 1 - c1) / n1);
+  Rational q1_hi = math::Max(-c1 / n1, (constraint1.range - 1 - c1) / n1);
+  Integer lower_bound;
+  Integer upper_bound;
+  if (constraint2.range > 0) {
+    Rational q2_low = math::Min(-c2 / n2, (constraint2.range - 1 - c2) / n2);
+    Rational q2_hi = math::Max(-c2 / n2, (constraint2.range - 1 - c2) / n2);
+    lower_bound = math::Max(math::Ceil(q1_low + d), math::Ceil(q2_low + d));
+    upper_bound = math::Min(math::Floor(q1_hi + d), math::Floor(q2_hi + d));
+  } else if (constraint2.range == -1) {
+    // Same calculations of lower/upper_bound as above, but with constraint2.range == infinity
+    Rational q2_low = -c2 / n2;
+    lower_bound = math::Max(math::Ceil(q1_low + d), math::Ceil(q2_low + d));
+    upper_bound = math::Floor(q1_hi + d);
+  } else {
+    throw std::runtime_error("Given constraint with empty range in IntersectParallelConstraintPair: " +
+                             to_string(constraint2));
+  }
+  Rational merged_offset = -lower_bound + d;
+  Integer range = upper_bound - lower_bound + 1;
+  if (range <= 0) {
+    throw std::runtime_error("Merging constraints with empty intersection: " + to_string(constraint1) + ", " +
+                             to_string(constraint2));
+  }
+  if (range > INT64_MAX) {
+    throw std::out_of_range("Bound range in IntersectParallelConstraintPair overflows int64.");
+  }
+  int64_t r = (int64_t)range;
+  Polynomial<Rational> p(constraint1.poly / n1);
+  p.setConstant(merged_offset);
+  return RangeConstraint(p, r);
+}
+
+}  // namespace
+
 template <typename T>
 Polynomial<T>::Polynomial() {}
 
@@ -272,6 +348,96 @@ bool RangeConstraint::IsParallel(const RangeConstraint& c) {
 SimpleConstraint RangeConstraint::lowerBound() const { return SimpleConstraint(-poly, 0); }
 
 SimpleConstraint RangeConstraint::upperBound() const { return SimpleConstraint(poly, range - 1); }
+
+bool IsImplied(const SimpleConstraint& constraint, const IndexBounds& bounds) {
+  auto worst = constraint.poly.constant();
+  for (const auto& [key, value] : constraint.poly.getMap()) {
+    if (key.empty()) {
+      continue;
+    }
+    if (value < 0) {
+      worst += value * bounds.find(key)->second.min;
+    } else {
+      worst += value * bounds.find(key)->second.max;
+    }
+  }
+  return (worst <= constraint.rhs);
+}
+
+RangeConstraint IntersectParallelConstraintPair(  //
+    const RangeConstraint& constraint1,           //
+    const SimpleConstraint& constraint2) {
+  // Combines two parallel constraints into one
+  IVLOG(5, "Merging the parallel constraints " << constraint1 << ", " << constraint2);
+  if (constraint1.range <= 0) {
+    throw std::runtime_error("Given constraint with empty range in IntersectParallelConstraintPair: " +
+                             to_string(constraint1));
+  }
+  return IntersectParallelConstraintPairInner(constraint1, RangeConstraint(constraint2.rhs - constraint2.poly, -1));
+}
+
+RangeConstraint IntersectParallelConstraintPair(  //
+    const RangeConstraint& constraint1,           //
+    const RangeConstraint& constraint2) {
+  // Combines two parallel constraints into one
+  IVLOG(5, "Merging the parallel constraints " << constraint1 << ", " << constraint2);
+  if (constraint1.range <= 0) {
+    throw std::runtime_error("Given constraint with empty range in IntersectParallelConstraintPair: " +
+                             to_string(constraint1));
+  }
+  if (constraint2.range <= 0) {
+    throw std::runtime_error("Given constraint with empty range in IntersectParallelConstraintPair: " +
+                             to_string(constraint2));
+  }
+  return IntersectParallelConstraintPairInner(constraint1, constraint2);
+}
+
+// TODO: Cull?
+// static RangeConstraint IntersectParallelConstraintPair(  //
+//     const SimpleConstraint& constraint1,                 //
+//     const RangeConstraint& constraint2) {
+//   // Combines two parallel constraints into one
+//   return IntersectParallelConstraintPair(constraint2, constraint1);
+// }
+
+// TODO: The Intersect...Constraint... functions should probably be moved to tile/math/polynomial.h
+
+// TODO: Need unit tests
+RangeConstraint IntersectOpposedSimpleConstraints(  //
+    const SimpleConstraint& constraint1,            //
+    const SimpleConstraint& constraint2) {
+  // Combines two SimpleConstraints which are parallel and bounding in opposite directions into
+  // a single equivalent RangeConstraint
+  Rational ratio = constraint1.poly.tryDivide(constraint2.poly, true);
+  if (ratio >= 0) {
+    throw std::invalid_argument(
+        "Parameters of IntersectOpposedSimpleConstraints must be parallel and in opposite directions");
+  }
+  // We know constraint1.poly <= constraint1.rhs and also constraint2.poly <= constraint2.rhs
+  // Could rewrite as 0 <= -constraint1.poly + constraint1.rhs and also 0 <= -constraint2.poly + constraint2.rhs
+  // Rewrite: constraint1.poly = p1 + c1 (where p1 has no constant part), constraint1.rhs = rhs1; similarly for 2
+  // So 0 <= -p1 - c1 + rhs1 and also 0 <= -p2 - c2 + rhs2
+  // and since a = ratio is negative, and p2 * a = p1, get
+  //   0 >= -a * p2 - a * c2 + a * rhs2
+  //   0 >= -p1 - a * c2 + a * rhs2
+  //   -c1 + rhs1 >= -p1 - a * c2 + a * rhs2 - c1 + rhs1
+  //   -c1 + rhs1 + a * c2 - a * rhs2 >= -p1 -c1 + rhs1
+  // So, merge into
+  //   0 <= -p1 - c1 + rhs1 <= -c1 + rhs1 + a * c2 - a * rhs2
+  // (noting that this is just for the bounds, not the integrality)
+  // And so use this to make a range constraint from constraint1 and then call to IntersectParallelConstraintPair
+  // Note that if the range is too generous the IntersectParallel call will fix it, so don't bother with a - 1
+  // This may have some duplication of work, but I think this is too tiny for that to matter for overall perf
+  auto merged_poly1 = -constraint1.poly + constraint1.rhs;
+  auto merged_const1 = -constraint1.poly.constant() + constraint1.rhs;
+  auto merged_const2 = -constraint2.poly.constant() + constraint2.rhs;
+  auto range = merged_const1 - ratio * merged_const2;
+  if (range > INT64_MAX) {
+    throw std::out_of_range("Bound range in IntersectOpposedSimpleConstraints overflows int64.");
+  }
+  int64_t r = (int64_t)range;
+  return IntersectParallelConstraintPair(RangeConstraint(merged_poly1, r), constraint2);
+}
 
 }  // namespace math
 }  // namespace tile

--- a/tile/math/polynomial.cc
+++ b/tile/math/polynomial.cc
@@ -392,16 +392,6 @@ RangeConstraint IntersectParallelConstraintPair(  //
   return IntersectParallelConstraintPairInner(constraint1, constraint2);
 }
 
-// TODO: Cull?
-// static RangeConstraint IntersectParallelConstraintPair(  //
-//     const SimpleConstraint& constraint1,                 //
-//     const RangeConstraint& constraint2) {
-//   // Combines two parallel constraints into one
-//   return IntersectParallelConstraintPair(constraint2, constraint1);
-// }
-
-// TODO: The Intersect...Constraint... functions should probably be moved to tile/math/polynomial.h
-
 // TODO: Need unit tests
 RangeConstraint IntersectOpposedSimpleConstraints(  //
     const SimpleConstraint& constraint1,            //

--- a/tile/math/polynomial.h
+++ b/tile/math/polynomial.h
@@ -104,6 +104,27 @@ inline std::string to_string(const RangeConstraint& c) {
   return "0 <= " + to_string(c.poly) + " < " + std::to_string(c.range);
 }
 
+// TODO: Verify namespace changes...
+// A range [min, max], ie min <= x <= max
+struct Bound {
+  int64_t min;  // Smallest value inclusive
+  int64_t max;  // Largest value inclusive
+};
+
+using IndexBounds = std::map<std::string, Bound>;
+
+// True iff `constraint` holds for every choice of index values satisfying `bounds`
+bool IsImplied(const SimpleConstraint& constraint, const IndexBounds& bounds);
+
+// Construct a single constraint equivalent to the intersection of the two supplied parallel constraints
+RangeConstraint IntersectParallelConstraintPair(const RangeConstraint& constraint1, const RangeConstraint& constraint2);
+RangeConstraint IntersectParallelConstraintPair(const RangeConstraint& constraint1,
+                                                const SimpleConstraint& constraint2);
+
+// Same as IntersectParallelConstraintPair; with SimpleConstraints they must be parallel & in opposite directions
+RangeConstraint IntersectOpposedSimpleConstraints(const SimpleConstraint& constraint1,
+                                                  const SimpleConstraint& constraint2);
+
 inline MAKE_LOGGABLE(RangeConstraint, c, os) {
   os << to_string(c);
   return os;
@@ -116,6 +137,11 @@ inline MAKE_LOGGABLE(SimpleConstraint, c, os) {
 
 inline MAKE_LOGGABLE(Polynomial<Rational>, c, os) {
   os << to_string(c);
+  return os;
+}
+
+inline MAKE_LOGGABLE(Bound, b, os) {
+  os << "Bound[" << b.min << ", " << b.max << "]";
   return os;
 }
 

--- a/tile/math/polynomial.h
+++ b/tile/math/polynomial.h
@@ -104,7 +104,6 @@ inline std::string to_string(const RangeConstraint& c) {
   return "0 <= " + to_string(c.poly) + " < " + std::to_string(c.range);
 }
 
-// TODO: Verify namespace changes...
 // A range [min, max], ie min <= x <= max
 struct Bound {
   int64_t min;  // Smallest value inclusive


### PR DESCRIPTION
Allow the Tile dialect to store constraints as one-sided constraints by adding mechanisms to construct two-sided constraints from pairs of opposing parallel one-sided constraints.