### PR TITLE
Attempting to get resnet50 to run to completion

### DIFF
--- a/ci/conda/keras_backend_test.yml
+++ b/ci/conda/keras_backend_test.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - cffi
   - numpy
-  - pip
+  - pip=19
   - python=3.7
   - pip:
       - keras==2.2.4

--- a/ci/conda/ml_gpu.yml
+++ b/ci/conda/ml_gpu.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - h5py
   - numpy
-  - pip
+  - pip=19
   - python=3.6
   - scipy=1.2.1
   - pip:

--- a/ci/conda/tensorflow-dnnl.yml
+++ b/ci/conda/tensorflow-dnnl.yml
@@ -2,6 +2,6 @@ channels:
   - anaconda
   - conda-forge
 dependencies:
-  - pip
+  - pip=19
   - python=3.7
   - anaconda::tensorflow=1.14.0

--- a/ci/conda/tensorflow.yml
+++ b/ci/conda/tensorflow.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - pip
+  - pip=19
   - python=3.6
   - pip:
       - tensorflow==1.8.0; platform_system == 'Darwin'

--- a/conda/unix.yml
+++ b/conda/unix.yml
@@ -6,7 +6,7 @@ dependencies:
   - doxygen
   - jupyter
   - nbformat=4.4.0 # Latest version of nbformat breaks the analysis notebook
-  - pip
+  - pip=19
   - python=3.7.4
   - scikit-image
   - pip:

--- a/conda/windows.yml
+++ b/conda/windows.yml
@@ -5,7 +5,7 @@ dependencies:
   - jupyter
   - m2-perl
   - nbformat=4.4.0 # Latest version of nbformat breaks the analysis notebook
-  - pip
+  - pip=19
   - python=3.7.4
   - scikit-image
   - pip:

--- a/environment-windows.yml
+++ b/environment-windows.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - conda=4.6
   - numpy=1.16
-  - pip
+  - pip=19
   - posix
   - pre_commit=1.17.0
   - python=3.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - numpy=1.16.4
-  - pip
+  - pip=19
   - pre_commit=1.17.0
   - python=3.7.4
   - pyyaml=5.1.2

--- a/networks/oplib/BUILD
+++ b/networks/oplib/BUILD
@@ -1,15 +1,37 @@
 # Copyright 2018 Intel Corporation.
 
-load("//bzl:plaidml.bzl", "plaidml_cc_binary")
+load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-plaidml_cc_binary(
-    name = "resnet50",
+plaidml_cc_library(
+    name = "oplib",
     srcs = ["resnet50.cc"],
+    hdrs = ["oplib.h"],
     deps = [
         "//plaidml",
         "//pmlc/util",
-        "@com_github_google_benchmark//:benchmark_main",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+plaidml_cc_binary(
+    name = "benchmark",
+    srcs = ["benchmark.cc"],
+    deps = [
+        ":oplib",
+        "//plaidml/exec",
+        "//pmlc/util",
+        "@com_github_google_benchmark//:benchmark",
+    ],
+)
+
+plaidml_cc_binary(
+    name = "run",
+    srcs = ["run.cc"],
+    deps = [
+        ":oplib",
+        "//plaidml/exec",
+        "//pmlc/util",
     ],
 )

--- a/networks/oplib/benchmark.cc
+++ b/networks/oplib/benchmark.cc
@@ -1,0 +1,48 @@
+// Copyright 2020, Intel Corporation
+
+#include "benchmark/benchmark.h"
+
+#include "networks/oplib/oplib.h"
+#include "plaidml/exec/exec.h"
+#include "plaidml/op/op.h"
+#include "pmlc/util/logging.h"
+
+namespace networks::oplib {
+
+struct resnet50 : public benchmark::Fixture {};
+
+BENCHMARK_DEFINE_F(resnet50, compile)(benchmark::State& state) {  // NOLINT[runtime/references]
+  auto program = buildResnet50();
+  for (auto _ : state) {
+    plaidml::exec::Binder(program).compile();
+  }
+}
+
+BENCHMARK_DEFINE_F(resnet50, run)(benchmark::State& state) {  // NOLINT[runtime/references]
+  auto program = buildResnet50();
+  auto executable = plaidml::exec::Binder(program).compile();
+  for (auto _ : state) {
+    executable->run();
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_REGISTER_F(resnet50, compile)->Unit(benchmark::kMillisecond);
+
+// TODO: get HAL timer results, UseManualTime() instead of UseRealTime()
+BENCHMARK_REGISTER_F(resnet50, run)->Unit(benchmark::kMillisecond)->UseRealTime();
+
+}  // namespace networks::oplib
+
+int main(int argc, char** argv) {
+  plaidml::init();
+  plaidml::edsl::init();
+  plaidml::op::init();
+  plaidml::exec::init();
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/networks/oplib/oplib.h
+++ b/networks/oplib/oplib.h
@@ -1,0 +1,11 @@
+// Copyright 2020, Intel Corporation
+
+#pragma once
+
+#include "plaidml/edsl/edsl.h"
+
+namespace networks::oplib {
+
+plaidml::edsl::Program buildResnet50(int64_t batch_size = 1);
+
+}  // namespace networks::oplib

--- a/networks/oplib/resnet50.cc
+++ b/networks/oplib/resnet50.cc
@@ -1,103 +1,110 @@
 // Copyright 2019, Intel Corporation
 
-#include "benchmark/benchmark.h"
+#include "networks/oplib/oplib.h"
 
-#include "plaidml/exec/exec.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
 #include "plaidml/op/op.h"
 
 namespace edsl = plaidml::edsl;
-namespace exec = plaidml::exec;
 namespace op = plaidml::op;
 
 namespace networks::oplib {
 
 namespace {
 
+using llvm::ArrayRef;
+using llvm::SmallVector;
+using llvm::StringRef;
 using plaidml::DType;
 
-edsl::Tensor block(                      //
-    const edsl::Tensor& I,               //
-    const std::vector<edsl::Tensor>& W,  //
-    const std::vector<edsl::Tensor>& B,  //
-    const std::vector<int>& strides,     //
-    bool use_shortcut_conv,              //
-    const std::string& base_name) {
+edsl::Tensor block(             //
+    const edsl::Tensor& I_raw,  //
+    ArrayRef<edsl::Tensor> W,   //
+    ArrayRef<edsl::Tensor> B,   //
+    ArrayRef<int> strides,      //
+    bool use_shortcut_conv,     //
+    StringRef base_name) {
+  // Add a tracepoint for diagnostics
+  auto I = edsl::trace(I_raw, base_name);
   // Note: The branch1 weights/biases are at the _end_ of the input vectors,
   // as their existence depends on use_shortcut_conv
-  auto conv_2a = op::convolution(  //
-      I,                           // input
-      W[0],                        // weights
-      strides,                     // strides
-      {1, 1},                      // dilations
-      {1, 1},                      // data dilations
-      {},                          // filter shape (ie for transposed)
-      1,                           // # of groups
-      "valid",                     // autopadding
-      {},                          // manual padding
-      "nxc",                       // input layout
-      "xck",                       // filter layout
-      "none",                      // group layout
-      false,                       // Winograd OK?
-      base_name + "_branch2a",     // name
-      "ungrouped",                 // autogroup (ie for grouped)
-      "none",                      // deriv (ie for transposed)
+  auto conv_2a = op::convolution(     //
+      I,                              // input
+      W[0],                           // weights
+      strides,                        // strides
+      {1, 1},                         // dilations
+      {1, 1},                         // data dilations
+      {},                             // filter shape (ie for transposed)
+      1,                              // # of groups
+      "valid",                        // autopadding
+      {},                             // manual padding
+      "nxc",                          // input layout
+      "xck",                          // filter layout
+      "none",                         // group layout
+      false,                          // Winograd OK?
+      base_name.str() + "_branch2a",  // name
+      "ungrouped",                    // autogroup (ie for grouped)
+      "none",                         // deriv (ie for transposed)
       {});
   auto relu_2a = op::relu(conv_2a + B[0]);
-  auto conv_2b = op::convolution(  //
-      relu_2a,                     // input
-      W[1],                        // weights
-      {1, 1},                      // strides
-      {1, 1},                      // dilations
-      {1, 1},                      // data dilations
-      {},                          // filter shape (ie for transposed)
-      1,                           // # of groups
-      "same_upper",                // autopadding
-      {},                          // manual padding
-      "nxc",                       // input layout
-      "xck",                       // filter layout
-      "none",                      // group layout
-      false,                       // Winograd OK?
-      base_name + "_branch2b",     // name
-      "ungrouped",                 // autogroup (ie for grouped)
-      "none",                      // deriv (ie for transposed)
+  auto conv_2b = op::convolution(     //
+      relu_2a,                        // input
+      W[1],                           // weights
+      {1, 1},                         // strides
+      {1, 1},                         // dilations
+      {1, 1},                         // data dilations
+      {},                             // filter shape (ie for transposed)
+      1,                              // # of groups
+      "same_upper",                   // autopadding
+      {},                             // manual padding
+      "nxc",                          // input layout
+      "xck",                          // filter layout
+      "none",                         // group layout
+      false,                          // Winograd OK?
+      base_name.str() + "_branch2b",  // name
+      "ungrouped",                    // autogroup (ie for grouped)
+      "none",                         // deriv (ie for transposed)
       {});
   auto relu_2b = op::relu(conv_2b + B[1]);
-  auto conv_2c = op::convolution(  //
-      relu_2b,                     // input
-      W[2],                        // weights
-      {1, 1},                      // strides
-      {1, 1},                      // dilations
-      {1, 1},                      // data dilations
-      {},                          // filter shape (ie for transposed)
-      1,                           // # of groups
-      "valid",                     // autopadding
-      {},                          // manual padding
-      "nxc",                       // input layout
-      "xck",                       // filter layout
-      "none",                      // group layout
-      false,                       // Winograd OK?
-      base_name + "_branch2c",     // name
-      "ungrouped",                 // autogroup (ie for grouped)
-      "none",                      // deriv (ie for transposed)
+  auto conv_2c = op::convolution(     //
+      relu_2b,                        // input
+      W[2],                           // weights
+      {1, 1},                         // strides
+      {1, 1},                         // dilations
+      {1, 1},                         // data dilations
+      {},                             // filter shape (ie for transposed)
+      1,                              // # of groups
+      "valid",                        // autopadding
+      {},                             // manual padding
+      "nxc",                          // input layout
+      "xck",                          // filter layout
+      "none",                         // group layout
+      false,                          // Winograd OK?
+      base_name.str() + "_branch2c",  // name
+      "ungrouped",                    // autogroup (ie for grouped)
+      "none",                         // deriv (ie for transposed)
       {});
   if (use_shortcut_conv) {
-    auto conv_1 = op::convolution(  //
-        I,                          // input
-        W[3],                       // weights
-        strides,                    // strides
-        {1, 1},                     // dilations
-        {1, 1},                     // data dilations
-        {},                         // filter shape (ie for transposed)
-        1,                          // # of groups
-        "valid",                    // autopadding
-        {},                         // manual padding
-        "nxc",                      // input layout
-        "xck",                      // filter layout
-        "none",                     // group layout
-        false,                      // Winograd OK?
-        base_name + "_branch1",     // name
-        "ungrouped",                // autogroup (ie for grouped)
-        "none",                     // deriv (ie for transposed)
+    auto conv_1 = op::convolution(     //
+        I,                             // input
+        W[3],                          // weights
+        strides,                       // strides
+        {1, 1},                        // dilations
+        {1, 1},                        // data dilations
+        {},                            // filter shape (ie for transposed)
+        1,                             // # of groups
+        "valid",                       // autopadding
+        {},                            // manual padding
+        "nxc",                         // input layout
+        "xck",                         // filter layout
+        "none",                        // group layout
+        false,                         // Winograd OK?
+        base_name.str() + "_branch1",  // name
+        "ungrouped",                   // autogroup (ie for grouped)
+        "none",                        // deriv (ie for transposed)
         {});
     return op::relu(conv_2c + B[2] + conv_1 + B[3]);
   } else {
@@ -269,157 +276,121 @@ std::vector<edsl::Tensor> bias_placeholders() {
   };
 }
 
+edsl::Program build(int64_t batch_size, const edsl::Tensor& I, ArrayRef<edsl::Tensor> W, ArrayRef<edsl::Tensor> B) {
+  auto W_conv1 = W[0];
+  auto B_conv1 = B[0];
+  auto conv1 = op::convolution(  //
+      I,                         // input
+      W_conv1,                   // weights
+      {2, 2},                    // strides
+      {1, 1},                    // dilations
+      {1, 1},                    // data dilations
+      {},                        // filter shape (ie for transposed)
+      1,                         // # of groups
+      "none",                    // autopadding
+      {3, 3},                    // manual padding
+      "nxc",                     // input layout
+      "xck",                     // filter layout
+      "none",                    // group layout
+      false,                     // Winograd OK?
+      "conv1",                   // name
+      "ungrouped",               // autogroup (ie for grouped)
+      "none",                    // deriv (ie for transposed)
+      {});
+  auto relu1 = op::relu(conv1 + B_conv1);
+  auto pool1 = op::pool(  //
+      relu1,              // input
+      "max",              // pool mode
+      {3, 3},             // pool shape
+      {2, 2},             // strides
+      "none",             // autopadding
+      {1, 1},             // manual padding
+      "nxc");             // input layout
+
+  // 2
+  SmallVector<edsl::Tensor, 4> W_block2a = {W[1], W[2], W[3], W[4]};
+  SmallVector<edsl::Tensor, 4> B_block2a = {B[1], B[2], B[3], B[4]};
+  auto block_2a = block(pool1, W_block2a, B_block2a, {1, 1}, true, "res2a");
+
+  SmallVector<edsl::Tensor, 3> W_block2b = {W[5], W[6], W[7]};
+  SmallVector<edsl::Tensor, 3> B_block2b = {B[5], B[6], B[7]};
+  auto block_2b = block(block_2a, W_block2b, B_block2b, {1, 1}, false, "res2b");
+
+  SmallVector<edsl::Tensor, 3> W_block2c = {W[8], W[9], W[10]};
+  SmallVector<edsl::Tensor, 3> B_block2c = {B[8], B[9], B[10]};
+  auto block_2c = block(block_2b, W_block2c, B_block2c, {1, 1}, false, "res2c");
+
+  // 3
+  SmallVector<edsl::Tensor, 4> W_block3a = {W[11], W[12], W[13], W[14]};
+  SmallVector<edsl::Tensor, 4> B_block3a = {B[11], B[12], B[13], B[14]};
+  auto block_3a = block(block_2c, W_block3a, B_block3a, {2, 2}, true, "res3a");
+
+  SmallVector<edsl::Tensor, 3> W_block3b = {W[15], W[16], W[17]};
+  SmallVector<edsl::Tensor, 3> B_block3b = {B[15], B[16], B[17]};
+  auto block_3b = block(block_3a, W_block3b, B_block3b, {1, 1}, false, "res3b");
+
+  SmallVector<edsl::Tensor, 3> W_block3c = {W[18], W[19], W[20]};
+  SmallVector<edsl::Tensor, 3> B_block3c = {B[18], B[19], B[20]};
+  auto block_3c = block(block_3b, W_block3c, B_block3c, {1, 1}, false, "res3c");
+
+  SmallVector<edsl::Tensor, 3> W_block3d = {W[21], W[22], W[23]};
+  SmallVector<edsl::Tensor, 3> B_block3d = {B[21], B[22], B[23]};
+  auto block_3d = block(block_3c, W_block3d, B_block3d, {1, 1}, false, "res3d");
+
+  // 4
+  SmallVector<edsl::Tensor, 4> W_block4a = {W[24], W[25], W[26], W[27]};
+  SmallVector<edsl::Tensor, 4> B_block4a = {B[24], B[25], B[26], B[27]};
+  auto block_4a = block(block_3d, W_block4a, B_block4a, {2, 2}, true, "res4a");
+
+  SmallVector<edsl::Tensor, 3> W_block4b = {W[28], W[29], W[30]};
+  SmallVector<edsl::Tensor, 3> B_block4b = {B[28], B[29], B[30]};
+  auto block_4b = block(block_4a, W_block4b, B_block4b, {1, 1}, false, "res4b");
+
+  SmallVector<edsl::Tensor, 3> W_block4c = {W[31], W[32], W[33]};
+  SmallVector<edsl::Tensor, 3> B_block4c = {B[31], B[32], B[33]};
+  auto block_4c = block(block_4b, W_block4c, B_block4c, {1, 1}, false, "res4c");
+
+  SmallVector<edsl::Tensor, 3> W_block4d = {W[34], W[35], W[36]};
+  SmallVector<edsl::Tensor, 3> B_block4d = {B[34], B[35], B[36]};
+  auto block_4d = block(block_4c, W_block4d, B_block4d, {1, 1}, false, "res4d");
+
+  SmallVector<edsl::Tensor, 3> W_block4e = {W[37], W[38], W[39]};
+  SmallVector<edsl::Tensor, 3> B_block4e = {B[37], B[38], B[39]};
+  auto block_4e = block(block_4d, W_block4e, B_block4e, {1, 1}, false, "res4e");
+
+  SmallVector<edsl::Tensor, 3> W_block4f = {W[40], W[41], W[42]};
+  SmallVector<edsl::Tensor, 3> B_block4f = {B[40], B[41], B[42]};
+  auto block_4f = block(block_4e, W_block4f, B_block4f, {1, 1}, false, "res4f");
+
+  // 5
+  SmallVector<edsl::Tensor, 4> W_block5a = {W[43], W[44], W[45], W[46]};
+  SmallVector<edsl::Tensor, 4> B_block5a = {B[43], B[44], B[45], B[46]};
+  auto block_5a = block(block_4f, W_block5a, B_block5a, {2, 2}, true, "res5a");
+
+  SmallVector<edsl::Tensor, 3> W_block5b = {W[47], W[48], W[49]};
+  SmallVector<edsl::Tensor, 3> B_block5b = {B[47], B[48], B[49]};
+  auto block_5b = block(block_5a, W_block5b, B_block5b, {1, 1}, false, "res5b");
+
+  SmallVector<edsl::Tensor, 3> W_block5c = {W[50], W[51], W[52]};
+  SmallVector<edsl::Tensor, 3> B_block5c = {B[50], B[51], B[52]};
+  auto block_5c = block(block_5b, W_block5c, B_block5c, {1, 1}, false, "res5c");
+
+  // End
+  auto global_mean = op::mean(block_5c, edsl::make_tuple<int64_t>({1, 2}));
+  auto W_dense = W[53];
+  auto B_dense = B[53];
+  auto dense = op::dot(global_mean, W_dense) + B_dense;
+  auto softmax = op::softmax(dense, 1);
+  return edsl::Program("resnet50", {softmax});
+}
+
 }  // namespace
 
-struct resnet50 : public benchmark::Fixture {
-  void SetUp(const benchmark::State& state) {  //
-    plaidml::op::init();
-  }
-
-  edsl::Program build(                     //
-      int64_t batch_size,                  //
-      const edsl::Tensor& I,               //
-      const std::vector<edsl::Tensor>& W,  //
-      const std::vector<edsl::Tensor>& B) {
-    auto W_conv1 = W[0];
-    auto B_conv1 = B[0];
-    auto conv1 = op::convolution(  //
-        I,                         // input
-        W_conv1,                   // weights
-        {2, 2},                    // strides
-        {1, 1},                    // dilations
-        {1, 1},                    // data dilations
-        {},                        // filter shape (ie for transposed)
-        1,                         // # of groups
-        "none",                    // autopadding
-        {3, 3},                    // manual padding
-        "nxc",                     // input layout
-        "xck",                     // filter layout
-        "none",                    // group layout
-        false,                     // Winograd OK?
-        "conv1",                   // name
-        "ungrouped",               // autogroup (ie for grouped)
-        "none",                    // deriv (ie for transposed)
-        {});
-    auto relu1 = op::relu(conv1 + B_conv1);
-    auto pool1 = op::pool(  //
-        relu1,              // input
-        "max",              // pool mode
-        {3, 3},             // pool shape
-        {2, 2},             // strides
-        "none",             // autopadding
-        {1, 1},             // manual padding
-        "nxc");             // input layout
-
-    // 2
-    std::vector<edsl::Tensor> W_block2a = {W[1], W[2], W[3], W[4]};
-    std::vector<edsl::Tensor> B_block2a = {B[1], B[2], B[3], B[4]};
-    auto block_2a = block(pool1, W_block2a, B_block2a, {1, 1}, true, "res2a");
-
-    std::vector<edsl::Tensor> W_block2b = {W[5], W[6], W[7]};
-    std::vector<edsl::Tensor> B_block2b = {B[5], B[6], B[7]};
-    auto block_2b = block(block_2a, W_block2b, B_block2b, {1, 1}, false, "res2b");
-
-    std::vector<edsl::Tensor> W_block2c = {W[8], W[9], W[10]};
-    std::vector<edsl::Tensor> B_block2c = {B[8], B[9], B[10]};
-    auto block_2c = block(block_2b, W_block2c, B_block2c, {1, 1}, false, "res2c");
-
-    // 3
-    std::vector<edsl::Tensor> W_block3a = {W[11], W[12], W[13], W[14]};
-    std::vector<edsl::Tensor> B_block3a = {B[11], B[12], B[13], B[14]};
-    auto block_3a = block(block_2c, W_block3a, B_block3a, {2, 2}, true, "res3a");
-
-    std::vector<edsl::Tensor> W_block3b = {W[15], W[16], W[17]};
-    std::vector<edsl::Tensor> B_block3b = {B[15], B[16], B[17]};
-    auto block_3b = block(block_3a, W_block3b, B_block3b, {1, 1}, false, "res3b");
-
-    std::vector<edsl::Tensor> W_block3c = {W[18], W[19], W[20]};
-    std::vector<edsl::Tensor> B_block3c = {B[18], B[19], B[20]};
-    auto block_3c = block(block_3b, W_block3c, B_block3c, {1, 1}, false, "res3c");
-
-    std::vector<edsl::Tensor> W_block3d = {W[21], W[22], W[23]};
-    std::vector<edsl::Tensor> B_block3d = {B[21], B[22], B[23]};
-    auto block_3d = block(block_3c, W_block3d, B_block3d, {1, 1}, false, "res3d");
-
-    // 4
-    std::vector<edsl::Tensor> W_block4a = {W[24], W[25], W[26], W[27]};
-    std::vector<edsl::Tensor> B_block4a = {B[24], B[25], B[26], B[27]};
-    auto block_4a = block(block_3d, W_block4a, B_block4a, {2, 2}, true, "res4a");
-
-    std::vector<edsl::Tensor> W_block4b = {W[28], W[29], W[30]};
-    std::vector<edsl::Tensor> B_block4b = {B[28], B[29], B[30]};
-    auto block_4b = block(block_4a, W_block4b, B_block4b, {1, 1}, false, "res4b");
-
-    std::vector<edsl::Tensor> W_block4c = {W[31], W[32], W[33]};
-    std::vector<edsl::Tensor> B_block4c = {B[31], B[32], B[33]};
-    auto block_4c = block(block_4b, W_block4c, B_block4c, {1, 1}, false, "res4c");
-
-    std::vector<edsl::Tensor> W_block4d = {W[34], W[35], W[36]};
-    std::vector<edsl::Tensor> B_block4d = {B[34], B[35], B[36]};
-    auto block_4d = block(block_4c, W_block4d, B_block4d, {1, 1}, false, "res4d");
-
-    std::vector<edsl::Tensor> W_block4e = {W[37], W[38], W[39]};
-    std::vector<edsl::Tensor> B_block4e = {B[37], B[38], B[39]};
-    auto block_4e = block(block_4d, W_block4e, B_block4e, {1, 1}, false, "res4e");
-
-    std::vector<edsl::Tensor> W_block4f = {W[40], W[41], W[42]};
-    std::vector<edsl::Tensor> B_block4f = {B[40], B[41], B[42]};
-    auto block_4f = block(block_4e, W_block4f, B_block4f, {1, 1}, false, "res4f");
-
-    // 5
-    std::vector<edsl::Tensor> W_block5a = {W[43], W[44], W[45], W[46]};
-    std::vector<edsl::Tensor> B_block5a = {B[43], B[44], B[45], B[46]};
-    auto block_5a = block(block_4f, W_block5a, B_block5a, {2, 2}, true, "res5a");
-
-    std::vector<edsl::Tensor> W_block5b = {W[47], W[48], W[49]};
-    std::vector<edsl::Tensor> B_block5b = {B[47], B[48], B[49]};
-    auto block_5b = block(block_5a, W_block5b, B_block5b, {1, 1}, false, "res5b");
-
-    std::vector<edsl::Tensor> W_block5c = {W[50], W[51], W[52]};
-    std::vector<edsl::Tensor> B_block5c = {B[50], B[51], B[52]};
-    auto block_5c = block(block_5b, W_block5c, B_block5c, {1, 1}, false, "res5c");
-
-    // End
-    auto global_mean = op::mean(block_5c, edsl::make_tuple<int64_t>({1, 2}));
-    auto W_dense = W[53];
-    auto B_dense = B[53];
-    auto dense = op::dot(global_mean, W_dense) + B_dense;
-    auto softmax = op::softmax(dense, 1);
-    return edsl::Program("resnet50", {softmax});
-  }
-
-  auto compile(int64_t batch_size = 1) {
-    auto I = edsl::Placeholder(DType::FLOAT32, {batch_size, 224, 224, 3});
-    auto W = weight_placeholders();
-    auto B = bias_placeholders();
-    auto program = build(batch_size, I, W, B);
-    return exec::Binder(program).compile();
-  }
-};
-
-BENCHMARK_DEFINE_F(resnet50, build)(benchmark::State& state) {  // NOLINT[runtime/references]
-  compile()->run();
+edsl::Program buildResnet50(int64_t batch_size) {
+  auto I = edsl::Placeholder(DType::FLOAT32, {batch_size, 224, 224, 3});
+  auto W = weight_placeholders();
+  auto B = bias_placeholders();
+  return build(batch_size, I, W, B);
 }
-
-BENCHMARK_DEFINE_F(resnet50, compile)(benchmark::State& state) {  // NOLINT[runtime/references]
-  for (auto _ : state) {
-    compile();
-  }
-}
-
-BENCHMARK_DEFINE_F(resnet50, run)(benchmark::State& state) {  // NOLINT[runtime/references]
-  auto executable = compile();
-  for (auto _ : state) {
-    executable->run();
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-
-BENCHMARK_REGISTER_F(resnet50, build)->Unit(benchmark::kMillisecond)->Iterations(1);
-
-BENCHMARK_REGISTER_F(resnet50, compile)->Unit(benchmark::kMillisecond);
-
-// TODO: get HAL timer results, UseManualTime() instead of UseRealTime()
-BENCHMARK_REGISTER_F(resnet50, run)->Unit(benchmark::kMillisecond)->UseRealTime();
 
 }  // namespace networks::oplib

--- a/networks/oplib/resnet50.mlir
+++ b/networks/oplib/resnet50.mlir
@@ -20,239 +20,255 @@
 !f32 = type tensor<!eltwise.f32>
 module {
   func @resnet50(%arg0: tensor<1000x!eltwise.f32>, %arg1: tensor<2048x1000x!eltwise.f32>, %arg2: tensor<2048x!eltwise.f32>, %arg3: tensor<1x1x1024x2048x!eltwise.f32>, %arg4: tensor<1024x!eltwise.f32>, %arg5: tensor<1x1x512x1024x!eltwise.f32>, %arg6: tensor<512x!eltwise.f32>, %arg7: tensor<1x1x256x512x!eltwise.f32>, %arg8: tensor<256x!eltwise.f32>, %arg9: tensor<1x1x64x256x!eltwise.f32>, %arg10: tensor<64x!eltwise.f32>, %arg11: tensor<7x7x3x64x!eltwise.f32>, %arg12: tensor<1x224x224x3x!eltwise.f32>, %arg13: tensor<256x!eltwise.f32>, %arg14: tensor<1x1x64x256x!eltwise.f32>, %arg15: tensor<64x!eltwise.f32>, %arg16: tensor<3x3x64x64x!eltwise.f32>, %arg17: tensor<64x!eltwise.f32>, %arg18: tensor<1x1x64x64x!eltwise.f32>, %arg19: tensor<256x!eltwise.f32>, %arg20: tensor<1x1x64x256x!eltwise.f32>, %arg21: tensor<64x!eltwise.f32>, %arg22: tensor<3x3x64x64x!eltwise.f32>, %arg23: tensor<64x!eltwise.f32>, %arg24: tensor<1x1x256x64x!eltwise.f32>, %arg25: tensor<256x!eltwise.f32>, %arg26: tensor<1x1x64x256x!eltwise.f32>, %arg27: tensor<64x!eltwise.f32>, %arg28: tensor<3x3x64x64x!eltwise.f32>, %arg29: tensor<64x!eltwise.f32>, %arg30: tensor<1x1x256x64x!eltwise.f32>, %arg31: tensor<512x!eltwise.f32>, %arg32: tensor<1x1x128x512x!eltwise.f32>, %arg33: tensor<128x!eltwise.f32>, %arg34: tensor<3x3x128x128x!eltwise.f32>, %arg35: tensor<128x!eltwise.f32>, %arg36: tensor<1x1x256x128x!eltwise.f32>, %arg37: tensor<512x!eltwise.f32>, %arg38: tensor<1x1x128x512x!eltwise.f32>, %arg39: tensor<128x!eltwise.f32>, %arg40: tensor<3x3x128x128x!eltwise.f32>, %arg41: tensor<128x!eltwise.f32>, %arg42: tensor<1x1x512x128x!eltwise.f32>, %arg43: tensor<512x!eltwise.f32>, %arg44: tensor<1x1x128x512x!eltwise.f32>, %arg45: tensor<128x!eltwise.f32>, %arg46: tensor<3x3x128x128x!eltwise.f32>, %arg47: tensor<128x!eltwise.f32>, %arg48: tensor<1x1x512x128x!eltwise.f32>, %arg49: tensor<512x!eltwise.f32>, %arg50: tensor<1x1x128x512x!eltwise.f32>, %arg51: tensor<128x!eltwise.f32>, %arg52: tensor<3x3x128x128x!eltwise.f32>, %arg53: tensor<128x!eltwise.f32>, %arg54: tensor<1x1x512x128x!eltwise.f32>, %arg55: tensor<1024x!eltwise.f32>, %arg56: tensor<1x1x256x1024x!eltwise.f32>, %arg57: tensor<256x!eltwise.f32>, %arg58: tensor<3x3x256x256x!eltwise.f32>, %arg59: tensor<256x!eltwise.f32>, %arg60: tensor<1x1x512x256x!eltwise.f32>, %arg61: tensor<1024x!eltwise.f32>, %arg62: tensor<1x1x256x1024x!eltwise.f32>, %arg63: tensor<256x!eltwise.f32>, %arg64: tensor<3x3x256x256x!eltwise.f32>, %arg65: tensor<256x!eltwise.f32>, %arg66: tensor<1x1x1024x256x!eltwise.f32>, %arg67: tensor<1024x!eltwise.f32>, %arg68: tensor<1x1x256x1024x!eltwise.f32>, %arg69: tensor<256x!eltwise.f32>, %arg70: tensor<3x3x256x256x!eltwise.f32>, %arg71: tensor<256x!eltwise.f32>, %arg72: tensor<1x1x1024x256x!eltwise.f32>, %arg73: tensor<1024x!eltwise.f32>, %arg74: tensor<1x1x256x1024x!eltwise.f32>, %arg75: tensor<256x!eltwise.f32>, %arg76: tensor<3x3x256x256x!eltwise.f32>, %arg77: tensor<256x!eltwise.f32>, %arg78: tensor<1x1x1024x256x!eltwise.f32>, %arg79: tensor<1024x!eltwise.f32>, %arg80: tensor<1x1x256x1024x!eltwise.f32>, %arg81: tensor<256x!eltwise.f32>, %arg82: tensor<3x3x256x256x!eltwise.f32>, %arg83: tensor<256x!eltwise.f32>, %arg84: tensor<1x1x1024x256x!eltwise.f32>, %arg85: tensor<1024x!eltwise.f32>, %arg86: tensor<1x1x256x1024x!eltwise.f32>, %arg87: tensor<256x!eltwise.f32>, %arg88: tensor<3x3x256x256x!eltwise.f32>, %arg89: tensor<256x!eltwise.f32>, %arg90: tensor<1x1x1024x256x!eltwise.f32>, %arg91: tensor<2048x!eltwise.f32>, %arg92: tensor<1x1x512x2048x!eltwise.f32>, %arg93: tensor<512x!eltwise.f32>, %arg94: tensor<3x3x512x512x!eltwise.f32>, %arg95: tensor<512x!eltwise.f32>, %arg96: tensor<1x1x1024x512x!eltwise.f32>, %arg97: tensor<2048x!eltwise.f32>, %arg98: tensor<1x1x512x2048x!eltwise.f32>, %arg99: tensor<512x!eltwise.f32>, %arg100: tensor<3x3x512x512x!eltwise.f32>, %arg101: tensor<512x!eltwise.f32>, %arg102: tensor<1x1x2048x512x!eltwise.f32>, %arg103: tensor<2048x!eltwise.f32>, %arg104: tensor<1x1x512x2048x!eltwise.f32>, %arg105: tensor<512x!eltwise.f32>, %arg106: tensor<3x3x512x512x!eltwise.f32>, %arg107: tensor<512x!eltwise.f32>, %arg108: tensor<1x1x2048x512x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32> {
-    %c49 = "eltwise.sconst"() {value = 49 : index} : () -> !i32
+    %c49 = "eltwise.sconst"() {value = 49 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
     %conv1 = tile.cion add, mul, %cst, %arg12, %arg11 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x!eltwise.f32>, tensor<7x7x3x64x!eltwise.f32> -> tensor<1x112x112x64x!eltwise.f32>
     %0 = "eltwise.add"(%conv1, %arg10) : (tensor<1x112x112x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
     %1 = "eltwise.cmp_lt"(%0, %cst) : (tensor<1x112x112x64x!eltwise.f32>, !f32) -> tensor<1x112x112x64x!eltwise.u1>
     %2 = "eltwise.select"(%1, %cst, %0) : (tensor<1x112x112x64x!eltwise.u1>, !f32, tensor<1x112x112x64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
     %3 = tile.cion max, none, %cst, %2 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x112x112x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch1 = tile.cion add, mul, %cst, %3, %arg9 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
-    %res2a_branch2a = tile.cion add, mul, %cst, %3, %arg18 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %4 = "eltwise.add"(%res2a_branch2a, %arg17) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %5 = "eltwise.cmp_lt"(%4, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
-    %6 = "eltwise.select"(%5, %cst, %4) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch2b = tile.cion add, mul, %cst, %6, %arg16 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %7 = "eltwise.add"(%res2a_branch2b, %arg15) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %8 = "eltwise.cmp_lt"(%7, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
-    %9 = "eltwise.select"(%8, %cst, %7) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch2c = tile.cion add, mul, %cst, %9, %arg14 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
-    %10 = "eltwise.add"(%res2a_branch2c, %arg13) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %11 = "eltwise.add"(%10, %res2a_branch1) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %12 = "eltwise.add"(%11, %arg8) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %13 = "eltwise.cmp_lt"(%12, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
-    %14 = "eltwise.select"(%13, %cst, %12) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res2b_branch2a = tile.cion add, mul, %cst, %14, %arg24 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %15 = "eltwise.add"(%res2b_branch2a, %arg23) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %16 = "eltwise.cmp_lt"(%15, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
-    %17 = "eltwise.select"(%16, %cst, %15) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2b_branch2b = tile.cion add, mul, %cst, %17, %arg22 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %18 = "eltwise.add"(%res2b_branch2b, %arg21) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %19 = "eltwise.cmp_lt"(%18, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
-    %20 = "eltwise.select"(%19, %cst, %18) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2b_branch2c = tile.cion add, mul, %cst, %20, %arg20 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
-    %21 = "eltwise.add"(%res2b_branch2c, %arg19) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %22 = "eltwise.add"(%21, %14) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %23 = "eltwise.cmp_lt"(%22, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
-    %24 = "eltwise.select"(%23, %cst, %22) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res2c_branch2a = tile.cion add, mul, %cst, %24, %arg30 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %25 = "eltwise.add"(%res2c_branch2a, %arg29) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %26 = "eltwise.cmp_lt"(%25, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
-    %27 = "eltwise.select"(%26, %cst, %25) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2c_branch2b = tile.cion add, mul, %cst, %27, %arg28 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
-    %28 = "eltwise.add"(%res2c_branch2b, %arg27) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %4 = "tile.trace"(%3) {msg = "res2a"} : (tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch1 = tile.cion add, mul, %cst, %4, %arg9 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2a_branch2a = tile.cion add, mul, %cst, %4, %arg18 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %5 = "eltwise.add"(%res2a_branch2a, %arg17) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %6 = "eltwise.cmp_lt"(%5, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %7 = "eltwise.select"(%6, %cst, %5) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch2b = tile.cion add, mul, %cst, %7, %arg16 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %8 = "eltwise.add"(%res2a_branch2b, %arg15) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %9 = "eltwise.cmp_lt"(%8, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %10 = "eltwise.select"(%9, %cst, %8) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch2c = tile.cion add, mul, %cst, %10, %arg14 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %11 = "eltwise.add"(%res2a_branch2c, %arg13) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %12 = "eltwise.add"(%11, %res2a_branch1) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %13 = "eltwise.add"(%12, %arg8) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %14 = "eltwise.cmp_lt"(%13, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %15 = "eltwise.select"(%14, %cst, %13) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %16 = "tile.trace"(%15) {msg = "res2b"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res2b_branch2a = tile.cion add, mul, %cst, %16, %arg24 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %17 = "eltwise.add"(%res2b_branch2a, %arg23) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %18 = "eltwise.cmp_lt"(%17, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %19 = "eltwise.select"(%18, %cst, %17) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2b = tile.cion add, mul, %cst, %19, %arg22 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %20 = "eltwise.add"(%res2b_branch2b, %arg21) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %21 = "eltwise.cmp_lt"(%20, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %22 = "eltwise.select"(%21, %cst, %20) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2c = tile.cion add, mul, %cst, %22, %arg20 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %23 = "eltwise.add"(%res2b_branch2c, %arg19) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %24 = "eltwise.add"(%23, %16) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %25 = "eltwise.cmp_lt"(%24, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %26 = "eltwise.select"(%25, %cst, %24) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %27 = "tile.trace"(%26) {msg = "res2c"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res2c_branch2a = tile.cion add, mul, %cst, %27, %arg30 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %28 = "eltwise.add"(%res2c_branch2a, %arg29) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %29 = "eltwise.cmp_lt"(%28, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %30 = "eltwise.select"(%29, %cst, %28) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2c_branch2c = tile.cion add, mul, %cst, %30, %arg26 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
-    %31 = "eltwise.add"(%res2c_branch2c, %arg25) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %32 = "eltwise.add"(%31, %24) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %33 = "eltwise.cmp_lt"(%32, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
-    %34 = "eltwise.select"(%33, %cst, %32) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res3a_branch1 = tile.cion add, mul, %cst, %34, %arg7 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %res3a_branch2a = tile.cion add, mul, %cst, %34, %arg36 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %35 = "eltwise.add"(%res3a_branch2a, %arg35) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %36 = "eltwise.cmp_lt"(%35, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %37 = "eltwise.select"(%36, %cst, %35) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3a_branch2b = tile.cion add, mul, %cst, %37, %arg34 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %38 = "eltwise.add"(%res3a_branch2b, %arg33) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %39 = "eltwise.cmp_lt"(%38, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %40 = "eltwise.select"(%39, %cst, %38) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3a_branch2c = tile.cion add, mul, %cst, %40, %arg32 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %41 = "eltwise.add"(%res3a_branch2c, %arg31) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %42 = "eltwise.add"(%41, %res3a_branch1) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %43 = "eltwise.add"(%42, %arg6) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %44 = "eltwise.cmp_lt"(%43, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
-    %45 = "eltwise.select"(%44, %cst, %43) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3b_branch2a = tile.cion add, mul, %cst, %45, %arg42 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %46 = "eltwise.add"(%res3b_branch2a, %arg41) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %47 = "eltwise.cmp_lt"(%46, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %48 = "eltwise.select"(%47, %cst, %46) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3b_branch2b = tile.cion add, mul, %cst, %48, %arg40 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %49 = "eltwise.add"(%res3b_branch2b, %arg39) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %50 = "eltwise.cmp_lt"(%49, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %51 = "eltwise.select"(%50, %cst, %49) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3b_branch2c = tile.cion add, mul, %cst, %51, %arg38 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %52 = "eltwise.add"(%res3b_branch2c, %arg37) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %53 = "eltwise.add"(%52, %45) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %54 = "eltwise.cmp_lt"(%53, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
-    %55 = "eltwise.select"(%54, %cst, %53) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3c_branch2a = tile.cion add, mul, %cst, %55, %arg48 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %56 = "eltwise.add"(%res3c_branch2a, %arg47) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %57 = "eltwise.cmp_lt"(%56, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %58 = "eltwise.select"(%57, %cst, %56) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3c_branch2b = tile.cion add, mul, %cst, %58, %arg46 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %59 = "eltwise.add"(%res3c_branch2b, %arg45) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %60 = "eltwise.cmp_lt"(%59, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %61 = "eltwise.select"(%60, %cst, %59) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3c_branch2c = tile.cion add, mul, %cst, %61, %arg44 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %62 = "eltwise.add"(%res3c_branch2c, %arg43) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %63 = "eltwise.add"(%62, %55) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %64 = "eltwise.cmp_lt"(%63, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
-    %65 = "eltwise.select"(%64, %cst, %63) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3d_branch2a = tile.cion add, mul, %cst, %65, %arg54 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %66 = "eltwise.add"(%res3d_branch2a, %arg53) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %67 = "eltwise.cmp_lt"(%66, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %68 = "eltwise.select"(%67, %cst, %66) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3d_branch2b = tile.cion add, mul, %cst, %68, %arg52 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
-    %69 = "eltwise.add"(%res3d_branch2b, %arg51) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %70 = "eltwise.cmp_lt"(%69, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
-    %71 = "eltwise.select"(%70, %cst, %69) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3d_branch2c = tile.cion add, mul, %cst, %71, %arg50 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %72 = "eltwise.add"(%res3d_branch2c, %arg49) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %73 = "eltwise.add"(%72, %65) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %74 = "eltwise.cmp_lt"(%73, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
-    %75 = "eltwise.select"(%74, %cst, %73) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res4a_branch1 = tile.cion add, mul, %cst, %75, %arg5 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4a_branch2a = tile.cion add, mul, %cst, %75, %arg60 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %76 = "eltwise.add"(%res4a_branch2a, %arg59) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %77 = "eltwise.cmp_lt"(%76, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %78 = "eltwise.select"(%77, %cst, %76) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4a_branch2b = tile.cion add, mul, %cst, %78, %arg58 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %79 = "eltwise.add"(%res4a_branch2b, %arg57) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %80 = "eltwise.cmp_lt"(%79, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %81 = "eltwise.select"(%80, %cst, %79) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4a_branch2c = tile.cion add, mul, %cst, %81, %arg56 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %82 = "eltwise.add"(%res4a_branch2c, %arg55) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %83 = "eltwise.add"(%82, %res4a_branch1) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %84 = "eltwise.add"(%83, %arg4) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %85 = "eltwise.cmp_lt"(%84, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
-    %86 = "eltwise.select"(%85, %cst, %84) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4b_branch2a = tile.cion add, mul, %cst, %86, %arg66 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %87 = "eltwise.add"(%res4b_branch2a, %arg65) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res2c_branch2b = tile.cion add, mul, %cst, %30, %arg28 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %31 = "eltwise.add"(%res2c_branch2b, %arg27) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %32 = "eltwise.cmp_lt"(%31, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %33 = "eltwise.select"(%32, %cst, %31) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2c_branch2c = tile.cion add, mul, %cst, %33, %arg26 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %34 = "eltwise.add"(%res2c_branch2c, %arg25) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %35 = "eltwise.add"(%34, %27) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %36 = "eltwise.cmp_lt"(%35, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %37 = "eltwise.select"(%36, %cst, %35) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %38 = "tile.trace"(%37) {msg = "res3a"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res3a_branch1 = tile.cion add, mul, %cst, %38, %arg7 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3a_branch2a = tile.cion add, mul, %cst, %38, %arg36 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %39 = "eltwise.add"(%res3a_branch2a, %arg35) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %40 = "eltwise.cmp_lt"(%39, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %41 = "eltwise.select"(%40, %cst, %39) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch2b = tile.cion add, mul, %cst, %41, %arg34 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %42 = "eltwise.add"(%res3a_branch2b, %arg33) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %43 = "eltwise.cmp_lt"(%42, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %44 = "eltwise.select"(%43, %cst, %42) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch2c = tile.cion add, mul, %cst, %44, %arg32 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %45 = "eltwise.add"(%res3a_branch2c, %arg31) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %46 = "eltwise.add"(%45, %res3a_branch1) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %47 = "eltwise.add"(%46, %arg6) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %48 = "eltwise.cmp_lt"(%47, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %49 = "eltwise.select"(%48, %cst, %47) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %50 = "tile.trace"(%49) {msg = "res3b"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3b_branch2a = tile.cion add, mul, %cst, %50, %arg42 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %51 = "eltwise.add"(%res3b_branch2a, %arg41) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %52 = "eltwise.cmp_lt"(%51, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %53 = "eltwise.select"(%52, %cst, %51) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2b = tile.cion add, mul, %cst, %53, %arg40 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %54 = "eltwise.add"(%res3b_branch2b, %arg39) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %55 = "eltwise.cmp_lt"(%54, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %56 = "eltwise.select"(%55, %cst, %54) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2c = tile.cion add, mul, %cst, %56, %arg38 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %57 = "eltwise.add"(%res3b_branch2c, %arg37) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %58 = "eltwise.add"(%57, %50) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %59 = "eltwise.cmp_lt"(%58, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %60 = "eltwise.select"(%59, %cst, %58) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %61 = "tile.trace"(%60) {msg = "res3c"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3c_branch2a = tile.cion add, mul, %cst, %61, %arg48 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %62 = "eltwise.add"(%res3c_branch2a, %arg47) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %63 = "eltwise.cmp_lt"(%62, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %64 = "eltwise.select"(%63, %cst, %62) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2b = tile.cion add, mul, %cst, %64, %arg46 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %65 = "eltwise.add"(%res3c_branch2b, %arg45) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %66 = "eltwise.cmp_lt"(%65, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %67 = "eltwise.select"(%66, %cst, %65) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2c = tile.cion add, mul, %cst, %67, %arg44 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %68 = "eltwise.add"(%res3c_branch2c, %arg43) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %69 = "eltwise.add"(%68, %61) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %70 = "eltwise.cmp_lt"(%69, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %71 = "eltwise.select"(%70, %cst, %69) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %72 = "tile.trace"(%71) {msg = "res3d"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3d_branch2a = tile.cion add, mul, %cst, %72, %arg54 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %73 = "eltwise.add"(%res3d_branch2a, %arg53) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %74 = "eltwise.cmp_lt"(%73, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %75 = "eltwise.select"(%74, %cst, %73) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2b = tile.cion add, mul, %cst, %75, %arg52 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %76 = "eltwise.add"(%res3d_branch2b, %arg51) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %77 = "eltwise.cmp_lt"(%76, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %78 = "eltwise.select"(%77, %cst, %76) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2c = tile.cion add, mul, %cst, %78, %arg50 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %79 = "eltwise.add"(%res3d_branch2c, %arg49) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %80 = "eltwise.add"(%79, %72) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %81 = "eltwise.cmp_lt"(%80, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %82 = "eltwise.select"(%81, %cst, %80) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %83 = "tile.trace"(%82) {msg = "res4a"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res4a_branch1 = tile.cion add, mul, %cst, %83, %arg5 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4a_branch2a = tile.cion add, mul, %cst, %83, %arg60 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %84 = "eltwise.add"(%res4a_branch2a, %arg59) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %85 = "eltwise.cmp_lt"(%84, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %86 = "eltwise.select"(%85, %cst, %84) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch2b = tile.cion add, mul, %cst, %86, %arg58 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %87 = "eltwise.add"(%res4a_branch2b, %arg57) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %88 = "eltwise.cmp_lt"(%87, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %89 = "eltwise.select"(%88, %cst, %87) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4b_branch2b = tile.cion add, mul, %cst, %89, %arg64 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %90 = "eltwise.add"(%res4b_branch2b, %arg63) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %91 = "eltwise.cmp_lt"(%90, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %92 = "eltwise.select"(%91, %cst, %90) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4b_branch2c = tile.cion add, mul, %cst, %92, %arg62 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %93 = "eltwise.add"(%res4b_branch2c, %arg61) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %94 = "eltwise.add"(%93, %86) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %95 = "eltwise.cmp_lt"(%94, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
-    %96 = "eltwise.select"(%95, %cst, %94) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4c_branch2a = tile.cion add, mul, %cst, %96, %arg72 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %97 = "eltwise.add"(%res4c_branch2a, %arg71) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %98 = "eltwise.cmp_lt"(%97, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %99 = "eltwise.select"(%98, %cst, %97) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4c_branch2b = tile.cion add, mul, %cst, %99, %arg70 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %100 = "eltwise.add"(%res4c_branch2b, %arg69) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %101 = "eltwise.cmp_lt"(%100, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %102 = "eltwise.select"(%101, %cst, %100) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4c_branch2c = tile.cion add, mul, %cst, %102, %arg68 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %103 = "eltwise.add"(%res4c_branch2c, %arg67) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %104 = "eltwise.add"(%103, %96) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %105 = "eltwise.cmp_lt"(%104, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
-    %106 = "eltwise.select"(%105, %cst, %104) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4d_branch2a = tile.cion add, mul, %cst, %106, %arg78 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %107 = "eltwise.add"(%res4d_branch2a, %arg77) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch2c = tile.cion add, mul, %cst, %89, %arg56 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %90 = "eltwise.add"(%res4a_branch2c, %arg55) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %91 = "eltwise.add"(%90, %res4a_branch1) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %92 = "eltwise.add"(%91, %arg4) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %93 = "eltwise.cmp_lt"(%92, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %94 = "eltwise.select"(%93, %cst, %92) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %95 = "tile.trace"(%94) {msg = "res4b"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4b_branch2a = tile.cion add, mul, %cst, %95, %arg66 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %96 = "eltwise.add"(%res4b_branch2a, %arg65) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %97 = "eltwise.cmp_lt"(%96, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %98 = "eltwise.select"(%97, %cst, %96) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2b = tile.cion add, mul, %cst, %98, %arg64 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %99 = "eltwise.add"(%res4b_branch2b, %arg63) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %100 = "eltwise.cmp_lt"(%99, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %101 = "eltwise.select"(%100, %cst, %99) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2c = tile.cion add, mul, %cst, %101, %arg62 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %102 = "eltwise.add"(%res4b_branch2c, %arg61) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %103 = "eltwise.add"(%102, %95) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %104 = "eltwise.cmp_lt"(%103, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %105 = "eltwise.select"(%104, %cst, %103) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %106 = "tile.trace"(%105) {msg = "res4c"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4c_branch2a = tile.cion add, mul, %cst, %106, %arg72 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %107 = "eltwise.add"(%res4c_branch2a, %arg71) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %108 = "eltwise.cmp_lt"(%107, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %109 = "eltwise.select"(%108, %cst, %107) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4d_branch2b = tile.cion add, mul, %cst, %109, %arg76 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %110 = "eltwise.add"(%res4d_branch2b, %arg75) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4c_branch2b = tile.cion add, mul, %cst, %109, %arg70 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %110 = "eltwise.add"(%res4c_branch2b, %arg69) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %111 = "eltwise.cmp_lt"(%110, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %112 = "eltwise.select"(%111, %cst, %110) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4d_branch2c = tile.cion add, mul, %cst, %112, %arg74 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %113 = "eltwise.add"(%res4d_branch2c, %arg73) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4c_branch2c = tile.cion add, mul, %cst, %112, %arg68 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %113 = "eltwise.add"(%res4c_branch2c, %arg67) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %114 = "eltwise.add"(%113, %106) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %115 = "eltwise.cmp_lt"(%114, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %116 = "eltwise.select"(%115, %cst, %114) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4e_branch2a = tile.cion add, mul, %cst, %116, %arg84 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %117 = "eltwise.add"(%res4e_branch2a, %arg83) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %118 = "eltwise.cmp_lt"(%117, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %119 = "eltwise.select"(%118, %cst, %117) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4e_branch2b = tile.cion add, mul, %cst, %119, %arg82 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %120 = "eltwise.add"(%res4e_branch2b, %arg81) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %121 = "eltwise.cmp_lt"(%120, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %122 = "eltwise.select"(%121, %cst, %120) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4e_branch2c = tile.cion add, mul, %cst, %122, %arg80 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %123 = "eltwise.add"(%res4e_branch2c, %arg79) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %124 = "eltwise.add"(%123, %116) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %125 = "eltwise.cmp_lt"(%124, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
-    %126 = "eltwise.select"(%125, %cst, %124) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4f_branch2a = tile.cion add, mul, %cst, %126, %arg90 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %127 = "eltwise.add"(%res4f_branch2a, %arg89) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %128 = "eltwise.cmp_lt"(%127, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %129 = "eltwise.select"(%128, %cst, %127) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4f_branch2b = tile.cion add, mul, %cst, %129, %arg88 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
-    %130 = "eltwise.add"(%res4f_branch2b, %arg87) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %131 = "eltwise.cmp_lt"(%130, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
-    %132 = "eltwise.select"(%131, %cst, %130) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4f_branch2c = tile.cion add, mul, %cst, %132, %arg86 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %133 = "eltwise.add"(%res4f_branch2c, %arg85) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %134 = "eltwise.add"(%133, %126) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %135 = "eltwise.cmp_lt"(%134, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
-    %136 = "eltwise.select"(%135, %cst, %134) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res5a_branch1 = tile.cion add, mul, %cst, %136, %arg3 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5a_branch2a = tile.cion add, mul, %cst, %136, %arg96 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %137 = "eltwise.add"(%res5a_branch2a, %arg95) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %138 = "eltwise.cmp_lt"(%137, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
-    %139 = "eltwise.select"(%138, %cst, %137) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5a_branch2b = tile.cion add, mul, %cst, %139, %arg94 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %140 = "eltwise.add"(%res5a_branch2b, %arg93) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %141 = "eltwise.cmp_lt"(%140, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
-    %142 = "eltwise.select"(%141, %cst, %140) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5a_branch2c = tile.cion add, mul, %cst, %142, %arg92 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
-    %143 = "eltwise.add"(%res5a_branch2c, %arg91) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %144 = "eltwise.add"(%143, %res5a_branch1) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %145 = "eltwise.add"(%144, %arg2) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %146 = "eltwise.cmp_lt"(%145, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
-    %147 = "eltwise.select"(%146, %cst, %145) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5b_branch2a = tile.cion add, mul, %cst, %147, %arg102 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %148 = "eltwise.add"(%res5b_branch2a, %arg101) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %149 = "eltwise.cmp_lt"(%148, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
-    %150 = "eltwise.select"(%149, %cst, %148) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5b_branch2b = tile.cion add, mul, %cst, %150, %arg100 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %151 = "eltwise.add"(%res5b_branch2b, %arg99) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %117 = "tile.trace"(%116) {msg = "res4d"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4d_branch2a = tile.cion add, mul, %cst, %117, %arg78 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %118 = "eltwise.add"(%res4d_branch2a, %arg77) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %119 = "eltwise.cmp_lt"(%118, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %120 = "eltwise.select"(%119, %cst, %118) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2b = tile.cion add, mul, %cst, %120, %arg76 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %121 = "eltwise.add"(%res4d_branch2b, %arg75) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %122 = "eltwise.cmp_lt"(%121, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %123 = "eltwise.select"(%122, %cst, %121) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2c = tile.cion add, mul, %cst, %123, %arg74 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %124 = "eltwise.add"(%res4d_branch2c, %arg73) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %125 = "eltwise.add"(%124, %117) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %126 = "eltwise.cmp_lt"(%125, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %127 = "eltwise.select"(%126, %cst, %125) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %128 = "tile.trace"(%127) {msg = "res4e"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4e_branch2a = tile.cion add, mul, %cst, %128, %arg84 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %129 = "eltwise.add"(%res4e_branch2a, %arg83) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %130 = "eltwise.cmp_lt"(%129, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %131 = "eltwise.select"(%130, %cst, %129) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2b = tile.cion add, mul, %cst, %131, %arg82 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %132 = "eltwise.add"(%res4e_branch2b, %arg81) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %133 = "eltwise.cmp_lt"(%132, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %134 = "eltwise.select"(%133, %cst, %132) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2c = tile.cion add, mul, %cst, %134, %arg80 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %135 = "eltwise.add"(%res4e_branch2c, %arg79) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %136 = "eltwise.add"(%135, %128) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %137 = "eltwise.cmp_lt"(%136, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %138 = "eltwise.select"(%137, %cst, %136) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %139 = "tile.trace"(%138) {msg = "res4f"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4f_branch2a = tile.cion add, mul, %cst, %139, %arg90 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %140 = "eltwise.add"(%res4f_branch2a, %arg89) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %141 = "eltwise.cmp_lt"(%140, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %142 = "eltwise.select"(%141, %cst, %140) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2b = tile.cion add, mul, %cst, %142, %arg88 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %143 = "eltwise.add"(%res4f_branch2b, %arg87) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %144 = "eltwise.cmp_lt"(%143, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %145 = "eltwise.select"(%144, %cst, %143) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2c = tile.cion add, mul, %cst, %145, %arg86 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %146 = "eltwise.add"(%res4f_branch2c, %arg85) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %147 = "eltwise.add"(%146, %139) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %148 = "eltwise.cmp_lt"(%147, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %149 = "eltwise.select"(%148, %cst, %147) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %150 = "tile.trace"(%149) {msg = "res5a"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res5a_branch1 = tile.cion add, mul, %cst, %150, %arg3 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5a_branch2a = tile.cion add, mul, %cst, %150, %arg96 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %151 = "eltwise.add"(%res5a_branch2a, %arg95) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %152 = "eltwise.cmp_lt"(%151, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %153 = "eltwise.select"(%152, %cst, %151) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5b_branch2c = tile.cion add, mul, %cst, %153, %arg98 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
-    %154 = "eltwise.add"(%res5b_branch2c, %arg97) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %155 = "eltwise.add"(%154, %147) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %156 = "eltwise.cmp_lt"(%155, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
-    %157 = "eltwise.select"(%156, %cst, %155) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5c_branch2a = tile.cion add, mul, %cst, %157, %arg108 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %158 = "eltwise.add"(%res5c_branch2a, %arg107) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %159 = "eltwise.cmp_lt"(%158, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
-    %160 = "eltwise.select"(%159, %cst, %158) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5c_branch2b = tile.cion add, mul, %cst, %160, %arg106 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
-    %161 = "eltwise.add"(%res5c_branch2b, %arg105) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %162 = "eltwise.cmp_lt"(%161, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
-    %163 = "eltwise.select"(%162, %cst, %161) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5c_branch2c = tile.cion add, mul, %cst, %163, %arg104 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
-    %164 = "eltwise.add"(%res5c_branch2c, %arg103) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %165 = "eltwise.add"(%164, %157) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %166 = "eltwise.cmp_lt"(%165, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
-    %167 = "eltwise.select"(%166, %cst, %165) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %168 = tile.cion add, none, %cst, %167 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x7x7x2048x!eltwise.f32> -> tensor<1x2048x!eltwise.f32>
-    %169 = "eltwise.div"(%168, %c49) : (tensor<1x2048x!eltwise.f32>, !i32) -> tensor<1x2048x!eltwise.f32>
-    %170 = tile.cion add, mul, %cst, %169, %arg1 {sink = #map10, srcs = [#map11, #map12]} : !f32, tensor<1x2048x!eltwise.f32>, tensor<2048x1000x!eltwise.f32> -> tensor<1x1000x!eltwise.f32>
-    %171 = "eltwise.add"(%170, %arg0) : (tensor<1x1000x!eltwise.f32>, tensor<1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %172 = "eltwise.ident"(%171) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %173 = tile.cion max, none, %cst, %172 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
-    %174 = "eltwise.sub"(%172, %173) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %175 = "eltwise.exp"(%174) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %176 = tile.cion add, none, %cst, %175 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
-    %177 = "eltwise.div"(%175, %176) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    return %177 : tensor<1x1000x!eltwise.f32>
+    %res5a_branch2b = tile.cion add, mul, %cst, %153, %arg94 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %154 = "eltwise.add"(%res5a_branch2b, %arg93) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %155 = "eltwise.cmp_lt"(%154, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %156 = "eltwise.select"(%155, %cst, %154) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5a_branch2c = tile.cion add, mul, %cst, %156, %arg92 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %157 = "eltwise.add"(%res5a_branch2c, %arg91) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %158 = "eltwise.add"(%157, %res5a_branch1) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %159 = "eltwise.add"(%158, %arg2) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %160 = "eltwise.cmp_lt"(%159, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %161 = "eltwise.select"(%160, %cst, %159) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %162 = "tile.trace"(%161) {msg = "res5b"} : (tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5b_branch2a = tile.cion add, mul, %cst, %162, %arg102 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %163 = "eltwise.add"(%res5b_branch2a, %arg101) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %164 = "eltwise.cmp_lt"(%163, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %165 = "eltwise.select"(%164, %cst, %163) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2b = tile.cion add, mul, %cst, %165, %arg100 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %166 = "eltwise.add"(%res5b_branch2b, %arg99) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %167 = "eltwise.cmp_lt"(%166, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %168 = "eltwise.select"(%167, %cst, %166) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2c = tile.cion add, mul, %cst, %168, %arg98 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %169 = "eltwise.add"(%res5b_branch2c, %arg97) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %170 = "eltwise.add"(%169, %162) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %171 = "eltwise.cmp_lt"(%170, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %172 = "eltwise.select"(%171, %cst, %170) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %173 = "tile.trace"(%172) {msg = "res5c"} : (tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5c_branch2a = tile.cion add, mul, %cst, %173, %arg108 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %174 = "eltwise.add"(%res5c_branch2a, %arg107) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %175 = "eltwise.cmp_lt"(%174, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %176 = "eltwise.select"(%175, %cst, %174) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2b = tile.cion add, mul, %cst, %176, %arg106 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %177 = "eltwise.add"(%res5c_branch2b, %arg105) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %178 = "eltwise.cmp_lt"(%177, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %179 = "eltwise.select"(%178, %cst, %177) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2c = tile.cion add, mul, %cst, %179, %arg104 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %180 = "eltwise.add"(%res5c_branch2c, %arg103) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %181 = "eltwise.add"(%180, %173) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %182 = "eltwise.cmp_lt"(%181, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %183 = "eltwise.select"(%182, %cst, %181) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %184 = tile.cion add, none, %cst, %183 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x7x7x2048x!eltwise.f32> -> tensor<1x2048x!eltwise.f32>
+    %185 = "eltwise.div"(%184, %c49) : (tensor<1x2048x!eltwise.f32>, !i32) -> tensor<1x2048x!eltwise.f32>
+    %186 = tile.cion add, mul, %cst, %185, %arg1 {sink = #map10, srcs = [#map11, #map12]} : !f32, tensor<1x2048x!eltwise.f32>, tensor<2048x1000x!eltwise.f32> -> tensor<1x1000x!eltwise.f32>
+    %187 = "eltwise.add"(%186, %arg0) : (tensor<1x1000x!eltwise.f32>, tensor<1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %188 = "eltwise.ident"(%187) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %189 = tile.cion max, none, %cst, %188 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %190 = "eltwise.sub"(%188, %189) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %191 = "eltwise.exp"(%190) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %192 = tile.cion add, none, %cst, %191 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %193 = "eltwise.div"(%191, %192) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    return %193 : tensor<1x1000x!eltwise.f32>
   }
 }

--- a/networks/oplib/resnet50.mlir
+++ b/networks/oplib/resnet50.mlir
@@ -1,0 +1,258 @@
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 * 2 + d4 - 3, d2 * 2 + d5 - 3, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1 * 2 + d4 - 1, d2 * 2 + d5 - 1, d3)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map6 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4 - 1, d2 + d5 - 1, d6)>
+#map7 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 * 2 + d4, d2 * 2 + d5, d6)>
+#map8 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>
+#map10 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map11 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map12 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map13 = affine_map<(d0, d1) -> (d0, 0)>
+#map14 = affine_map<(d0, d1) -> (d0, d1)>
+
+#set0 = affine_set<(d0, d1, d2, d3, d4, d5) : (d4 >= 0, -d4 + 2 >= 0, d5 >= 0, -d5 + 2 >= 0)>
+
+!i32 = type tensor<!eltwise.i32>
+!f32 = type tensor<!eltwise.f32>
+module {
+  func @resnet50(%arg0: tensor<1000x!eltwise.f32>, %arg1: tensor<2048x1000x!eltwise.f32>, %arg2: tensor<2048x!eltwise.f32>, %arg3: tensor<1x1x1024x2048x!eltwise.f32>, %arg4: tensor<1024x!eltwise.f32>, %arg5: tensor<1x1x512x1024x!eltwise.f32>, %arg6: tensor<512x!eltwise.f32>, %arg7: tensor<1x1x256x512x!eltwise.f32>, %arg8: tensor<256x!eltwise.f32>, %arg9: tensor<1x1x64x256x!eltwise.f32>, %arg10: tensor<64x!eltwise.f32>, %arg11: tensor<7x7x3x64x!eltwise.f32>, %arg12: tensor<1x224x224x3x!eltwise.f32>, %arg13: tensor<256x!eltwise.f32>, %arg14: tensor<1x1x64x256x!eltwise.f32>, %arg15: tensor<64x!eltwise.f32>, %arg16: tensor<3x3x64x64x!eltwise.f32>, %arg17: tensor<64x!eltwise.f32>, %arg18: tensor<1x1x64x64x!eltwise.f32>, %arg19: tensor<256x!eltwise.f32>, %arg20: tensor<1x1x64x256x!eltwise.f32>, %arg21: tensor<64x!eltwise.f32>, %arg22: tensor<3x3x64x64x!eltwise.f32>, %arg23: tensor<64x!eltwise.f32>, %arg24: tensor<1x1x256x64x!eltwise.f32>, %arg25: tensor<256x!eltwise.f32>, %arg26: tensor<1x1x64x256x!eltwise.f32>, %arg27: tensor<64x!eltwise.f32>, %arg28: tensor<3x3x64x64x!eltwise.f32>, %arg29: tensor<64x!eltwise.f32>, %arg30: tensor<1x1x256x64x!eltwise.f32>, %arg31: tensor<512x!eltwise.f32>, %arg32: tensor<1x1x128x512x!eltwise.f32>, %arg33: tensor<128x!eltwise.f32>, %arg34: tensor<3x3x128x128x!eltwise.f32>, %arg35: tensor<128x!eltwise.f32>, %arg36: tensor<1x1x256x128x!eltwise.f32>, %arg37: tensor<512x!eltwise.f32>, %arg38: tensor<1x1x128x512x!eltwise.f32>, %arg39: tensor<128x!eltwise.f32>, %arg40: tensor<3x3x128x128x!eltwise.f32>, %arg41: tensor<128x!eltwise.f32>, %arg42: tensor<1x1x512x128x!eltwise.f32>, %arg43: tensor<512x!eltwise.f32>, %arg44: tensor<1x1x128x512x!eltwise.f32>, %arg45: tensor<128x!eltwise.f32>, %arg46: tensor<3x3x128x128x!eltwise.f32>, %arg47: tensor<128x!eltwise.f32>, %arg48: tensor<1x1x512x128x!eltwise.f32>, %arg49: tensor<512x!eltwise.f32>, %arg50: tensor<1x1x128x512x!eltwise.f32>, %arg51: tensor<128x!eltwise.f32>, %arg52: tensor<3x3x128x128x!eltwise.f32>, %arg53: tensor<128x!eltwise.f32>, %arg54: tensor<1x1x512x128x!eltwise.f32>, %arg55: tensor<1024x!eltwise.f32>, %arg56: tensor<1x1x256x1024x!eltwise.f32>, %arg57: tensor<256x!eltwise.f32>, %arg58: tensor<3x3x256x256x!eltwise.f32>, %arg59: tensor<256x!eltwise.f32>, %arg60: tensor<1x1x512x256x!eltwise.f32>, %arg61: tensor<1024x!eltwise.f32>, %arg62: tensor<1x1x256x1024x!eltwise.f32>, %arg63: tensor<256x!eltwise.f32>, %arg64: tensor<3x3x256x256x!eltwise.f32>, %arg65: tensor<256x!eltwise.f32>, %arg66: tensor<1x1x1024x256x!eltwise.f32>, %arg67: tensor<1024x!eltwise.f32>, %arg68: tensor<1x1x256x1024x!eltwise.f32>, %arg69: tensor<256x!eltwise.f32>, %arg70: tensor<3x3x256x256x!eltwise.f32>, %arg71: tensor<256x!eltwise.f32>, %arg72: tensor<1x1x1024x256x!eltwise.f32>, %arg73: tensor<1024x!eltwise.f32>, %arg74: tensor<1x1x256x1024x!eltwise.f32>, %arg75: tensor<256x!eltwise.f32>, %arg76: tensor<3x3x256x256x!eltwise.f32>, %arg77: tensor<256x!eltwise.f32>, %arg78: tensor<1x1x1024x256x!eltwise.f32>, %arg79: tensor<1024x!eltwise.f32>, %arg80: tensor<1x1x256x1024x!eltwise.f32>, %arg81: tensor<256x!eltwise.f32>, %arg82: tensor<3x3x256x256x!eltwise.f32>, %arg83: tensor<256x!eltwise.f32>, %arg84: tensor<1x1x1024x256x!eltwise.f32>, %arg85: tensor<1024x!eltwise.f32>, %arg86: tensor<1x1x256x1024x!eltwise.f32>, %arg87: tensor<256x!eltwise.f32>, %arg88: tensor<3x3x256x256x!eltwise.f32>, %arg89: tensor<256x!eltwise.f32>, %arg90: tensor<1x1x1024x256x!eltwise.f32>, %arg91: tensor<2048x!eltwise.f32>, %arg92: tensor<1x1x512x2048x!eltwise.f32>, %arg93: tensor<512x!eltwise.f32>, %arg94: tensor<3x3x512x512x!eltwise.f32>, %arg95: tensor<512x!eltwise.f32>, %arg96: tensor<1x1x1024x512x!eltwise.f32>, %arg97: tensor<2048x!eltwise.f32>, %arg98: tensor<1x1x512x2048x!eltwise.f32>, %arg99: tensor<512x!eltwise.f32>, %arg100: tensor<3x3x512x512x!eltwise.f32>, %arg101: tensor<512x!eltwise.f32>, %arg102: tensor<1x1x2048x512x!eltwise.f32>, %arg103: tensor<2048x!eltwise.f32>, %arg104: tensor<1x1x512x2048x!eltwise.f32>, %arg105: tensor<512x!eltwise.f32>, %arg106: tensor<3x3x512x512x!eltwise.f32>, %arg107: tensor<512x!eltwise.f32>, %arg108: tensor<1x1x2048x512x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32> {
+    %c49 = "eltwise.sconst"() {value = 49 : index} : () -> !i32
+    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %conv1 = tile.cion add, mul, %cst, %arg12, %arg11 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x!eltwise.f32>, tensor<7x7x3x64x!eltwise.f32> -> tensor<1x112x112x64x!eltwise.f32>
+    %0 = "eltwise.add"(%conv1, %arg10) : (tensor<1x112x112x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
+    %1 = "eltwise.cmp_lt"(%0, %cst) : (tensor<1x112x112x64x!eltwise.f32>, !f32) -> tensor<1x112x112x64x!eltwise.u1>
+    %2 = "eltwise.select"(%1, %cst, %0) : (tensor<1x112x112x64x!eltwise.u1>, !f32, tensor<1x112x112x64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
+    %3 = tile.cion max, none, %cst, %2 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x112x112x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch1 = tile.cion add, mul, %cst, %3, %arg9 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2a_branch2a = tile.cion add, mul, %cst, %3, %arg18 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %4 = "eltwise.add"(%res2a_branch2a, %arg17) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %5 = "eltwise.cmp_lt"(%4, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %6 = "eltwise.select"(%5, %cst, %4) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch2b = tile.cion add, mul, %cst, %6, %arg16 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %7 = "eltwise.add"(%res2a_branch2b, %arg15) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %8 = "eltwise.cmp_lt"(%7, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %9 = "eltwise.select"(%8, %cst, %7) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch2c = tile.cion add, mul, %cst, %9, %arg14 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %10 = "eltwise.add"(%res2a_branch2c, %arg13) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %11 = "eltwise.add"(%10, %res2a_branch1) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %12 = "eltwise.add"(%11, %arg8) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %13 = "eltwise.cmp_lt"(%12, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %14 = "eltwise.select"(%13, %cst, %12) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res2b_branch2a = tile.cion add, mul, %cst, %14, %arg24 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %15 = "eltwise.add"(%res2b_branch2a, %arg23) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %16 = "eltwise.cmp_lt"(%15, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %17 = "eltwise.select"(%16, %cst, %15) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2b = tile.cion add, mul, %cst, %17, %arg22 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %18 = "eltwise.add"(%res2b_branch2b, %arg21) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %19 = "eltwise.cmp_lt"(%18, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %20 = "eltwise.select"(%19, %cst, %18) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2c = tile.cion add, mul, %cst, %20, %arg20 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %21 = "eltwise.add"(%res2b_branch2c, %arg19) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %22 = "eltwise.add"(%21, %14) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %23 = "eltwise.cmp_lt"(%22, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %24 = "eltwise.select"(%23, %cst, %22) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res2c_branch2a = tile.cion add, mul, %cst, %24, %arg30 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %25 = "eltwise.add"(%res2c_branch2a, %arg29) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %26 = "eltwise.cmp_lt"(%25, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %27 = "eltwise.select"(%26, %cst, %25) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2c_branch2b = tile.cion add, mul, %cst, %27, %arg28 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %28 = "eltwise.add"(%res2c_branch2b, %arg27) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %29 = "eltwise.cmp_lt"(%28, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
+    %30 = "eltwise.select"(%29, %cst, %28) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
+    %res2c_branch2c = tile.cion add, mul, %cst, %30, %arg26 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %31 = "eltwise.add"(%res2c_branch2c, %arg25) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %32 = "eltwise.add"(%31, %24) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %33 = "eltwise.cmp_lt"(%32, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
+    %34 = "eltwise.select"(%33, %cst, %32) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
+    %res3a_branch1 = tile.cion add, mul, %cst, %34, %arg7 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3a_branch2a = tile.cion add, mul, %cst, %34, %arg36 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %35 = "eltwise.add"(%res3a_branch2a, %arg35) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %36 = "eltwise.cmp_lt"(%35, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %37 = "eltwise.select"(%36, %cst, %35) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch2b = tile.cion add, mul, %cst, %37, %arg34 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %38 = "eltwise.add"(%res3a_branch2b, %arg33) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %39 = "eltwise.cmp_lt"(%38, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %40 = "eltwise.select"(%39, %cst, %38) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch2c = tile.cion add, mul, %cst, %40, %arg32 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %41 = "eltwise.add"(%res3a_branch2c, %arg31) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %42 = "eltwise.add"(%41, %res3a_branch1) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %43 = "eltwise.add"(%42, %arg6) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %44 = "eltwise.cmp_lt"(%43, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %45 = "eltwise.select"(%44, %cst, %43) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3b_branch2a = tile.cion add, mul, %cst, %45, %arg42 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %46 = "eltwise.add"(%res3b_branch2a, %arg41) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %47 = "eltwise.cmp_lt"(%46, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %48 = "eltwise.select"(%47, %cst, %46) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2b = tile.cion add, mul, %cst, %48, %arg40 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %49 = "eltwise.add"(%res3b_branch2b, %arg39) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %50 = "eltwise.cmp_lt"(%49, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %51 = "eltwise.select"(%50, %cst, %49) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2c = tile.cion add, mul, %cst, %51, %arg38 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %52 = "eltwise.add"(%res3b_branch2c, %arg37) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %53 = "eltwise.add"(%52, %45) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %54 = "eltwise.cmp_lt"(%53, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %55 = "eltwise.select"(%54, %cst, %53) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3c_branch2a = tile.cion add, mul, %cst, %55, %arg48 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %56 = "eltwise.add"(%res3c_branch2a, %arg47) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %57 = "eltwise.cmp_lt"(%56, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %58 = "eltwise.select"(%57, %cst, %56) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2b = tile.cion add, mul, %cst, %58, %arg46 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %59 = "eltwise.add"(%res3c_branch2b, %arg45) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %60 = "eltwise.cmp_lt"(%59, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %61 = "eltwise.select"(%60, %cst, %59) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2c = tile.cion add, mul, %cst, %61, %arg44 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %62 = "eltwise.add"(%res3c_branch2c, %arg43) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %63 = "eltwise.add"(%62, %55) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %64 = "eltwise.cmp_lt"(%63, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %65 = "eltwise.select"(%64, %cst, %63) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res3d_branch2a = tile.cion add, mul, %cst, %65, %arg54 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %66 = "eltwise.add"(%res3d_branch2a, %arg53) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %67 = "eltwise.cmp_lt"(%66, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %68 = "eltwise.select"(%67, %cst, %66) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2b = tile.cion add, mul, %cst, %68, %arg52 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %69 = "eltwise.add"(%res3d_branch2b, %arg51) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %70 = "eltwise.cmp_lt"(%69, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
+    %71 = "eltwise.select"(%70, %cst, %69) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2c = tile.cion add, mul, %cst, %71, %arg50 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %72 = "eltwise.add"(%res3d_branch2c, %arg49) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %73 = "eltwise.add"(%72, %65) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %74 = "eltwise.cmp_lt"(%73, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
+    %75 = "eltwise.select"(%74, %cst, %73) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
+    %res4a_branch1 = tile.cion add, mul, %cst, %75, %arg5 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4a_branch2a = tile.cion add, mul, %cst, %75, %arg60 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %76 = "eltwise.add"(%res4a_branch2a, %arg59) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %77 = "eltwise.cmp_lt"(%76, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %78 = "eltwise.select"(%77, %cst, %76) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch2b = tile.cion add, mul, %cst, %78, %arg58 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %79 = "eltwise.add"(%res4a_branch2b, %arg57) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %80 = "eltwise.cmp_lt"(%79, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %81 = "eltwise.select"(%80, %cst, %79) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch2c = tile.cion add, mul, %cst, %81, %arg56 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %82 = "eltwise.add"(%res4a_branch2c, %arg55) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %83 = "eltwise.add"(%82, %res4a_branch1) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %84 = "eltwise.add"(%83, %arg4) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %85 = "eltwise.cmp_lt"(%84, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %86 = "eltwise.select"(%85, %cst, %84) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4b_branch2a = tile.cion add, mul, %cst, %86, %arg66 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %87 = "eltwise.add"(%res4b_branch2a, %arg65) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %88 = "eltwise.cmp_lt"(%87, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %89 = "eltwise.select"(%88, %cst, %87) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2b = tile.cion add, mul, %cst, %89, %arg64 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %90 = "eltwise.add"(%res4b_branch2b, %arg63) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %91 = "eltwise.cmp_lt"(%90, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %92 = "eltwise.select"(%91, %cst, %90) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2c = tile.cion add, mul, %cst, %92, %arg62 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %93 = "eltwise.add"(%res4b_branch2c, %arg61) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %94 = "eltwise.add"(%93, %86) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %95 = "eltwise.cmp_lt"(%94, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %96 = "eltwise.select"(%95, %cst, %94) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4c_branch2a = tile.cion add, mul, %cst, %96, %arg72 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %97 = "eltwise.add"(%res4c_branch2a, %arg71) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %98 = "eltwise.cmp_lt"(%97, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %99 = "eltwise.select"(%98, %cst, %97) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4c_branch2b = tile.cion add, mul, %cst, %99, %arg70 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %100 = "eltwise.add"(%res4c_branch2b, %arg69) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %101 = "eltwise.cmp_lt"(%100, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %102 = "eltwise.select"(%101, %cst, %100) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4c_branch2c = tile.cion add, mul, %cst, %102, %arg68 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %103 = "eltwise.add"(%res4c_branch2c, %arg67) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %104 = "eltwise.add"(%103, %96) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %105 = "eltwise.cmp_lt"(%104, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %106 = "eltwise.select"(%105, %cst, %104) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4d_branch2a = tile.cion add, mul, %cst, %106, %arg78 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %107 = "eltwise.add"(%res4d_branch2a, %arg77) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %108 = "eltwise.cmp_lt"(%107, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %109 = "eltwise.select"(%108, %cst, %107) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2b = tile.cion add, mul, %cst, %109, %arg76 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %110 = "eltwise.add"(%res4d_branch2b, %arg75) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %111 = "eltwise.cmp_lt"(%110, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %112 = "eltwise.select"(%111, %cst, %110) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2c = tile.cion add, mul, %cst, %112, %arg74 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %113 = "eltwise.add"(%res4d_branch2c, %arg73) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %114 = "eltwise.add"(%113, %106) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %115 = "eltwise.cmp_lt"(%114, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %116 = "eltwise.select"(%115, %cst, %114) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4e_branch2a = tile.cion add, mul, %cst, %116, %arg84 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %117 = "eltwise.add"(%res4e_branch2a, %arg83) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %118 = "eltwise.cmp_lt"(%117, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %119 = "eltwise.select"(%118, %cst, %117) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2b = tile.cion add, mul, %cst, %119, %arg82 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %120 = "eltwise.add"(%res4e_branch2b, %arg81) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %121 = "eltwise.cmp_lt"(%120, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %122 = "eltwise.select"(%121, %cst, %120) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2c = tile.cion add, mul, %cst, %122, %arg80 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %123 = "eltwise.add"(%res4e_branch2c, %arg79) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %124 = "eltwise.add"(%123, %116) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %125 = "eltwise.cmp_lt"(%124, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %126 = "eltwise.select"(%125, %cst, %124) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4f_branch2a = tile.cion add, mul, %cst, %126, %arg90 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %127 = "eltwise.add"(%res4f_branch2a, %arg89) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %128 = "eltwise.cmp_lt"(%127, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %129 = "eltwise.select"(%128, %cst, %127) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2b = tile.cion add, mul, %cst, %129, %arg88 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %130 = "eltwise.add"(%res4f_branch2b, %arg87) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %131 = "eltwise.cmp_lt"(%130, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
+    %132 = "eltwise.select"(%131, %cst, %130) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2c = tile.cion add, mul, %cst, %132, %arg86 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %133 = "eltwise.add"(%res4f_branch2c, %arg85) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %134 = "eltwise.add"(%133, %126) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %135 = "eltwise.cmp_lt"(%134, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
+    %136 = "eltwise.select"(%135, %cst, %134) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
+    %res5a_branch1 = tile.cion add, mul, %cst, %136, %arg3 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5a_branch2a = tile.cion add, mul, %cst, %136, %arg96 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %137 = "eltwise.add"(%res5a_branch2a, %arg95) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %138 = "eltwise.cmp_lt"(%137, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %139 = "eltwise.select"(%138, %cst, %137) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5a_branch2b = tile.cion add, mul, %cst, %139, %arg94 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %140 = "eltwise.add"(%res5a_branch2b, %arg93) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %141 = "eltwise.cmp_lt"(%140, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %142 = "eltwise.select"(%141, %cst, %140) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5a_branch2c = tile.cion add, mul, %cst, %142, %arg92 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %143 = "eltwise.add"(%res5a_branch2c, %arg91) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %144 = "eltwise.add"(%143, %res5a_branch1) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %145 = "eltwise.add"(%144, %arg2) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %146 = "eltwise.cmp_lt"(%145, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %147 = "eltwise.select"(%146, %cst, %145) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5b_branch2a = tile.cion add, mul, %cst, %147, %arg102 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %148 = "eltwise.add"(%res5b_branch2a, %arg101) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %149 = "eltwise.cmp_lt"(%148, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %150 = "eltwise.select"(%149, %cst, %148) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2b = tile.cion add, mul, %cst, %150, %arg100 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %151 = "eltwise.add"(%res5b_branch2b, %arg99) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %152 = "eltwise.cmp_lt"(%151, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %153 = "eltwise.select"(%152, %cst, %151) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2c = tile.cion add, mul, %cst, %153, %arg98 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %154 = "eltwise.add"(%res5b_branch2c, %arg97) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %155 = "eltwise.add"(%154, %147) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %156 = "eltwise.cmp_lt"(%155, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %157 = "eltwise.select"(%156, %cst, %155) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5c_branch2a = tile.cion add, mul, %cst, %157, %arg108 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %158 = "eltwise.add"(%res5c_branch2a, %arg107) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %159 = "eltwise.cmp_lt"(%158, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %160 = "eltwise.select"(%159, %cst, %158) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2b = tile.cion add, mul, %cst, %160, %arg106 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %161 = "eltwise.add"(%res5c_branch2b, %arg105) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %162 = "eltwise.cmp_lt"(%161, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
+    %163 = "eltwise.select"(%162, %cst, %161) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2c = tile.cion add, mul, %cst, %163, %arg104 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %164 = "eltwise.add"(%res5c_branch2c, %arg103) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %165 = "eltwise.add"(%164, %157) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %166 = "eltwise.cmp_lt"(%165, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
+    %167 = "eltwise.select"(%166, %cst, %165) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
+    %168 = tile.cion add, none, %cst, %167 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x7x7x2048x!eltwise.f32> -> tensor<1x2048x!eltwise.f32>
+    %169 = "eltwise.div"(%168, %c49) : (tensor<1x2048x!eltwise.f32>, !i32) -> tensor<1x2048x!eltwise.f32>
+    %170 = tile.cion add, mul, %cst, %169, %arg1 {sink = #map10, srcs = [#map11, #map12]} : !f32, tensor<1x2048x!eltwise.f32>, tensor<2048x1000x!eltwise.f32> -> tensor<1x1000x!eltwise.f32>
+    %171 = "eltwise.add"(%170, %arg0) : (tensor<1x1000x!eltwise.f32>, tensor<1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %172 = "eltwise.ident"(%171) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %173 = tile.cion max, none, %cst, %172 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %174 = "eltwise.sub"(%172, %173) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %175 = "eltwise.exp"(%174) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    %176 = tile.cion add, none, %cst, %175 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %177 = "eltwise.div"(%175, %176) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
+    return %177 : tensor<1x1000x!eltwise.f32>
+  }
+}

--- a/networks/oplib/run.cc
+++ b/networks/oplib/run.cc
@@ -1,0 +1,27 @@
+// Copyright 2020, Intel Corporation
+
+#include <iostream>
+
+#include "networks/oplib/oplib.h"
+#include "plaidml/exec/exec.h"
+#include "plaidml/op/op.h"
+
+// TODO: command line parsing to dispatch on network to run
+int main(int argc, char** argv) {
+  try {
+    plaidml::init();
+    plaidml::edsl::init();
+    plaidml::op::init();
+    plaidml::exec::init();
+    auto program = networks::oplib::buildResnet50();
+    auto executable = plaidml::exec::Binder(program).compile();
+    executable->run();
+    return EXIT_SUCCESS;
+  } catch (const std::exception& ex) {
+    std::cerr << "Caught unhandled exception: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "Caught unhandled exception" << std::endl;
+    return EXIT_FAILURE;
+  }
+}

--- a/networks/oplib/run.cc
+++ b/networks/oplib/run.cc
@@ -14,7 +14,9 @@ int main(int argc, char** argv) {
     plaidml::op::init();
     plaidml::exec::init();
     auto program = networks::oplib::buildResnet50();
+    // std::cout << program.str() << std::endl;
     auto executable = plaidml::exec::Binder(program).compile();
+    std::cout << "Running..." << std::endl;
     executable->run();
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/plaidml/bridge/pytorch/compiler.cc
+++ b/plaidml/bridge/pytorch/compiler.cc
@@ -32,13 +32,13 @@ edsl::Tensor addmm(const std::vector<edsl::Value>& args) {
   IVLOG(1, "addmm");
 
   const auto& A = args[0].as_tensor();
-  IVLOG(2, "  A: " << A.shape().str());
+  IVLOG(2, "  A: " << A.compute_shape().str());
 
   const auto& B = args[1].as_tensor();
-  IVLOG(2, "  B: " << B.shape().str());
+  IVLOG(2, "  B: " << B.compute_shape().str());
 
   const auto& C = args[2].as_tensor();
-  IVLOG(2, "  C: " << C.shape().str());
+  IVLOG(2, "  C: " << C.compute_shape().str());
 
   const auto& beta = args[3].as_tensor();
   IVLOG(2, "  beta: " << beta);
@@ -61,7 +61,7 @@ edsl::Tensor add(const std::vector<edsl::Value>& args) {
   auto A = args[0].as_tensor();
   auto B = args[1].as_tensor();
   auto C = args[2].as_tensor();
-  IVLOG(2, "  " << A.shape().str() << " + " << B.shape().str() << " * " << C);
+  IVLOG(2, "  " << A.compute_shape().str() << " + " << B.compute_shape().str() << " * " << C);
   return A + B * C;
 }
 
@@ -70,7 +70,7 @@ edsl::Tensor mul(const std::vector<edsl::Value>& args) {
   IVLOG(1, "mul");
   auto A = args[0].as_tensor();
   auto B = args[1].as_tensor();
-  IVLOG(2, "  " << A.shape().str() << " * " << B.shape().str());
+  IVLOG(2, "  " << A.compute_shape().str() << " * " << B.compute_shape().str());
   return A * B;
 }
 
@@ -89,7 +89,7 @@ edsl::Tensor batch_norm(const std::vector<edsl::Value>& args) {
   IVLOG(1, "batch_norm");
 
   const auto& I = args[0].as_tensor();  // input
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   edsl::TensorDim N, C, H, W;
   I.bind_dims(N, C, H, W);
@@ -151,7 +151,7 @@ edsl::Tensor convolution(const std::vector<edsl::Value>& args) {
   IVLOG(1, "convolution");
 
   auto I = args[0].as_tensor();  // input
-  IVLOG(2, "  I: " << I.shape());
+  IVLOG(2, "  I: " << I.compute_shape());
 
   auto K = args[1].as_tensor();  // weight
   IVLOG(2, "  K: " << K);
@@ -236,7 +236,7 @@ edsl::Tensor avg_pool2d(const std::vector<edsl::Value>& args) {
   IVLOG(1, "avg_pool2d");
 
   const auto& I = args[0].as_tensor();
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   const auto& kernel_size = args[1].as_tuple();
   IVLOG(2, "  kernel_size: " << args[1].str());
@@ -273,7 +273,7 @@ edsl::Tensor adaptive_avg_pool2d(const std::vector<edsl::Value>& args) {
   IVLOG(1, "adaptive_avg_pool2d");
 
   const auto& I = args[0].as_tensor();
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   const auto& output_size = args[1].as_tuple();
   IVLOG(2, "  output_size: " << args[1].str());
@@ -319,7 +319,7 @@ edsl::Tensor max_pool2d(const std::vector<edsl::Value>& args) {
   IVLOG(1, "max_pool2d");
 
   const auto& I = args[0].as_tensor();
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   const auto& kernel_size = args[1].as_tuple();
   IVLOG(2, "  kernel_size: " << args[1].str());
@@ -363,7 +363,7 @@ edsl::Tensor relu(const std::vector<edsl::Value>& args) {
   IVLOG(1, "relu");
 
   const auto& I = args[0].as_tensor();
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   edsl::Tensor Z{0.0};
   return edsl::select(I < Z, Z, I);
@@ -374,8 +374,8 @@ edsl::Tensor reshape(const std::vector<edsl::Value>& args) {
   IVLOG(1, "reshape");
 
   const auto& I = args[0].as_tensor();
-  auto I_dims = I.shape().int_dims();
-  IVLOG(2, "  I: " << I.shape().str());
+  auto I_dims = I.compute_shape().int_dims();
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   const auto& shape = args[1].as_tuple();
   IVLOG(2, "  shape: " << args[1].str());
@@ -413,7 +413,7 @@ edsl::Tensor transpose(const std::vector<edsl::Value>& args) {
   IVLOG(1, "transpose");
 
   const auto& I = args[0].as_tensor();
-  IVLOG(2, "  I: " << I.shape().str());
+  IVLOG(2, "  I: " << I.compute_shape().str());
 
   edsl::TensorDim X, Y;
   edsl::TensorIndex x, y;
@@ -428,7 +428,7 @@ edsl::Tensor linear(const std::vector<edsl::Value>& args) {
   IVLOG(1, "linear");
 
   const auto& input = args[0].as_tensor();
-  IVLOG(2, "  input: " << input.shape().str());
+  IVLOG(2, "  input: " << input.compute_shape().str());
 
   const auto& weight = args[1].as_tensor();
   IVLOG(2, "  weight: " << weight.str());
@@ -612,7 +612,7 @@ Executable::Executable(                       //
       // input_bindings_(inputs.size()),
       output_ivalues_(outputs.size()) {
   // for (size_t i = 0; i < inputs.size(); i++) {
-  //   auto shape = inputs[i].shape();
+  //   auto shape = inputs[i].compute_shape();
   //   plaidml::TensorShape tensor_shape(shape.dtype(), shape.int_dims());
   //   plaidml::Buffer buffer(device_id, tensor_shape);
   //   input_bindings_[i] = plaidml::exec::Binding{inputs[i], buffer};
@@ -626,7 +626,7 @@ Executable::Executable(                       //
   IVLOG(2, program.str());
   binder_ = std::make_unique<plaidml::exec::Binder>(program);
   // for (size_t i = 0; i < outputs.size(); i++) {
-  //   // auto shape = outputs[i].shape();
+  //   // auto shape = outputs[i].compute_shape();
   //   // plaidml::TensorShape tensor_shape(shape.dtype(), shape.int_dims());
   //   // output_bindings_.emplace_back(plaidml::exec::Binding{
   //   //     program_->outputs().at(i),                // tensor

--- a/plaidml/core/BUILD
+++ b/plaidml/core/BUILD
@@ -18,13 +18,6 @@ exports_files([
     "ffi.h",
 ])
 
-pkg_tar(
-    name = "include_pkg",
-    srcs = SDK_HDRS,
-    package_dir = "include/plaidml/core",
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "docs",
     srcs = ["core.h"],
@@ -64,12 +57,6 @@ plaidml_cc_library(
         "@llvm-project//llvm:support",
     ],
     alwayslink = 1,
-)
-
-plaidml_cc_library(
-    name = "api",
-    hdrs = SDK_HDRS,
-    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/plaidml/core/core.h
+++ b/plaidml/core/core.h
@@ -97,6 +97,37 @@ enum class DType {
   FLOAT64 = PLAIDML_DATA_FLOAT64,
 };
 
+inline const char* to_string(DType dtype) {
+  switch (dtype) {
+    case DType::BOOLEAN:
+      return "bool";
+    case DType::INT8:
+      return "int8";
+    case DType::UINT8:
+      return "uint8";
+    case DType::INT16:
+      return "int16";
+    case DType::UINT16:
+      return "uint16";
+    case DType::INT32:
+      return "int32";
+    case DType::UINT32:
+      return "uint32";
+    case DType::INT64:
+      return "uint64";
+    case DType::BFLOAT16:
+      return "bfloat16";
+    case DType::FLOAT16:
+      return "float16";
+    case DType::FLOAT32:
+      return "float32";
+    case DType::FLOAT64:
+      return "float64";
+    default:
+      return "<invalid>";
+  }
+}
+
 ///
 /// \ingroup core_objects
 /// \class TensorShape

--- a/plaidml/edsl/BUILD
+++ b/plaidml/edsl/BUILD
@@ -14,13 +14,6 @@ exports_files([
     "ffi.h",
 ])
 
-pkg_tar(
-    name = "include_pkg",
-    srcs = SDK_HDRS,
-    package_dir = "include/plaidml/edsl",
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "docs",
     srcs = ["edsl.h"],
@@ -62,18 +55,10 @@ py_library(
     ],
 )
 
-plaidml_cc_library(
-    name = "api",
-    hdrs = SDK_HDRS,
-    visibility = ["//visibility:public"],
-    deps = ["//plaidml/core:api"],
-)
-
 plaidml_cc_test(
     name = "cc_test",
     srcs = ["edsl_test.cc"],
     deps = [
-        ":api",
         ":edsl",
         "//plaidml:testenv",
         "//plaidml/exec",

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -1054,6 +1054,14 @@ inline Tensor tan(const Tensor& x) { return Call("tan", x); }
 inline Tensor tanh(const Tensor& x) { return Call("tanh", x); }
 
 ///
+/// Adds a tracepoint to the graph
+///
+inline Tensor trace(const Tensor& x, const std::string& msg) {
+  auto ptr = ffi::call<plaidml_expr*>(plaidml_expr_trace, x.as_ptr(), msg.c_str());
+  return Tensor{ptr};
+}
+
+///
 /// Returns a Tensor with a value of 0.
 /// \return Tensor
 ///

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -90,7 +90,7 @@ class Program {
   ///
   /// Return the Program as a string.
   ///
-  std::string str() const { return ffi::str(ffi::call<plaidml_string*>(plaidml_program_repr, ptr_.get())); }
+  std::string str() const { return ffi::str(ffi::call<plaidml_string*>(plaidml_program_repr, as_ptr())); }
 
   ///
   /// args
@@ -150,7 +150,7 @@ class TensorDim {
   /// Returns the TensorDim as a string.
   ///
   std::string str() const {  //
-    return ffi::str(ffi::call<plaidml_string*>(plaidml_dim_expr_repr, ptr_.get()));
+    return ffi::str(ffi::call<plaidml_string*>(plaidml_dim_expr_repr, as_ptr()));
   }
 
   ///
@@ -160,7 +160,7 @@ class TensorDim {
     if (!ptr_) {
       throw std::runtime_error("as_int() only available on TensorDim with an integer value");
     }
-    return ffi::call<int64_t>(plaidml_dim_expr_get_int, ptr_.get());
+    return ffi::call<int64_t>(plaidml_dim_expr_get_int, as_ptr());
   }
 
   plaidml_dim_expr* as_ptr() const { return ptr_.get(); }
@@ -394,14 +394,14 @@ class LogicalShape {
   /// Returns a LogicalShape as a string
   ///
   std::string str() const {  //
-    return ffi::str(ffi::call<plaidml_string*>(plaidml_logical_shape_repr, ptr_.get()));
+    return ffi::str(ffi::call<plaidml_string*>(plaidml_logical_shape_repr, as_ptr()));
   }
 
   ///
   /// Returns the datatype of the LogicalShape
   ///
   DType dtype() const {
-    auto ret = ffi::call<plaidml_datatype>(plaidml_logical_shape_get_dtype, ptr_.get());
+    auto ret = ffi::call<plaidml_datatype>(plaidml_logical_shape_get_dtype, as_ptr());
     return static_cast<DType>(ret);
   }
 
@@ -409,7 +409,7 @@ class LogicalShape {
   /// Returns the number of dimensions of the LogicalShape
   ///
   size_t ndims() const {  //
-    return ffi::call<size_t>(plaidml_logical_shape_get_ndims, ptr_.get());
+    return ffi::call<size_t>(plaidml_logical_shape_get_ndims, as_ptr());
   }
 
   ///
@@ -418,7 +418,7 @@ class LogicalShape {
   std::vector<int64_t> int_dims() const {
     std::vector<int64_t> ret(ndims());
     for (size_t i = 0; i < ret.size(); i++) {
-      ret[i] = ffi::call<int64_t>(plaidml_logical_shape_get_dim_int, ptr_.get(), i);
+      ret[i] = ffi::call<int64_t>(plaidml_logical_shape_get_dim_int, as_ptr(), i);
     }
     return ret;
   }
@@ -657,8 +657,17 @@ class Tensor {
   ///
   /// Return the tensor's shape
   ///
-  LogicalShape shape() const {
+  LogicalShape compute_shape() const {
     return LogicalShape(ffi::call<plaidml_logical_shape*>(plaidml_expr_get_shape, as_ptr()));
+  }
+
+  DType dtype() const {  //
+    auto ret = ffi::call<plaidml_datatype>(plaidml_expr_get_dtype, as_ptr());
+    return static_cast<DType>(ret);
+  }
+
+  size_t rank() const {  //
+    return ffi::call<size_t>(plaidml_expr_get_rank, as_ptr());
   }
 
   ///

--- a/plaidml/edsl/edsl_test.cc
+++ b/plaidml/edsl/edsl_test.cc
@@ -452,7 +452,7 @@ Tensor MaxPooling2(const Tensor& I) {
 }
 
 Tensor Flatten(const Tensor& X) {
-  std::vector<TensorDim> X_dims(X.shape().ndims());
+  std::vector<TensorDim> X_dims(X.rank());
   X.bind_dims(X_dims);
   if (X_dims.empty()) {
     return X;
@@ -478,7 +478,7 @@ TEST(CppEdsl, MnistCnn) {
   auto pool1 = MaxPooling2(conv2);
   // model.add(Flatten())
   auto flat = Flatten(pool1);
-  EXPECT_THAT(flat.shape(), Eq(LogicalShape(DType::FLOAT32, {1, 12100})));
+  EXPECT_THAT(flat.compute_shape(), Eq(LogicalShape(DType::FLOAT32, {1, 12100})));
   // model.add(Dense(128, activation='relu'))
   auto kernel3 = Placeholder(DType::FLOAT32, {12100, 128});
   auto bias3 = Placeholder(DType::FLOAT32, {128});
@@ -541,7 +541,7 @@ module {
 Tensor Normalize(const Tensor& X) {
   auto XSqr = X * X;
   auto X_MS = TensorOutput();
-  std::vector<TensorIndex> idxs(X.shape().ndims());
+  std::vector<TensorIndex> idxs(X.rank());
   X_MS() += XSqr(idxs);
   return sqrt(X_MS);
 }
@@ -578,25 +578,25 @@ TEST(CppEdsl, LarsMomentum4d) {
 !f32 = type tensor<!eltwise.f32>
 module {
   func @lars_momentum4d(%arg0: tensor<4x7x3x9x!eltwise.f32>, %arg1: tensor<4x7x3x9x!eltwise.f32>, %arg2: !f32, %arg3: tensor<4x7x3x9x!eltwise.f32>) -> (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) {
-    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %cst_0 = "eltwise.sconst"() {value = 4.8828125E-4 : f64} : () -> !f32
-    %cst_1 = "eltwise.sconst"() {value = 9.765625E-4 : f64} : () -> !f32
-    %cst_2 = "eltwise.sconst"() {value = 1.250000e-01 : f64} : () -> !f32
-    %0 = "eltwise.mul"(%arg0, %cst_0) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
+    %cst = "eltwise.sconst"() {value = 1.250000e-01 : f64} : () -> !f32
+    %cst_0 = "eltwise.sconst"() {value = 9.765625E-4 : f64} : () -> !f32
+    %cst_1 = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %cst_2 = "eltwise.sconst"() {value = 4.8828125E-4 : f64} : () -> !f32
+    %0 = "eltwise.mul"(%arg0, %cst_2) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
     %1 = "eltwise.add"(%arg1, %0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     %2 = "eltwise.mul"(%arg0, %arg0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %3 = tile.cion add, none, %cst, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %3 = tile.cion add, none, %cst_1, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %4 = "eltwise.sqrt"(%3) : (!f32) -> !f32
-    %5 = "eltwise.mul"(%4, %cst_0) : (!f32, !f32) -> !f32
+    %5 = "eltwise.mul"(%4, %cst_2) : (!f32, !f32) -> !f32
     %6 = "eltwise.mul"(%arg1, %arg1) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %7 = tile.cion add, none, %cst, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %7 = tile.cion add, none, %cst_1, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %8 = "eltwise.sqrt"(%7) : (!f32) -> !f32
     %9 = "eltwise.add"(%8, %5) : (!f32, !f32) -> !f32
-    %10 = "eltwise.mul"(%arg2, %cst_1) : (!f32, !f32) -> !f32
+    %10 = "eltwise.mul"(%arg2, %cst_0) : (!f32, !f32) -> !f32
     %11 = "eltwise.mul"(%10, %4) : (!f32, !f32) -> !f32
     %12 = "eltwise.div"(%11, %9) : (!f32, !f32) -> !f32
     %13 = "eltwise.mul"(%12, %1) : (!f32, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %14 = "eltwise.mul"(%arg3, %cst_2) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
+    %14 = "eltwise.mul"(%arg3, %cst) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
     %15 = "eltwise.add"(%14, %13) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     %16 = "eltwise.sub"(%arg0, %15) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     return %16, %15 : tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>
@@ -679,7 +679,7 @@ TEST(CppEdsl, ArgMax) {
   auto I = Placeholder(DType::FLOAT32, {1, 10, 10});
   auto X = ArgMax(I);
   Program program("arg_max", {X});
-  EXPECT_THAT(X.shape(), Eq(LogicalShape(DType::UINT32, {1, 10})));
+  EXPECT_THAT(X.compute_shape(), Eq(LogicalShape(DType::UINT32, {1, 10})));
   EXPECT_THAT(program, Eq(R"#(
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<() -> ()>
@@ -688,12 +688,12 @@ TEST(CppEdsl, ArgMax) {
 #map4 = affine_map<(d0, d1, d2) -> (d2)>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 module {
   func @arg_max(%arg0: tensor<1x10x10x!eltwise.f32>) -> tensor<1x10x!eltwise.u32> {
-    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %0 = tile.cion assign, none, %cst, %c1 {sink = #map0, srcs = [#map1]} : !f32, !i32 -> tensor<10x!eltwise.i32>
     %1 = "tile.index"(%0) {dim = 0 : i64} : (tensor<10x!eltwise.i32>) -> tensor<10x!eltwise.i32>
     %2 = tile.cion max, none, %cst, %arg0 {sink = #map2, srcs = [#map3]} : !f32, tensor<1x10x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
@@ -1054,8 +1054,8 @@ TEST(CppEdsl, Select) {
 !i32 = type tensor<!eltwise.i32>
 module {
   func @select(%arg0: tensor<10x20x!eltwise.f32>) -> tensor<10x20x!eltwise.i32> {
-    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
+    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %0 = "eltwise.cmp_eq"(%arg0, %c0) : (tensor<10x20x!eltwise.f32>, !i32) -> tensor<10x20x!eltwise.u1>
     %1 = "eltwise.select"(%0, %c0, %c1) : (tensor<10x20x!eltwise.u1>, !i32, !i32) -> tensor<10x20x!eltwise.i32>
     return %1 : tensor<10x20x!eltwise.i32>
@@ -1095,10 +1095,10 @@ TEST(CppEdsl, Prng) {
 !i32 = type tensor<!eltwise.i32>
 module {
   func @prng(%arg0: tensor<3x2048x!eltwise.u32>) -> (tensor<2x3x4x5x!eltwise.f32>, tensor<3x2048x!eltwise.u32>) {
-    %c5 = "eltwise.sconst"() {value = 5 : i64} : () -> !i32
-    %c4 = "eltwise.sconst"() {value = 4 : i64} : () -> !i32
-    %c3 = "eltwise.sconst"() {value = 3 : i64} : () -> !i32
     %c2 = "eltwise.sconst"() {value = 2 : i64} : () -> !i32
+    %c3 = "eltwise.sconst"() {value = 3 : i64} : () -> !i32
+    %c4 = "eltwise.sconst"() {value = 4 : i64} : () -> !i32
+    %c5 = "eltwise.sconst"() {value = 5 : i64} : () -> !i32
     %result, %new_state = "tile.prng"(%arg0, %c2, %c3, %c4, %c5) : (tensor<3x2048x!eltwise.u32>, !i32, !i32, !i32, !i32) -> (tensor<2x3x4x5x!eltwise.f32>, tensor<3x2048x!eltwise.u32>)
     return %result, %new_state : tensor<2x3x4x5x!eltwise.f32>, tensor<3x2048x!eltwise.u32>
   }

--- a/plaidml/edsl/edsl_test.py
+++ b/plaidml/edsl/edsl_test.py
@@ -352,8 +352,8 @@ module {
 !f32 = type tensor<!eltwise.f32>
 module {
   func @avg_stages(%arg0: tensor<1x784x!eltwise.f32>) -> !f32 {
-    %c784 = tile.affine_const 784
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c784 = tile.affine_const 784
     %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
     %1 = "eltwise.div"(%0, %c784) : (!f32, index) -> !f32
     return %1 : !f32
@@ -374,8 +374,8 @@ module {
 !f32 = type tensor<!eltwise.f32>
 module {
   func @avg_merge(%arg0: tensor<1x784x!eltwise.f32>) -> !f32 {
-    %c784 = tile.affine_const 784
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c784 = tile.affine_const 784
     %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
     %1 = "eltwise.div"(%0, %c784) : (!f32, index) -> !f32
     return %1 : !f32
@@ -590,8 +590,8 @@ module {
 !f32 = type tensor<!eltwise.f32>
 module {
   func @mnist_cnn(%arg0: tensor<100x!eltwise.f32>, %arg1: tensor<128x100x!eltwise.f32>, %arg2: tensor<128x!eltwise.f32>, %arg3: tensor<12100x128x!eltwise.f32>, %arg4: tensor<64x!eltwise.f32>, %arg5: tensor<3x3x32x64x!eltwise.f32>, %arg6: tensor<32x!eltwise.f32>, %arg7: tensor<3x3x1x32x!eltwise.f32>, %arg8: tensor<1x224x224x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32> {
-    %c12100 = tile.affine_const 12100
     %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
+    %c12100 = tile.affine_const 12100
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
     %0 = tile.cion add, mul, %cst, %arg8, %arg7 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
     %1 = "eltwise.add"(%0, %arg6) : (tensor<1x222x222x32x!eltwise.f32>, tensor<32x!eltwise.f32>) -> tensor<1x222x222x32x!eltwise.f32>
@@ -717,7 +717,7 @@ module {
 '''
         self.compare_results(program, expected)
 
-    def test_lars_momentum_4d(self):
+    def test_lars_momentum4d(self):
         X_shape = LogicalShape(plaidml.DType.FLOAT32, [4, 7, 3, 9])
         LR_Shape = LogicalShape(plaidml.DType.FLOAT32)
         X = Tensor(X_shape)
@@ -725,7 +725,7 @@ module {
         Veloc = Tensor(X_shape)
         LR = Tensor(LR_Shape)
         R = lars_momentum(X, Grad, Veloc, LR, 1. / 1024., 1. / 2048., 1. / 8.)
-        program = Program('lars_momentum_4d', R)
+        program = Program('lars_momentum4d', R)
         expected = '''
 #map0 = affine_map<() -> ()>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
@@ -733,26 +733,26 @@ module {
 
 !f32 = type tensor<!eltwise.f32>
 module {
-  func @lars_momentum_4d(%arg0: tensor<4x7x3x9x!eltwise.f32>, %arg1: tensor<4x7x3x9x!eltwise.f32>, %arg2: !f32, %arg3: tensor<4x7x3x9x!eltwise.f32>) -> (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) {
-    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %cst_0 = "eltwise.sconst"() {value = 4.8828125E-4 : f64} : () -> !f32
-    %cst_1 = "eltwise.sconst"() {value = 9.765625E-4 : f64} : () -> !f32
-    %cst_2 = "eltwise.sconst"() {value = 1.250000e-01 : f64} : () -> !f32
-    %0 = "eltwise.mul"(%arg0, %cst_0) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
+  func @lars_momentum4d(%arg0: tensor<4x7x3x9x!eltwise.f32>, %arg1: tensor<4x7x3x9x!eltwise.f32>, %arg2: !f32, %arg3: tensor<4x7x3x9x!eltwise.f32>) -> (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) {
+    %cst = "eltwise.sconst"() {value = 1.250000e-01 : f64} : () -> !f32
+    %cst_0 = "eltwise.sconst"() {value = 9.765625E-4 : f64} : () -> !f32
+    %cst_1 = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %cst_2 = "eltwise.sconst"() {value = 4.8828125E-4 : f64} : () -> !f32
+    %0 = "eltwise.mul"(%arg0, %cst_2) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
     %1 = "eltwise.add"(%arg1, %0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     %2 = "eltwise.mul"(%arg0, %arg0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %3 = tile.cion add, none, %cst, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %3 = tile.cion add, none, %cst_1, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %4 = "eltwise.sqrt"(%3) : (!f32) -> !f32
-    %5 = "eltwise.mul"(%4, %cst_0) : (!f32, !f32) -> !f32
+    %5 = "eltwise.mul"(%4, %cst_2) : (!f32, !f32) -> !f32
     %6 = "eltwise.mul"(%arg1, %arg1) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %7 = tile.cion add, none, %cst, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %7 = tile.cion add, none, %cst_1, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %8 = "eltwise.sqrt"(%7) : (!f32) -> !f32
     %9 = "eltwise.add"(%8, %5) : (!f32, !f32) -> !f32
-    %10 = "eltwise.mul"(%arg2, %cst_1) : (!f32, !f32) -> !f32
+    %10 = "eltwise.mul"(%arg2, %cst_0) : (!f32, !f32) -> !f32
     %11 = "eltwise.mul"(%10, %4) : (!f32, !f32) -> !f32
     %12 = "eltwise.div"(%11, %9) : (!f32, !f32) -> !f32
     %13 = "eltwise.mul"(%12, %1) : (!f32, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %14 = "eltwise.mul"(%arg3, %cst_2) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
+    %14 = "eltwise.mul"(%arg3, %cst) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
     %15 = "eltwise.add"(%14, %13) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     %16 = "eltwise.sub"(%arg0, %15) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     return %16, %15 : tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -234,6 +234,36 @@ void* plaidml_expr_ptr(  //
   });
 }
 
+plaidml_datatype plaidml_expr_get_dtype(  //
+    plaidml_error* err,                   //
+    plaidml_expr* expr) {
+  return ffi_wrap<plaidml_datatype>(err, PLAIDML_DATA_INVALID, [&] {
+    IVLOG(3, "plaidml_expr_get_dtype");
+    auto tensorType = expr->value.getType().dyn_cast<mlir::RankedTensorType>();
+    if (!tensorType) {
+      throw std::runtime_error("Expected RankedTensorType");
+    }
+    auto elementType = tensorType.getElementType();
+    auto scalarType = elementType.dyn_cast<ScalarType>();
+    if (!scalarType) {
+      throw std::runtime_error("Expected ScalarType");
+    }
+    return static_cast<plaidml_datatype>(scalarType.type());
+  });
+}
+
+size_t plaidml_expr_get_rank(  //
+    plaidml_error* err,        //
+    plaidml_expr* expr) {
+  return ffi_wrap<size_t>(err, 0, [&] {
+    auto tensorType = expr->value.getType().dyn_cast<mlir::RankedTensorType>();
+    if (!tensorType) {
+      throw std::runtime_error("Expected RankedTensorType");
+    }
+    return tensorType.getRank();
+  });
+}
+
 plaidml_logical_shape* plaidml_expr_get_shape(  //
     plaidml_error* err,                         //
     plaidml_expr* expr) {
@@ -414,9 +444,9 @@ plaidml_expr* plaidml_expr_index_map(  //
       idx_values[i] = raw_idxs[i]->value;
     }
     if (ref) {
-      return new plaidml_expr{GlobalContext::get()->MakeAffineSourceIndexMapOp(ref->value, idx_values)};
+      return new plaidml_expr{GlobalContext::get()->MakeAffineTensorMapOp(ref->value, idx_values)};
     }
-    return new plaidml_expr{GlobalContext::get()->MakeAffineSinkIndexMapOp(idx_values)};
+    return new plaidml_expr{GlobalContext::get()->MakeAffineMapOp(idx_values)};
   });
 }
 
@@ -430,7 +460,7 @@ plaidml_expr* plaidml_expr_size_map(  //
     for (size_t i = 0; i < ndims; i++) {
       dim_values.emplace_back(raw_dims[i]->value);
     }
-    return new plaidml_expr{GlobalContext::get()->MakeAffineSizeMapOp(dim_values)};
+    return new plaidml_expr{GlobalContext::get()->MakeAffineMapOp(dim_values)};
   });
 }
 

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -363,6 +363,16 @@ plaidml_expr* plaidml_expr_cast(  //
   });
 }
 
+plaidml_expr* plaidml_expr_trace(  //
+    plaidml_error* err,            //
+    plaidml_expr* tensor,          //
+    const char* msg) {
+  return ffi_wrap<plaidml_expr*>(err, nullptr, [&] {
+    IVLOG(3, "plaidml_expr_trace");
+    return new plaidml_expr{GlobalContext::get()->MakeTraceOp(tensor->value, msg)};
+  });
+}
+
 plaidml_expr* plaidml_expr_call(  //
     plaidml_error* err,           //
     const char* fn,               //

--- a/plaidml/edsl/ffi.h
+++ b/plaidml/edsl/ffi.h
@@ -167,6 +167,14 @@ void* plaidml_expr_ptr(  //
     plaidml_error* err,  //
     plaidml_expr* expr);
 
+plaidml_datatype plaidml_expr_get_dtype(  //
+    plaidml_error* err,                   //
+    plaidml_expr* expr);
+
+size_t plaidml_expr_get_rank(  //
+    plaidml_error* err,        //
+    plaidml_expr* expr);
+
 plaidml_logical_shape* plaidml_expr_get_shape(  //
     plaidml_error* err,                         //
     plaidml_expr* expr);

--- a/plaidml/edsl/ffi.h
+++ b/plaidml/edsl/ffi.h
@@ -228,6 +228,11 @@ plaidml_expr* plaidml_expr_cast(  //
     plaidml_expr* tensor,         //
     plaidml_datatype dtype);
 
+plaidml_expr* plaidml_expr_trace(  //
+    plaidml_error* err,            //
+    plaidml_expr* tensor,          //
+    const char* msg);
+
 plaidml_expr* plaidml_expr_index_map(  //
     plaidml_error* err,                //
     plaidml_expr* ref,                 //

--- a/plaidml/exec/BUILD
+++ b/plaidml/exec/BUILD
@@ -40,16 +40,6 @@ plaidml_cc_library(
     alwayslink = 1,
 )
 
-plaidml_cc_library(
-    name = "api",
-    hdrs = SDK_HDRS,
-    visibility = ["//visibility:public"],
-    deps = [
-        "//plaidml/core:api",
-        "//plaidml/edsl:api",
-    ],
-)
-
 py_library(
     name = "py",
     srcs = [

--- a/plaidml/op/BUILD
+++ b/plaidml/op/BUILD
@@ -13,13 +13,6 @@ exports_files([
     "ffi.h",
 ])
 
-pkg_tar(
-    name = "include_pkg",
-    srcs = SDK_HDRS,
-    package_dir = "include/plaidml/op",
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "sdk",
     srcs = SDK_HDRS,
@@ -33,6 +26,7 @@ plaidml_cc_library(
     ],
     hdrs = [
         "ffi.h",
+        "op.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -41,17 +35,6 @@ plaidml_cc_library(
         "//plaidml/op/lib",
         "//pmlc/util",
         "@llvm-project//llvm:support",
-    ],
-    alwayslink = 1,
-)
-
-plaidml_cc_library(
-    name = "api",
-    hdrs = SDK_HDRS,
-    visibility = ["//visibility:public"],
-    deps = [
-        "//plaidml/core:api",
-        "//plaidml/edsl:api",
     ],
 )
 
@@ -71,7 +54,6 @@ plaidml_cc_test(
     name = "cc_test",
     srcs = ["op_test.cc"],
     deps = [
-        ":api",
         ":op",
         "//plaidml:testenv",
     ],

--- a/plaidml/op/lib/BUILD
+++ b/plaidml/op/lib/BUILD
@@ -14,7 +14,6 @@ plaidml_cc_library(
     deps = [
         "//plaidml/core",
         "//plaidml/edsl",
-        "//plaidml/op:api",
         "//pmlc/util",
         "@llvm-project//llvm:support",
     ],

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -9,7 +9,6 @@
 
 #include "llvm/Support/FormatVariadic.h"
 
-#include "plaidml/op/op.h"
 #include "pmlc/util/logging.h"
 
 using namespace plaidml::edsl;  // NOLINT

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -53,14 +53,14 @@ TEST(Op, All) {
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 !u8 = type tensor<!eltwise.u8>
 module {
   func @all(%arg0: tensor<1x224x224x3x!eltwise.f32> {tile.name = "I"}) -> !u8 {
-    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
-    %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
+    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %0 = "eltwise.cmp_eq"(%arg0, %c0) : (tensor<1x224x224x3x!eltwise.f32>, !i32) -> tensor<1x224x224x3x!eltwise.u1>
     %1 = "eltwise.select"(%0, %c0, %c1) : (tensor<1x224x224x3x!eltwise.u1>, !i32, !i32) -> tensor<1x224x224x3x!eltwise.i32>
     %2 = tile.cion mul, none, %cst, %1 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x224x224x3x!eltwise.i32> -> !i32
@@ -80,15 +80,15 @@ TEST(Op, Any) {
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 !u1 = type tensor<!eltwise.u1>
 !u8 = type tensor<!eltwise.u8>
 module {
   func @any(%arg0: tensor<1x224x224x3x!eltwise.f32> {tile.name = "I"}) -> !u8 {
-    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
-    %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
+    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %0 = "eltwise.cmp_eq"(%arg0, %c0) : (tensor<1x224x224x3x!eltwise.f32>, !i32) -> tensor<1x224x224x3x!eltwise.u1>
     %1 = "eltwise.select"(%0, %c0, %c1) : (tensor<1x224x224x3x!eltwise.u1>, !i32, !i32) -> tensor<1x224x224x3x!eltwise.i32>
     %2 = tile.cion add, none, %cst, %1 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x224x224x3x!eltwise.i32> -> !i32
@@ -110,13 +110,13 @@ TEST(Op, Argmax) {
 #map1 = affine_map<() -> ()>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 !u32 = type tensor<!eltwise.u32>
 module {
   func @argmax(%arg0: tensor<1x224x224x3x!eltwise.f32> {tile.name = "I"}) -> !u32 {
-    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
     %0 = tile.cion assign, none, %cst, %c1 {sink = #map0, srcs = [#map1]} : !f32, !i32 -> tensor<1x224x224x3x!eltwise.i32>
     %1 = "tile.index"(%0) {dim = 0 : i64} : (tensor<1x224x224x3x!eltwise.i32>) -> tensor<1x224x224x3x!eltwise.i32>
     %2 = tile.cion max, none, %cst, %arg0 {sink = #map1, srcs = [#map0]} : !f32, tensor<1x224x224x3x!eltwise.f32> -> !f32
@@ -135,17 +135,17 @@ TEST(Op, BinaryCrossentropy) {
   IVLOG(1, program);
   EXPECT_THAT(program, Eq(R"#(
 
-!f32 = type tensor<!eltwise.f32>
 !i32 = type tensor<!eltwise.i32>
+!f32 = type tensor<!eltwise.f32>
 module {
   func @binary_crossentropy(%arg0: tensor<7x7x3x64x!eltwise.f32> {tile.name = "O"}, %arg1: tensor<7x7x3x64x!eltwise.f32> {tile.name = "I"}) -> tensor<7x7x3x64x!eltwise.f32> {
-    %cst = "eltwise.sconst"() {value = 1.000000e+00 : f64} : () -> !f32
-    %cst_0 = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
     %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
-    %0 = "eltwise.cmp_gt"(%arg0, %cst_0) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.u1>
-    %1 = "eltwise.select"(%0, %arg0, %cst_0) : (tensor<7x7x3x64x!eltwise.u1>, tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
-    %2 = "eltwise.cmp_lt"(%1, %cst) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.u1>
-    %3 = "eltwise.select"(%2, %1, %cst) : (tensor<7x7x3x64x!eltwise.u1>, tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
+    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %cst_0 = "eltwise.sconst"() {value = 1.000000e+00 : f64} : () -> !f32
+    %0 = "eltwise.cmp_gt"(%arg0, %cst) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.u1>
+    %1 = "eltwise.select"(%0, %arg0, %cst) : (tensor<7x7x3x64x!eltwise.u1>, tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
+    %2 = "eltwise.cmp_lt"(%1, %cst_0) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.u1>
+    %3 = "eltwise.select"(%2, %1, %cst_0) : (tensor<7x7x3x64x!eltwise.u1>, tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
     %4 = "eltwise.sub"(%c1, %3) : (!i32, tensor<7x7x3x64x!eltwise.f32>) -> tensor<7x7x3x64x!eltwise.f32>
     %5 = "eltwise.log"(%4) : (tensor<7x7x3x64x!eltwise.f32>) -> tensor<7x7x3x64x!eltwise.f32>
     %6 = "eltwise.ident"(%arg1) : (tensor<7x7x3x64x!eltwise.f32>) -> tensor<7x7x3x64x!eltwise.f32>
@@ -314,12 +314,12 @@ TEST(Op, Elu) {
   IVLOG(1, program);
   EXPECT_THAT(program, Eq(R"#(
 
-!f32 = type tensor<!eltwise.f32>
 !i32 = type tensor<!eltwise.i32>
+!f32 = type tensor<!eltwise.f32>
 module {
   func @elu(%arg0: tensor<7x7x3x64x!eltwise.f32> {tile.name = "I"}) -> tensor<7x7x3x64x!eltwise.f32> {
-    %cst = "eltwise.sconst"() {value = 1.000000e-01 : f64} : () -> !f32
     %c0 = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
+    %cst = "eltwise.sconst"() {value = 1.000000e-01 : f64} : () -> !f32
     %0 = "eltwise.exp"(%arg0) : (tensor<7x7x3x64x!eltwise.f32>) -> tensor<7x7x3x64x!eltwise.f32>
     %1 = "eltwise.mul"(%0, %cst) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
     %2 = "eltwise.sub"(%1, %cst) : (tensor<7x7x3x64x!eltwise.f32>, !f32) -> tensor<7x7x3x64x!eltwise.f32>
@@ -380,18 +380,18 @@ TEST(Op, HardSigmoid) {
 !f32 = type tensor<!eltwise.f32>
 module {
   func @hard_sigmoid(%arg0: tensor<10x20x!eltwise.f32> {tile.name = "A"}) -> tensor<10x20x!eltwise.f32> {
-    %cst = "eltwise.sconst"() {value = 5.000000e-01 : f64} : () -> !f32
-    %cst_0 = "eltwise.sconst"() {value = 5.000000e-02 : f64} : () -> !f32
-    %cst_1 = "eltwise.sconst"() {value = 1.000000e+00 : f64} : () -> !f32
-    %cst_2 = "eltwise.sconst"() {value = 1.000000e+01 : f64} : () -> !f32
-    %cst_3 = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %cst_4 = "eltwise.sconst"() {value = -1.000000e+01 : f64} : () -> !f32
-    %0 = "eltwise.mul"(%arg0, %cst_0) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.f32>
-    %1 = "eltwise.add"(%0, %cst) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.f32>
-    %2 = "eltwise.cmp_gt"(%arg0, %cst_2) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.u1>
-    %3 = "eltwise.select"(%2, %cst_1, %1) : (tensor<10x20x!eltwise.u1>, !f32, tensor<10x20x!eltwise.f32>) -> tensor<10x20x!eltwise.f32>
-    %4 = "eltwise.cmp_lt"(%arg0, %cst_4) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.u1>
-    %5 = "eltwise.select"(%4, %cst_3, %3) : (tensor<10x20x!eltwise.u1>, !f32, tensor<10x20x!eltwise.f32>) -> tensor<10x20x!eltwise.f32>
+    %cst = "eltwise.sconst"() {value = -1.000000e+01 : f64} : () -> !f32
+    %cst_0 = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %cst_1 = "eltwise.sconst"() {value = 1.000000e+01 : f64} : () -> !f32
+    %cst_2 = "eltwise.sconst"() {value = 1.000000e+00 : f64} : () -> !f32
+    %cst_3 = "eltwise.sconst"() {value = 5.000000e-02 : f64} : () -> !f32
+    %cst_4 = "eltwise.sconst"() {value = 5.000000e-01 : f64} : () -> !f32
+    %0 = "eltwise.mul"(%arg0, %cst_3) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.f32>
+    %1 = "eltwise.add"(%0, %cst_4) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.f32>
+    %2 = "eltwise.cmp_gt"(%arg0, %cst_1) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.u1>
+    %3 = "eltwise.select"(%2, %cst_2, %1) : (tensor<10x20x!eltwise.u1>, !f32, tensor<10x20x!eltwise.f32>) -> tensor<10x20x!eltwise.f32>
+    %4 = "eltwise.cmp_lt"(%arg0, %cst) : (tensor<10x20x!eltwise.f32>, !f32) -> tensor<10x20x!eltwise.u1>
+    %5 = "eltwise.select"(%4, %cst_0, %3) : (tensor<10x20x!eltwise.u1>, !f32, tensor<10x20x!eltwise.f32>) -> tensor<10x20x!eltwise.f32>
     return %5 : tensor<10x20x!eltwise.f32>
   }
 }
@@ -451,12 +451,12 @@ TEST(Op, Mean) {
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 module {
   func @mean(%arg0: tensor<10x20x!eltwise.f32> {tile.name = "A"}) -> !f32 {
-    %c200 = "eltwise.sconst"() {value = 200 : index} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c200 = "eltwise.sconst"() {value = 200 : i64} : () -> !i32
     %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<10x20x!eltwise.f32> -> !f32
     %1 = "eltwise.div"(%0, %c200) : (!f32, !i32) -> !f32
     return %1 : !f32
@@ -676,8 +676,8 @@ TEST(Op, Reshape) {
   EXPECT_THAT(program, Eq(R"#(
 module {
   func @reshape(%arg0: tensor<10x20x!eltwise.f32> {tile.name = "A"}) -> tensor<20x10x!eltwise.f32> {
-    %c10 = tile.affine_const 10
     %c20 = tile.affine_const 20
+    %c10 = tile.affine_const 10
     %0 = "tile.reshape"(%arg0, %c20, %c10) : (tensor<10x20x!eltwise.f32>, index, index) -> tensor<20x10x!eltwise.f32>
     return %0 : tensor<20x10x!eltwise.f32>
   }
@@ -824,8 +824,8 @@ TEST(Op, Squeeze) {
   EXPECT_THAT(program, Eq(R"#(
 module {
   func @squeeze(%arg0: tensor<32x1x4x1x!eltwise.f32> {tile.name = "A"}) -> tensor<32x4x!eltwise.f32> {
-    %c4 = tile.affine_const 4
     %c32 = tile.affine_const 32
+    %c4 = tile.affine_const 4
     %0 = "tile.reshape"(%arg0, %c32, %c4) : (tensor<32x1x4x1x!eltwise.f32>, index, index) -> tensor<32x4x!eltwise.f32>
     return %0 : tensor<32x4x!eltwise.f32>
   }
@@ -887,12 +887,12 @@ TEST(Op, Variance) {
 #map3 = affine_map<(d0, d1) -> (d0, d1)>
 
 
-!i32 = type tensor<!eltwise.i32>
 !f32 = type tensor<!eltwise.f32>
+!i32 = type tensor<!eltwise.i32>
 module {
   func @variance(%arg0: tensor<10x20x!eltwise.f32> {tile.name = "A"}) -> !f32 {
-    %c200 = "eltwise.sconst"() {value = 200 : index} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
+    %c200 = "eltwise.sconst"() {value = 200 : i64} : () -> !i32
     %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<10x20x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %1 = "eltwise.div"(%0, %c200) : (tensor<1x1x!eltwise.f32>, !i32) -> tensor<1x1x!eltwise.f32>
     %2 = "eltwise.sub"(%arg0, %1) : (tensor<10x20x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<10x20x!eltwise.f32>

--- a/plaidml/plaidml_link.jsonnet
+++ b/plaidml/plaidml_link.jsonnet
@@ -54,6 +54,8 @@ local exports = [
   'plaidml_dim_expr_op',
   'plaidml_expr_free',
   'plaidml_expr_ptr',
+  'plaidml_expr_get_dtype',
+  'plaidml_expr_get_rank',
   'plaidml_expr_get_shape',
   'plaidml_expr_bind_shape',
   'plaidml_expr_bind_dims',

--- a/plaidml/plaidml_link.jsonnet
+++ b/plaidml/plaidml_link.jsonnet
@@ -67,6 +67,7 @@ local exports = [
   'plaidml_expr_float',
   'plaidml_expr_cast',
   'plaidml_expr_call',
+  'plaidml_expr_trace',
   'plaidml_expr_index_map',
   'plaidml_expr_size_map',
   'plaidml_expr_contraction',

--- a/pmlc/compiler/compiler.cc
+++ b/pmlc/compiler/compiler.cc
@@ -13,6 +13,7 @@
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/DebugStringHelper.h"
 #include "mlir/Target/LLVMIR.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -108,6 +109,7 @@ Executable::Executable(StringRef entry, StringRef target, ModuleOp programModule
   auto shouldPrintAfterPass = [](auto, auto) { return VLOG_IS_ON(3); };
   manager.enableIRPrinting(shouldPrintBeforePass, shouldPrintAfterPass, true, false, llvm::errs());
 
+  manager.addNestedPass<FuncOp>(createCanonicalizerPass());
   manager.addPass(dialect::tile::createComputeBoundsPass());
   manager.addNestedPass<FuncOp>(createCanonicalizerPass());
   manager.addNestedPass<FuncOp>(createCSEPass());

--- a/pmlc/compiler/registry.cc
+++ b/pmlc/compiler/registry.cc
@@ -22,7 +22,7 @@ class TargetRegistry {
     return &registry;
   }
 
-  void registerTarget(StringRef name, const TargetRegistryFunction& function) {  //
+  void registerTarget(StringRef name, const TargetRegistryFunction& function) {
     if (registry.count(name)) {
       throw std::runtime_error(formatv("Target is already registered: {0}", name));
     }

--- a/pmlc/compiler/registry.h
+++ b/pmlc/compiler/registry.h
@@ -13,7 +13,7 @@ class OpPassManager;
 
 namespace pmlc::compiler {
 
-using TargetRegistryFunction = std::function<void(mlir::OpPassManager*)>;
+using TargetRegistryFunction = std::function<void(mlir::OpPassManager&)>;
 
 void registerTarget(llvm::StringRef name, const TargetRegistryFunction& function);
 TargetRegistryFunction resolveTarget(llvm::StringRef name);

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -843,6 +843,6 @@ std::unique_ptr<mlir::Pass> createLowerTileToPXAPass() {  //
 
 static mlir::PassRegistration<LoweringPass> legalize_pass(  //
     "convert-tile-to-pxa",                                  //
-    "Convert from Tile dialect to PXA dialect");
+    "Convert Tile dialect to PXA dialect");
 
 }  // namespace pmlc::conversion::tile_to_pxa

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -34,6 +34,7 @@ using dialect::tile::ContractionOpOperandAdaptor;
 using dialect::tile::IndexOp;
 using dialect::tile::ShapeOp;
 using dialect::tile::ShapeOpOperandAdaptor;
+using dialect::tile::TraceOp;
 using util::DataType;
 
 using llvm::Optional;
@@ -47,10 +48,12 @@ using mlir::AffineStoreOp;
 using mlir::AllocOp;
 using mlir::ArrayRef;
 using mlir::Attribute;
+using mlir::CallOp;
 using mlir::CmpFPredicate;
 using mlir::CmpIPredicate;
 using mlir::ConversionPattern;
 using mlir::ConversionPatternRewriter;
+using mlir::FlatSymbolRefAttr;
 using mlir::FloatAttr;
 using mlir::FloatType;
 using mlir::FuncOp;
@@ -60,6 +63,7 @@ using mlir::IntegerType;
 using mlir::Location;
 using mlir::MemRefType;
 using mlir::MLIRContext;
+using mlir::ModuleOp;
 using mlir::NamedAttribute;
 using mlir::OpBuilder;
 using mlir::OpConversionPattern;
@@ -69,6 +73,8 @@ using mlir::Pattern;
 using mlir::PatternMatchResult;
 using mlir::RankedTensorType;
 using mlir::ReturnOp;
+using mlir::StringAttr;
+using mlir::SymbolRefAttr;
 using mlir::Type;
 using mlir::Value;
 
@@ -148,6 +154,7 @@ struct AffineConstantOpConversion : public OpConversionPattern<AffineConstantOp>
       ArrayRef<Value> operands,        //
       ConversionPatternRewriter& rewriter) const final {
     auto value = op.getValue().cast<IntegerAttr>().getInt();
+    // rewriter.replaceOpWithNewOp<mlir::ConstantIndexOp>(op, value);
     auto newOp = rewriter.create<mlir::ConstantIndexOp>(op.getLoc(), value);
     rewriter.replaceOp(op, {newOp});
     return matchSuccess();
@@ -416,6 +423,7 @@ struct EltwiseOpConversion : public OpConversionPattern<FromOpType> {
   using OpConversionPattern<FromOpType>::OpConversionPattern;
 
   PatternMatchResult match(Operation* op) const final {
+    IVLOG(2, "EltwiseOpConversion::match>");
     Matcher pred;
     return pred(op);
   }
@@ -486,6 +494,7 @@ struct ContractionOpConversion : public OpConversionPattern<ContractionOp> {
   using OpConversionPattern<ContractionOp>::OpConversionPattern;
 
   PatternMatchResult match(Operation* op) const final {
+    IVLOG(2, "ContractionOpConversion::match>");
     if (auto cionOp = llvm::dyn_cast<ContractionOp>(op)) {
       if (cionOp.combo() != comboKind) {
         return matchFailure();
@@ -735,6 +744,7 @@ struct ReturnOpConversion : public OpConversionPattern<ReturnOp> {
       ReturnOp op,                     //
       ArrayRef<Value> operands,        //
       ConversionPatternRewriter& rewriter) const final {
+    IVLOG(2, "ReturnOpConversion::matchAndRewrite>");
     auto& block = op.getParentRegion()->front();
     auto funcOp = op.getParentOfType<FuncOp>();
     auto blockArg = funcOp.getType().getNumInputs() - op.getNumOperands();
@@ -746,6 +756,34 @@ struct ReturnOpConversion : public OpConversionPattern<ReturnOp> {
   }
 };
 
+struct TraceOpConversion : public OpConversionPattern<TraceOp> {
+  using OpConversionPattern<TraceOp>::OpConversionPattern;
+
+  PatternMatchResult matchAndRewrite(  //
+      TraceOp op,                      //
+      ArrayRef<Value> operands,        //
+      ConversionPatternRewriter& rewriter) const final {
+    // auto module = op.getParentOfType<ModuleOp>();
+    // auto symbol = createStubFunc(module, op.msgAttr());
+    // rewriter.create<CallOp>(op.getLoc(), symbol, ArrayRef<Type>{});
+    rewriter.replaceOp(op, op.tensor());
+    return matchSuccess();
+  }
+
+  FlatSymbolRefAttr createStubFunc(ModuleOp module, StringAttr msg) const {
+    static unsigned uniqueId = 0;
+    auto symbol = llvm::formatv("plaidml_rt_trace_{0}", uniqueId++).str();
+    auto context = module.getContext();
+    OpBuilder builder(context);
+    builder.setInsertionPointToStart(module.getBody());
+    auto funcType = FunctionType::get({}, {}, context);
+    auto funcOp = builder.create<FuncOp>(module.getLoc(), symbol, funcType, ArrayRef<NamedAttribute>{});
+    funcOp.setAttr("msg", msg);
+    funcOp.setAttr("trace", mlir::UnitAttr::get(context));
+    return SymbolRefAttr::get(symbol, context);
+  }
+};
+
 struct LoweringPass : public mlir::ModulePass<LoweringPass> {
   void runOnModule() final {
     // Set up target (i.e. what is legal)
@@ -754,11 +792,11 @@ struct LoweringPass : public mlir::ModulePass<LoweringPass> {
     target.addLegalDialect<mlir::StandardOpsDialect>();
     target.addLegalDialect<dialect::pxa::Dialect>();
     target.addLegalOp<mlir::ModuleOp, mlir::ModuleTerminatorOp>();
-    target.addDynamicallyLegalOp<FuncOp>([&](FuncOp op) {
+    target.addDynamicallyLegalOp<FuncOp>([](FuncOp op) {
       auto funcType = op.getType();
       return funcType.getNumResults() == 0;
     });
-    target.addDynamicallyLegalOp<ReturnOp>([&](ReturnOp op) {  //
+    target.addDynamicallyLegalOp<ReturnOp>([](ReturnOp op) {  //
       return op.getNumOperands() == 0;
     });
 
@@ -773,9 +811,10 @@ struct LoweringPass : public mlir::ModulePass<LoweringPass> {
         CastOpConversion,            //
         FuncOpConversion,            //
         IndexOpConversion,           //
+        ReturnOpConversion,          //
         ScalarConstantOpConversion,  //
         ShapeOpConversion,           //
-        ReturnOpConversion,          //
+        TraceOpConversion,           //
         // TODO: PrngOpConversion
         // TODO: SpecialOpConversion (GatherOp, ReshapeOp, ScatterOp, ZeroOp)
         ContractionOpConversion<CombinationKind::none, FirstOperand>,
@@ -827,8 +866,6 @@ struct LoweringPass : public mlir::ModulePass<LoweringPass> {
 
     // Run the conversion
     if (failed(applyFullConversion(getModule(), target, patterns, nullptr))) {
-      getModule().dump();
-      emitError(mlir::UnknownLoc::get(&getContext()), "Error lowering tile -> pxa\n");
       signalPassFailure();
       return;
     }

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -154,9 +154,7 @@ struct AffineConstantOpConversion : public OpConversionPattern<AffineConstantOp>
       ArrayRef<Value> operands,        //
       ConversionPatternRewriter& rewriter) const final {
     auto value = op.getValue().cast<IntegerAttr>().getInt();
-    // rewriter.replaceOpWithNewOp<mlir::ConstantIndexOp>(op, value);
-    auto newOp = rewriter.create<mlir::ConstantIndexOp>(op.getLoc(), value);
-    rewriter.replaceOp(op, {newOp});
+    rewriter.replaceOpWithNewOp<mlir::ConstantIndexOp>(op, value);
     return matchSuccess();
   }
 };
@@ -179,8 +177,7 @@ struct ScalarConstantOpConversion : public OpConversionPattern<ew::ScalarConstan
     } else {
       llvm_unreachable("Invalid scalar constant op");
     }
-    auto newOp = rewriter.create<mlir::ConstantOp>(op.getLoc(), stdType, value);
-    rewriter.replaceOp(op, {newOp});
+    rewriter.replaceOpWithNewOp<mlir::ConstantOp>(op, stdType, value);
     return matchSuccess();
   }
 };

--- a/pmlc/dialect/eltwise/ir/dialect.cc
+++ b/pmlc/dialect/eltwise/ir/dialect.cc
@@ -78,6 +78,7 @@ std::string Dialect::getCanonicalOpName(llvm::StringRef name) {
 mlir::Type Dialect::parseType(mlir::DialectAsmParser& parser) const {
   auto dtype = util::symbolizeDataType(parser.getFullSymbolSpec());
   if (!dtype.hasValue()) {
+    parser.emitError(parser.getNameLoc(), "unknown eltwise type: ") << parser.getFullSymbolSpec();
     return {};
   }
   return ScalarType::get(getContext(), dtype.getValue());

--- a/pmlc/dialect/eltwise/ir/ops.cc
+++ b/pmlc/dialect/eltwise/ir/ops.cc
@@ -7,8 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "llvm/ADT/StringSwitch.h"
-
 #include "mlir/Dialect/StandardOps/Ops.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"

--- a/pmlc/dialect/tile/builder.h
+++ b/pmlc/dialect/tile/builder.h
@@ -80,6 +80,7 @@ class TileBuilder {
   mlir::Value MakeScalarConstantOp(double value);
   mlir::Value MakePrimitiveOp(llvm::StringRef fn, llvm::ArrayRef<mlir::Value> args);
   mlir::Value MakeCastOp(mlir::Value tensor, DataType dtype);
+  mlir::Value MakeTraceOp(mlir::Value tensor, const char* msg);
   mlir::Value MakeDimOp(mlir::Value tensor, unsigned dim);
   mlir::Value MakePlaceholderOp(mlir::RankedTensorType type, pmlc::util::BufferPtr buffer, llvm::StringRef name);
   mlir::Value MakeAffineConstantOp(int64_t value);

--- a/pmlc/dialect/tile/builder.h
+++ b/pmlc/dialect/tile/builder.h
@@ -92,9 +92,8 @@ class TileBuilder {
   mlir::Value MakeAffineNegOp(llvm::ArrayRef<mlir::Value> args);
   mlir::Value MakeAffineMaxOp(llvm::ArrayRef<mlir::Value> args);
   mlir::Value MakeAffineMinOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineSourceIndexMapOp(mlir::Value tensor, llvm::ArrayRef<mlir::Value> idxs);
-  mlir::Value MakeAffineSinkIndexMapOp(llvm::ArrayRef<mlir::Value> idxs);
-  mlir::Value MakeAffineSizeMapOp(llvm::ArrayRef<mlir::Value> sizes);
+  mlir::Value MakeAffineTensorMapOp(mlir::Value tensor, llvm::ArrayRef<mlir::Value> idxs);
+  mlir::Value MakeAffineMapOp(llvm::ArrayRef<mlir::Value> idxs);
 
   mlir::Value MakeContractionOp(         //
       util::AggregationKind agg,         //

--- a/pmlc/dialect/tile/gradient.cc
+++ b/pmlc/dialect/tile/gradient.cc
@@ -194,8 +194,8 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out, size_
           for (const auto& dim : llvm::cast<AffineMapOp>(op.sink().getDefiningOp()).dims()) {
             dout_idxs.push_back(dim);
           }
-          new_srcs.push_back(builder_->MakeAffineSourceIndexMapOp(op, dout_idxs));
-          new_srcs.push_back(builder_->MakeAffineSourceIndexMapOp(dout, dout_idxs));
+          new_srcs.push_back(builder_->MakeAffineTensorMapOp(op, dout_idxs));
+          new_srcs.push_back(builder_->MakeAffineTensorMapOp(dout, dout_idxs));
           // Also track that this is the differentiated source for later use
           target_src = src;
         } else {
@@ -214,7 +214,7 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out, size_
           for (const auto& dim : llvm::cast<AffineMapOp>(op.sink().getDefiningOp()).dims()) {
             dout_idxs.push_back(dim);
           }
-          new_srcs.push_back(builder_->MakeAffineSourceIndexMapOp(dout, dout_idxs));
+          new_srcs.push_back(builder_->MakeAffineTensorMapOp(dout, dout_idxs));
           // Also track that this is the differentiated source for later use
           target_src = src;
         } else {
@@ -274,12 +274,12 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out, size_
   // if (src_name) {
   //   new_name = llvm::formatv("d{0}", op.name()).str();
   // } // else use the empty string (already initialized by default ctor)
-  auto dop_val = builder_->MakeContractionOp(         //
-      util::AggregationKind::add,                     //
-      combo_kind,                                     //
-      new_srcs,                                       //
-      builder_->MakeAffineSinkIndexMapOp(dsrc_idxs),  //
-      builder_->MakeAffineSizeMapOp(sizes),           //
+  auto dop_val = builder_->MakeContractionOp(  //
+      util::AggregationKind::add,              //
+      combo_kind,                              //
+      new_srcs,                                //
+      builder_->MakeAffineMapOp(dsrc_idxs),    //
+      builder_->MakeAffineMapOp(sizes),        //
       new_name);
   // Copy the constraints from the forward pass contraction
   auto src_cons = llvm::dyn_cast<AffineConstraintsOp>(op.cons().getDefiningOp());

--- a/pmlc/dialect/tile/ir/dialect.cc
+++ b/pmlc/dialect/tile/ir/dialect.cc
@@ -95,7 +95,7 @@ Operation* Dialect::materializeConstant(  //
     Attribute value,                      //
     Type type,                            //
     Location loc) {
-  IVLOG(5, "tile::Dialect::materializeConstant");
+  IVLOG(5, "tile::Dialect::materializeConstant> " << mlir::debugString(value) << " : " << mlir::debugString(type));
   if (auto attr = value.dyn_cast<IntegerAttr>()) {
     auto indexType = builder.getIndexType();
     auto indexAttr = builder.getIntegerAttr(indexType, attr.getInt());

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -327,7 +327,10 @@ def ReshapeOp : SpecialOp<"reshape">, HasCanonicalizer {
 
 def ScatterOp : SpecialOp<"scatter">, HasCanonicalizer {
   let summary = "special scatter operation";
-  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, RankedTensorOf<[ScalarIndex]>:$dims, RankedTensorOf<[AnyScalar]>:$other);
+  let arguments = (ins
+    RankedTensorOf<[AnyScalar]>:$tensor,
+    RankedTensorOf<[ScalarIndex]>:$dims,
+    RankedTensorOf<[AnyScalar]>:$other);
   let results = (outs RankedTensorOf<[AnyScalar]>:$result);
 }
 
@@ -335,4 +338,18 @@ def ShapeOp : SpecialOp<"shape">, HasCanonicalizer {
   let summary = "tensor shape operation";
   let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor);
   let results = (outs RankedTensorOf<[ScalarIndex]>:$result);
+}
+
+def TraceOp : Op<TileDialect, "trace", []>, HasCanonicalizer {
+  let summary = "tracepoint operation";
+  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, StrAttr:$msg);
+  let results = (outs RankedTensorOf<[AnyScalar]>:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, Value tensor, StringRef msg", [{
+      result.addTypes(tensor.getType());
+      result.addOperands(tensor);
+      result.addAttribute("msg", builder->getStringAttr(msg));
+    }]
+  >];
 }

--- a/pmlc/dialect/tile/transforms/contraction.cc
+++ b/pmlc/dialect/tile/transforms/contraction.cc
@@ -752,8 +752,7 @@ void ComputeBoundsPass::runOnFunction() {
 }
 
 std::unique_ptr<mlir::OpPassBase<mlir::FuncOp>> createComputeBoundsPass() {
-  std::unique_ptr<mlir::OpPassBase<mlir::FuncOp>> pass = std::make_unique<ComputeBoundsPass>();
-  return pass;
+  return std::make_unique<ComputeBoundsPass>();
 }
 
 }  // namespace pmlc::dialect::tile

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -2,30 +2,81 @@
 
 #include "mlir/Conversion/LoopToStandard/ConvertLoopToStandard.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
 
 #include "pmlc/compiler/registry.h"
 #include "pmlc/conversion/pxa_to_affine/pxa_to_affine.h"
+#include "pmlc/util/logging.h"
 
 using namespace mlir;  // NOLINT[build/namespaces]
 using pmlc::conversion::pxa_to_affine::createLowerPXAToAffinePass;
 
 namespace pmlc::target::x86 {
 
-static compiler::TargetRegistration pipeline("llvm_cpu", [](OpPassManager* pm) {
+namespace {
+
+struct TraceLinkingPass : public OperationPass<TraceLinkingPass, LLVM::LLVMFuncOp> {
+  void runOnOperation() override {
+    auto op = getOperation();
+    if (!op.getAttrOfType<UnitAttr>("trace")) {
+      return;
+    }
+    IVLOG(1, "TraceLinkingPass");
+    auto context = op.getContext();
+    auto module = op.getParentOfType<ModuleOp>();
+    auto ref = getOrInsertTrace(module);
+    auto block = op.addEntryBlock();
+    auto dialect = context->getRegisteredDialect<LLVM::LLVMDialect>();
+    auto voidTy = LLVM::LLVMType::getVoidTy(dialect);
+    OpBuilder builder(context);
+    builder.setInsertionPointToStart(block);
+    auto args = ArrayRef<Value>{};
+    builder.create<LLVM::CallOp>(op.getLoc(), voidTy, ref, args);
+    builder.create<LLVM::ReturnOp>(op.getLoc(), args);
+  }
+
+  FlatSymbolRefAttr getOrInsertTrace(ModuleOp module) {
+    const char* symbol = "plaidml_rt_trace";
+    auto context = module.getContext();
+    if (module.lookupSymbol(symbol)) {
+      return SymbolRefAttr::get(symbol, context);
+    }
+    OpBuilder builder(context);
+    builder.setInsertionPointToStart(module.getBody());
+    auto dialect = context->getRegisteredDialect<LLVM::LLVMDialect>();
+    auto voidTy = LLVM::LLVMType::getVoidTy(dialect);
+    auto msgTy = LLVM::LLVMType::getInt8PtrTy(dialect);
+    auto funcType = LLVM::LLVMType::getFunctionTy(voidTy, {msgTy}, false);
+    builder.create<LLVM::LLVMFuncOp>(module.getLoc(), symbol, funcType);
+    return SymbolRefAttr::get(symbol, context);
+  }
+
+  static std::unique_ptr<Pass> create() { return std::make_unique<TraceLinkingPass>(); }
+};
+
+void addToPipeline(OpPassManager& pm) {
   // TODO: do optimizations here
 
-  pm->addPass(createLowerPXAToAffinePass());
-  pm->addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm->addNestedPass<FuncOp>(createCSEPass());
+  pm.addPass(createLowerPXAToAffinePass());
+  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<FuncOp>(createCSEPass());
 
-  pm->addPass(createLowerAffinePass());
-  pm->addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm->addNestedPass<FuncOp>(createCSEPass());
+  pm.addPass(createLowerAffinePass());
+  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<FuncOp>(createCSEPass());
 
-  pm->addPass(createLowerToLLVMPass(true));
-});
+  pm.addPass(createLowerToLLVMPass(true));
+  // pm.addPass(TraceLinkingPass::create());
+}
+
+static PassPipelineRegistration<> passPipelineReg("target-cpu", "Target pipeline for CPU", addToPipeline);
+static compiler::TargetRegistration targetReg("llvm_cpu", addToPipeline);
+
+}  // namespace
 
 }  // namespace pmlc::target::x86

--- a/pmlc/tools/pmlc-opt/pmlc-opt.cc
+++ b/pmlc/tools/pmlc-opt/pmlc-opt.cc
@@ -54,7 +54,6 @@ int main(int argc, char** argv) {
     IVLOG(level, "PLAIDML_VERBOSE=" << level);
   }
 
-  PrettyStackTraceProgram x(argc, argv);
   InitLLVM y(argc, argv);
 
   // Register any pass manager command line options.

--- a/pmlc/util/util.cc
+++ b/pmlc/util/util.cc
@@ -4,19 +4,26 @@
 
 #include "mlir/IR/Function.h"
 
+using mlir::FuncOp;
+using mlir::FunctionType;
+using mlir::Operation;
+using mlir::OperationName;
+using mlir::SmallVector;
+using mlir::Type;
+
 namespace pmlc::util {
 
-llvm::StringRef getOpName(const mlir::OperationName& name) {
+llvm::StringRef getOpName(const OperationName& name) {
   return name.getStringRef().drop_front(name.getDialect().size() + 1);
 }
 
-void UpdateFuncOpType(mlir::Operation* op) {
-  if (auto funcOp = op->getParentOfType<mlir::FuncOp>()) {
+void UpdateFuncOpType(Operation* op) {
+  if (auto funcOp = op->getParentOfType<FuncOp>()) {
     auto retOp = &funcOp.getOperation()->getRegion(0).front().back();
     auto funcType = funcOp.getType();
     if (funcType.getNumResults() == retOp->getNumOperands()) {
-      mlir::SmallVector<mlir::Type, 4> retTypes(retOp->getOperandTypes());
-      auto newType = mlir::FunctionType::get(funcType.getInputs(), retTypes, funcOp.getContext());
+      SmallVector<Type, 4> retTypes(retOp->getOperandTypes());
+      auto newType = FunctionType::get(funcType.getInputs(), retTypes, funcOp.getContext());
       if (funcType != newType) {
         funcOp.setType(newType);
       }


### PR DESCRIPTION
* Use a forward (top-to-bottom) pass for initial canonicalization when creating a program (turning `tile.sym_cion` into `tile.cion` and computing static shapes).
* Rename `Tensor::shape()` to `Tensor::compute_shape()` and replace most usages of `tensor.shape()` with new APIs:
  * Tensor::dtype()
  * Tensor::rank()
* Make it easier to use the resnet50 EDSL model in different situations:
  * benchmarking
  * running from command line
* Add a new TraceOp to the EDSL and tile dialects. Still WIP, starting lowering into a `std.call` but still need to complete stub generation during LLVM dialect lowering.
