### PR TITLE
Added type to mlir cast

### DIFF
--- a/pmlc/dialect/stripe/from_mlir.cc
+++ b/pmlc/dialect/stripe/from_mlir.cc
@@ -652,6 +652,7 @@ void StripeBuilder::visit(eltwise::CastOp castOp) {
   auto out_name = scalar_name(op);
   scalars_[result] = out_name;
   auto intr = std::make_shared<stripe::Intrinsic>();
+  intr->type = dtype;
   if (is_float(dtype)) {
     intr->name = "as_float";
   } else if (is_int(dtype)) {


### PR DESCRIPTION
Before, the generated `CPUProgram`s using `as_*` ops would have statements like
```
int d3__s = 32;
float d3___X2 = as_uint(d3___X0, d3__s);
```
Now, they read
```
int d3__s = 32;
uint32 d3___X2 = as_uint(d3___X0, d3__s);
```