### PR TITLE
Add nbstripout to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
         args:
           - --filter=-legal/copyright,-readability/todo,-build/c++11
           - --linelength=120
+      - id: nbstripout
+        name: nbstripout
+        entry: nbstripout
+        language: python
+        files: '\.ipynb$'
       - id: yapf
         name: yapf
         entry: yapf

--- a/environment-windows.yml
+++ b/environment-windows.yml
@@ -10,6 +10,7 @@ dependencies:
   - pyyaml
   - pip:
     - cpplint==1.4.4
+    - nbstripout
     - yapf==0.27.0
     - win32event
     - certifi

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,5 @@ dependencies:
   - pyyaml=5.1.2
   - pip:
     - cpplint==1.4.4
+    - nbstripout
     - yapf==0.27.0


### PR DESCRIPTION
This will enable cleaner committing of python notebooks