### PR TITLE
Add compiler API to convert tile source code into Program

### DIFF
--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -986,7 +986,6 @@ plaidml_program* plaidml_compile(  //
 
     auto program = GlobalContext::get()->MakeProgram(name, mutations, *floatx_dtype, *intx_dtype);
     auto ret = new plaidml_program{program};
-    assert(noutputs <= ret->program->outputs.size());
     auto nargs = ret->program->arguments.size();
     auto args = new plaidml_program_arg[nargs];
     for (unsigned i = 0; i < nargs; i++) {

--- a/pmlc/compiler/compiler.cc
+++ b/pmlc/compiler/compiler.cc
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/StandardOps/Ops.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
+#include "mlir/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/DebugStringHelper.h"
@@ -113,6 +114,15 @@ void Executable::initialize() {
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();
   initializeLLVMPasses();
+}
+
+Program::Program(mlir::ModuleOp module) : module(module) {}
+
+Program::Program(mlir::StringRef source) {
+  auto inputBuffer = llvm::MemoryBuffer::getMemBuffer(source);
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(inputBuffer), llvm::SMLoc());
+  module = mlir::parseSourceFile(sourceMgr, &context);
 }
 
 void Program::compile(StringRef target, bool collectPasses) {

--- a/pmlc/compiler/compiler.h
+++ b/pmlc/compiler/compiler.h
@@ -35,11 +35,12 @@ struct Program {
   std::string entry;
   std::string tileIR;
   mlir::OwningModuleRef module;
-  std::vector<mlir::Value> outputs;
   std::vector<ProgramArgument> arguments;
   std::vector<PassInfo> passes;
+  mlir::MLIRContext context;
 
-  explicit Program(mlir::ModuleOp module) : module(module) {}
+  explicit Program(mlir::ModuleOp module);
+  explicit Program(mlir::StringRef source);
 
   void compile(mlir::StringRef target, bool collectPasses = false);
 


### PR DESCRIPTION
This is can be used to turn the textual representation of the tile dialect into a `Program`, which can then be used for running compiler passes.

Note: This doesn't yet populate the `arguments`, which is needed for execution. Let me know if you need that.