### PR TITLE
Use ubuntu 18.04 in bazel farm

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,13 +1,13 @@
 ---
 bazel: 1.0.0
 tasks:
-  ubuntu1604:
-    name: "PlaidML Ubuntu 16.04"
+  ubuntu1804:
+    name: PlaidML
     shell_commands:
-    - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh 
+    - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     - sh ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
     environment:
-      PATH: /var/lib/buildkite-agent/miniconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/go1.12.6.linux-amd64/bin:/opt/swift-4.2.1-RELEASE-ubuntu16.04/usr/bin
+      PATH: /var/lib/buildkite-agent/miniconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PLAIDML_DEVICE_IDS: llvm_cpu.0
       PLAIDML_DEVICE: llvm_cpu.0
       PLAIDML_TARGET: llvm_cpu
@@ -18,10 +18,10 @@ tasks:
     test_targets:
     - "..."
   macos:
-    name: "PlaidML MacOS"
+    name: PlaidML
     xcode_version: "11.2"
     shell_commands:
-    - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh 
+    - curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     - sh ./Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda
     environment:
       PATH: /Users/buildkite/miniconda/bin:/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin


### PR DESCRIPTION
Apparently some of the latest deps for some of our tests require a newer glibc++