### PR TITLE
Improve testing for xsmm op

### DIFF
--- a/pmlc/dialect/pxa/analysis/BUILD
+++ b/pmlc/dialect/pxa/analysis/BUILD
@@ -16,4 +16,3 @@ plaidml_cc_library(
         "//pmlc/dialect/pxa/ir",
     ],
 )
-

--- a/pmlc/dialect/pxa/analysis/strides.h
+++ b/pmlc/dialect/pxa/analysis/strides.h
@@ -15,9 +15,12 @@ namespace mlir {
 // the loop moves a pure affine expression by a fixed distance, 'strides' holds
 // that distance.  Additionally it holds a fixed offset.
 struct StrideInfo {
-  StrideInfo() : offset(0) {}
+  explicit StrideInfo(int64_t offset = 0) : offset(offset) {}
   int64_t offset;
   DenseMap<BlockArgument, int64_t> strides;
+
+  StrideInfo &operator*=(int64_t factor);
+  StrideInfo &operator+=(const StrideInfo &rhs);
 };
 
 // Compute stride info for a given affine value (such an an induction variable

--- a/pmlc/dialect/pxa/transforms/registration.cc
+++ b/pmlc/dialect/pxa/transforms/registration.cc
@@ -23,11 +23,11 @@ struct Autotile10Pass : public mlir::FunctionPass<Autotile10Pass> {
   }
 };
 
-static mlir::PassRegistration<Autotile10Pass> regAutotile10( //
-    "autotile-10", "Tile all dimensions by 10");
+static mlir::PassRegistration<Autotile10Pass>
+    regAutotile10("autotile-10", "Tile all dimensions by 10");
 
-static mlir::PassRegistration<TestStrideInfoPass> regTestStrideInfo( //
-    "test-stride-info",
-    "Report stride data for all loads/stores for unit tests");
+static mlir::PassRegistration<TestStrideInfoPass>
+    regTestStrideInfo("test-stride-info",
+                      "Report stride data for all loads/stores for unit tests");
 
 } // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/transforms/test_analysis.cc
+++ b/pmlc/dialect/pxa/transforms/test_analysis.cc
@@ -1,6 +1,13 @@
 // Copyright 2020 Intel Corporation
 
 #include "pmlc/dialect/pxa/transforms/test_analysis.h"
+
+#include <map>
+#include <string>
+
+#include "mlir/ADT/TypeSwitch.h"
+#include "llvm/Support/FormatVariadic.h"
+
 #include "pmlc/dialect/pxa/analysis/strides.h"
 
 namespace pmlc::dialect::pxa {
@@ -8,22 +15,45 @@ namespace pmlc::dialect::pxa {
 using namespace llvm; // NOLINT
 using namespace mlir; // NOLINT
 
+static std::string getUniqueName(Block *ref, BlockArgument arg) {
+  unsigned reverseDepth = 0;
+  while (arg.getOwner() != ref) {
+    ref = ref->getParentOp()->getBlock();
+    reverseDepth++;
+  }
+  return llvm::formatv("^bb{0}:%arg{1}", reverseDepth, arg.getArgNumber())
+      .str();
+}
+
+template <typename T>
+static void printStrideInfo(T op) {
+  auto info = computeStrideInfo(op);
+  llvm::outs() << "stride begin\n";
+  if (!info) {
+    llvm::outs() << "stride none\n";
+  } else {
+    llvm::outs() << "offset = " << info->offset << "\n";
+    std::map<std::string, unsigned> ordered;
+    auto block = op.getOperation()->getBlock();
+    for (auto kvp : info->strides) {
+      ordered.emplace(getUniqueName(block, kvp.first), kvp.second);
+    }
+    for (auto kvp : ordered) {
+      llvm::outs() << kvp.first << " = " << kvp.second << "\n";
+    }
+  }
+  llvm::outs() << "stride end\n";
+  llvm::outs().flush();
+}
+
 void TestStrideInfoPass::runOnOperation() {
   auto op = getOperation();
-  op->walk([&](AffineLoadOp op) {
-    auto info = computeStrideInfo(op);
-    llvm::outs() << "stride begin\n";
-    if (!info) {
-      llvm::outs() << "stride none\n";
-    } else {
-      llvm::outs() << "offset = " << info->offset << "\n";
-      for (auto kvp : info->strides) {
-        llvm::outs() << "ba" << kvp.first.getArgNumber() << " = " << kvp.second
-                     << "\n";
-      }
-    }
-    llvm::outs() << "stride end\n";
+  op->walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op)
+        .Case<AffineLoadOp>([](auto op) { printStrideInfo(op); })
+        .Case<AffineStoreOp>([](auto op) { printStrideInfo(op); })
+        .Case<AffineReduceOp>([](auto op) { printStrideInfo(op); });
   });
 }
 
-} // End namespace pmlc::dialect::pxa
+} // namespace pmlc::dialect::pxa

--- a/pmlc/rt/xsmm.cc
+++ b/pmlc/rt/xsmm.cc
@@ -16,12 +16,12 @@ extern "C" void plaidml_rt_xsmm_gemm_f32(UnrankedMemRefType a,
                                          int32_t ldb, int32_t ldc, int32_t m,
                                          int32_t n, int32_t k) {
   auto aRef = static_cast<StridedMemRefType<float, 2> *>(a.descriptor);
+  auto aPtr = aRef->data + aRef->offset;
   auto bRef = static_cast<StridedMemRefType<float, 2> *>(b.descriptor);
+  auto bPtr = bRef->data + bRef->offset;
   auto cRef = static_cast<StridedMemRefType<float, 2> *>(c.descriptor);
+  auto cPtr = cRef->data + cRef->offset;
 
-  libxsmm_blasint m_int = m;
-  libxsmm_blasint n_int = n;
-  libxsmm_blasint k_int = k;
   libxsmm_blasint lda_int = lda;
   libxsmm_blasint ldb_int = ldb;
   libxsmm_blasint ldc_int = ldc;
@@ -29,10 +29,10 @@ extern "C" void plaidml_rt_xsmm_gemm_f32(UnrankedMemRefType a,
   //                                  /*alpha=*/nullptr,
   //                                  /*beta=*/nullptr, /*flags=*/nullptr,
   //                                  /*prefetch=*/nullptr);
-  auto aPtr = aRef->data + aRef->offset;
-  auto bPtr = bRef->data + bRef->offset;
-  auto cPtr = cRef->data + cRef->offset;
   // sgemm(aPtr, bPtr, cPtr);
+  libxsmm_blasint m_int = m;
+  libxsmm_blasint n_int = n;
+  libxsmm_blasint k_int = k;
   libxsmm_gemm(/*transa=*/nullptr, /*transb=*/nullptr, &m_int, &n_int, &k_int,
                /*alpha=*/nullptr, aPtr, &lda_int, bPtr, &ldb_int,
                /*beta=*/nullptr, cPtr, &ldc_int);

--- a/pmlc/target/x86/tests/xsmm.mlir
+++ b/pmlc/target/x86/tests/xsmm.mlir
@@ -1,57 +1,355 @@
-// RUN: pmlc-opt -convert-linalg-to-loops -convert-loop-to-std -convert-std-to-llvm %s | pmlc-jit | FileCheck %s
+// RUN: pmlc-opt \
+// RUN:   -convert-linalg-to-loops \
+// RUN:   -convert-pxa-to-affine \
+// RUN:   -lower-affine \
+// RUN:   -convert-loop-to-std \
+// RUN:   -convert-std-to-llvm \
+// RUN:   %s | \
+// RUN: pmlc-jit -entry-point-result=void | FileCheck %s
 
 func @print_memref_f32(memref<*xf32>)
 func @plaidml_rt_xsmm_gemm_f32(memref<*xf32>, memref<*xf32>, memref<*xf32>, i32, i32, i32, i32, i32, i32)
 
-func @main() -> f32 {
+func @main() {
+  call @test_dot() : () -> ()
+  call @test_conv2() : () -> ()
+  return
+}
+
+func @fill_2d(%buf : memref<?x?xf32>, %alt : i1) {
   %c0 = constant 0 : index
-  %c1 = constant 1 : index
+  %c5 = constant 5 : index
+  %X = dim %buf, 0 : memref<?x?xf32>
+  %Y = dim %buf, 1 : memref<?x?xf32>
+  affine.parallel (%x, %y) = (0, 0) to (%X, %Y) {
+    // i = linear offset
+    %i = affine.apply affine_map<(x, y)[Y] -> (x * Y + y)>(%x, %y)[%Y]
+    // t = alt ? i : 0
+    %t = select %alt, %i, %c0 : index
+    // v = x + y + t - 5
+    %1 = addi %x, %y : index
+    %2 = addi %1, %t : index
+    %v = subi %2, %c5 : index
+    %v_i64 = index_cast %v : index to i64
+    %v_f32 = sitofp %v_i64 : i64 to f32
+    store %v_f32, %buf[%x, %y] : memref<?x?xf32>
+  }
+  return
+}
+
+func @fill_4d(%buf : memref<?x?x?x?xf32>, %alt : i1) {
+  %c0 = constant 0 : index
+  %c5 = constant 5 : index
+  %X = dim %buf, 0 : memref<?x?x?x?xf32>
+  %Y = dim %buf, 1 : memref<?x?x?x?xf32>
+  %Z = dim %buf, 2 : memref<?x?x?x?xf32>
+  %W = dim %buf, 3 : memref<?x?x?x?xf32>
+  affine.parallel (%x, %y, %z, %w) = (0, 0, 0, 0) to (%X, %Y, %Z, %W) {
+    // i = linear offset
+    %i = affine.apply affine_map<(x, y, z, w)[Y, Z, W] -> (x * Y + y * W + z * W + w)>(%x, %y, %z, %w)[%Y, %Z, %W]
+    // t = alt ? i : 0
+    %t = select %alt, %i, %c0 : index
+    %j = affine.apply affine_map<(x, y, z, w) -> (x + y + z + w)>(%x, %y, %z, %w)
+    // v = j + t - 5
+    %2 = addi %j, %t : index
+    %v = subi %2, %c5 : index
+    %v_i64 = index_cast %v : index to i64
+    %v_f32 = sitofp %v_i64 : i64 to f32
+    store %v_f32, %buf[%x, %y, %z, %w] : memref<?x?x?x?xf32>
+  }
+  return
+}
+
+func @test_dot() {
+  %false = constant 0 : i1
+  %true = constant 1 : i1
   %f0 = constant 0.0 : f32
-  %f1 = constant 1.0 : f32
-  %f2 = constant 2.0 : f32
   %A = alloc() : memref<8x8xf32>
+  %A_2d = memref_cast %A : memref<8x8xf32> to memref<?x?xf32>
+  %A_ud = memref_cast %A : memref<8x8xf32> to memref<*xf32>
+  call @fill_2d(%A_2d, %false) : (memref<?x?xf32>, i1) -> ()
+  //call @print_memref_f32(%A_ud) : (memref<*xf32>) -> ()
   %B = alloc() : memref<8x8xf32>
+  %B_2d = memref_cast %B : memref<8x8xf32> to memref<?x?xf32>
+  %B_ud = memref_cast %B : memref<8x8xf32> to memref<*xf32>
+  call @fill_2d(%B_2d, %true) : (memref<?x?xf32>, i1) -> ()
+  //call @print_memref_f32(%B_ud) : (memref<*xf32>) -> ()
   %C = alloc() : memref<8x8xf32>
-  linalg.fill(%A, %f1) : memref<8x8xf32>, f32
-  linalg.fill(%B, %f2) : memref<8x8xf32>, f32
+  %C_2d = memref_cast %C : memref<8x8xf32> to memref<?x?xf32>
+  %C_ud = memref_cast %C : memref<8x8xf32> to memref<*xf32>
+
   linalg.fill(%C, %f0) : memref<8x8xf32>, f32
-  call @dot(%A, %B, %C) : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> ()
-  %U = memref_cast %C : memref<8x8xf32> to memref<*xf32>
-  call @print_memref_f32(%U) : (memref<*xf32>) -> ()
+  call @dot(%A_2d, %B_2d, %C_2d) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  call @print_memref_f32(%C_ud) : (memref<*xf32>) -> ()
+  // CHECK:  [60,   36,   12,   -12,   -36,   -60,   -84,   -108],
+  // CHECK:  [272,   264,   256,   248,   240,   232,   224,   216],
+  // CHECK:  [484,   492,   500,   508,   516,   524,   532,   540],
+  // CHECK:  [696,   720,   744,   768,   792,   816,   840,   864],
+  // CHECK:  [908,   948,   988,   1028,   1068,   1108,   1148,   1188],
+  // CHECK:  [1120,   1176,   1232,   1288,   1344,   1400,   1456,   1512],
+  // CHECK:  [1332,   1404,   1476,   1548,   1620,   1692,   1764,   1836],
+  // CHECK:  [1544,   1632,   1720,   1808,   1896,   1984,   2072,   2160]
+
+  linalg.fill(%C, %f0) : memref<8x8xf32>, f32
+  call @dot_tiled(%A_2d, %B_2d, %C_2d) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  call @print_memref_f32(%C_ud) : (memref<*xf32>) -> ()
+  // CHECK:  [60,   36,   12,   -12,   -36,   -60,   -84,   -108],
+  // CHECK:  [272,   264,   256,   248,   240,   232,   224,   216],
+  // CHECK:  [484,   492,   500,   508,   516,   524,   532,   540],
+  // CHECK:  [696,   720,   744,   768,   792,   816,   840,   864],
+  // CHECK:  [908,   948,   988,   1028,   1068,   1108,   1148,   1188],
+  // CHECK:  [1120,   1176,   1232,   1288,   1344,   1400,   1456,   1512],
+  // CHECK:  [1332,   1404,   1476,   1548,   1620,   1692,   1764,   1836],
+  // CHECK:  [1544,   1632,   1720,   1808,   1896,   1984,   2072,   2160]
+
+  linalg.fill(%C, %f0) : memref<8x8xf32>, f32
+  call @dot_xsmm(%A_2d, %B_2d, %C_2d) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  call @print_memref_f32(%C_ud) : (memref<*xf32>) -> ()
+  // CHECK:  [60,   36,   12,   -12,   -36,   -60,   -84,   -108],
+  // CHECK:  [272,   264,   256,   248,   240,   232,   224,   216],
+  // CHECK:  [484,   492,   500,   508,   516,   524,   532,   540],
+  // CHECK:  [696,   720,   744,   768,   792,   816,   840,   864],
+  // CHECK:  [908,   948,   988,   1028,   1068,   1108,   1148,   1188],
+  // CHECK:  [1120,   1176,   1232,   1288,   1344,   1400,   1456,   1512],
+  // CHECK:  [1332,   1404,   1476,   1548,   1620,   1692,   1764,   1836],
+  // CHECK:  [1544,   1632,   1720,   1808,   1896,   1984,   2072,   2160]
+
   dealloc %C : memref<8x8xf32>
   dealloc %B : memref<8x8xf32>
   dealloc %A : memref<8x8xf32>
-  return %f1 : f32
+  return
 }
 
-func @dot(%A: memref<8x8xf32>, %B: memref<8x8xf32>, %C: memref<8x8xf32>) {
-  %c0 = constant 0 : index
-  %c2 = constant 2 : index
-  %c8 = constant 8 : index
-  %c2_i32 = constant 2 : i32
-  %c8_i32 = constant 8 : i32
-  loop.for %i = %c0 to %c8 step %c2 {
-    loop.for %j = %c0 to %c8 step %c2 {
-      loop.for %k = %c0 to %c8 step %c2 {
-        %a_view = subview %B[%i, %k][][] : memref<8x8xf32> to memref<2x2xf32, offset: ?, strides: [2, 2]>
-        %b_view = subview %A[%k, %j][][] : memref<8x8xf32> to memref<2x2xf32, offset: ?, strides: [2, 2]>
-        %c_view = subview %C[%i, %j][][] : memref<8x8xf32> to memref<2x2xf32, offset: ?, strides: [2, 2]>
-        %a_ref = memref_cast %a_view : memref<2x2xf32, offset: ?, strides: [2, 2]> to memref<*xf32>
-        %b_ref = memref_cast %b_view : memref<2x2xf32, offset: ?, strides: [2, 2]> to memref<*xf32>
-        %c_ref = memref_cast %c_view : memref<2x2xf32, offset: ?, strides: [2, 2]> to memref<*xf32>
-        call @plaidml_rt_xsmm_gemm_f32(%a_ref, %b_ref, %c_ref, %c8_i32, %c8_i32, %c8_i32, %c2_i32, %c2_i32, %c2_i32)
-          : (memref<*xf32>, memref<*xf32>, memref<*xf32>, i32, i32, i32, i32, i32, i32) -> ()
-      }
+func @dot(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+  %M = dim %C, 0 : memref<?x?xf32>
+  %N = dim %C, 1 : memref<?x?xf32>
+  %K = dim %A, 1 : memref<?x?xf32>
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (%M, %N, %K) {
+    %0 = affine.load %A[%i, %k] : memref<?x?xf32>
+    %1 = affine.load %B[%k, %j] : memref<?x?xf32>
+    %2 = mulf %0, %1 : f32
+    pxa.reduce add %2, %C[%i, %j] : memref<?x?xf32>
+  }
+  return
+}
+
+func @dot_tiled(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+  %M = dim %C, 0 : memref<?x?xf32>
+  %N = dim %C, 1 : memref<?x?xf32>
+  %K = dim %A, 1 : memref<?x?xf32>
+  affine.parallel (%i0, %j0, %k0) = (0, 0, 0) to (%M, %N, %K) step (2, 2, 2) {
+    affine.parallel (%i1, %j1, %k1) = (%i0, %j0, %k0) to (%i0 + 2, %j0 + 2, %k0 + 2) {
+      %0 = affine.load %A[%i1, %k1] : memref<?x?xf32>
+      %1 = affine.load %B[%k1, %j1] : memref<?x?xf32>
+      %2 = mulf %0, %1 : f32
+      pxa.reduce add %2, %C[%i1, %j1] : memref<?x?xf32>
     }
   }
   return
 }
 
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16],
-// CHECK: [16,   16,   16,   16,   16,   16,   16,   16]
+func @dot_xsmm(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+  %c0 = constant 0 : index
+  %c2 = constant 2 : index
+  %tile_m = constant 2 : i32
+  %tile_n = constant 2 : i32
+  %tile_k = constant 2 : i32
+  %lda = constant 8 : i32
+  %ldb = constant 8 : i32
+  %ldc = constant 8 : i32
+  %M = dim %C, 0 : memref<?x?xf32>
+  %N = dim %C, 1 : memref<?x?xf32>
+  %K = dim %A, 1 : memref<?x?xf32>
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (%M, %N, %K) step (2, 2, 2) {
+    %a_view = subview %A[%i, %k][][] : memref<?x?xf32> to memref<2x2xf32, offset: ?, strides: [?, ?]>
+    %b_view = subview %B[%k, %j][][] : memref<?x?xf32> to memref<2x2xf32, offset: ?, strides: [?, ?]>
+    %c_view = subview %C[%i, %j][][] : memref<?x?xf32> to memref<2x2xf32, offset: ?, strides: [?, ?]>
+    %a_ref = memref_cast %a_view : memref<2x2xf32, offset: ?, strides: [?, ?]> to memref<*xf32>
+    %b_ref = memref_cast %b_view : memref<2x2xf32, offset: ?, strides: [?, ?]> to memref<*xf32>
+    %c_ref = memref_cast %c_view : memref<2x2xf32, offset: ?, strides: [?, ?]> to memref<*xf32>
+    // NOTE: a and b are swapped in this call to XSMM (why is this required?)
+    call @plaidml_rt_xsmm_gemm_f32(%b_ref, %a_ref, %c_ref, %ldb, %lda, %ldc, %tile_m, %tile_n, %tile_k)
+      : (memref<*xf32>, memref<*xf32>, memref<*xf32>, i32, i32, i32, i32, i32, i32) -> ()
+  }
+  return
+}
+
+func @test_conv2() {
+  %false = constant 0 : i1
+  %true = constant 1 : i1
+  %f0 = constant 0.0 : f32
+  %I = alloc() : memref<1x6x5x7xf32>
+  %I_2d = memref_cast %I : memref<1x6x5x7xf32> to memref<?x?x?x?xf32>
+  %I_ud = memref_cast %I : memref<1x6x5x7xf32> to memref<*xf32>
+  call @fill_4d(%I_2d, %false) : (memref<?x?x?x?xf32>, i1) -> ()
+  call @print_memref_f32(%I_ud) : (memref<*xf32>) -> ()
+  %K = alloc() : memref<1x1x7x11xf32>
+  %K_2d = memref_cast %K : memref<1x1x7x11xf32> to memref<?x?x?x?xf32>
+  %K_ud = memref_cast %K : memref<1x1x7x11xf32> to memref<*xf32>
+  call @fill_4d(%K_2d, %true) : (memref<?x?x?x?xf32>, i1) -> ()
+  call @print_memref_f32(%K_ud) : (memref<*xf32>) -> ()
+  %O = alloc() : memref<1x6x5x11xf32>
+  %O_2d = memref_cast %O : memref<1x6x5x11xf32> to memref<?x?x?x?xf32>
+  %O_ud = memref_cast %O : memref<1x6x5x11xf32> to memref<*xf32>
+
+  linalg.fill(%O, %f0) : memref<1x6x5x11xf32>, f32
+  call @conv2(%I_2d, %K_2d, %O_2d) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>) -> ()
+  call @print_memref_f32(%O_ud) : (memref<*xf32>) -> ()
+  // CHECK: [-98,     -126,     -154,     -182,     -210,     -238,     -266,     -294,     -322,     -350,     -378],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050]],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407]],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764]],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121]],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478]],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478],
+  // CHECK: [1855,     1953,     2051,     2149,     2247,     2345,     2443,     2541,     2639,     2737,     2835]]]]
+
+  linalg.fill(%O, %f0) : memref<1x6x5x11xf32>, f32
+  call @conv2_tiled(%I_2d, %K_2d, %O_2d) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>) -> ()
+  call @print_memref_f32(%O_ud) : (memref<*xf32>) -> ()
+  // CHECK: [-98,     -126,     -154,     -182,     -210,     -238,     -266,     -294,     -322,     -350,     -378],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050]],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407]],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764]],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121]],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478]],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478],
+  // CHECK: [1855,     1953,     2051,     2149,     2247,     2345,     2443,     2541,     2639,     2737,     2835]]]]
+
+  linalg.fill(%O, %f0) : memref<1x6x5x11xf32>, f32
+  call @conv2_xsmm(%I_2d, %K_2d, %O_2d) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>) -> ()
+  call @print_memref_f32(%O_ud) : (memref<*xf32>) -> ()
+  // CHECK: [-98,     -126,     -154,     -182,     -210,     -238,     -266,     -294,     -322,     -350,     -378],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050]],
+  // CHECK: [119,     105,     91,     77,     63,     49,     35,     21,     7,     -7,     -21],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407]],
+  // CHECK: [336,     336,     336,     336,     336,     336,     336,     336,     336,     336,     336],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764]],
+  // CHECK: [553,     567,     581,     595,     609,     623,     637,     651,     665,     679,     693],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121]],
+  // CHECK: [770,     798,     826,     854,     882,     910,     938,     966,     994,     1022,     1050],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478]],
+  // CHECK: [987,     1029,     1071,     1113,     1155,     1197,     1239,     1281,     1323,     1365,     1407],
+  // CHECK: [1204,     1260,     1316,     1372,     1428,     1484,     1540,     1596,     1652,     1708,     1764],
+  // CHECK: [1421,     1491,     1561,     1631,     1701,     1771,     1841,     1911,     1981,     2051,     2121],
+  // CHECK: [1638,     1722,     1806,     1890,     1974,     2058,     2142,     2226,     2310,     2394,     2478],
+  // CHECK: [1855,     1953,     2051,     2149,     2247,     2345,     2443,     2541,     2639,     2737,     2835]]]]
+
+  dealloc %O : memref<1x6x5x11xf32>
+  dealloc %K : memref<1x1x7x11xf32>
+  dealloc %I : memref<1x6x5x7xf32>
+  return
+}
+
+func @conv2(%I: memref<?x?x?x?xf32>, %K: memref<?x?x?x?xf32>, %O: memref<?x?x?x?xf32>) {
+  %X = dim %I, 1 : memref<?x?x?x?xf32>
+  %Y = dim %I, 2 : memref<?x?x?x?xf32>
+  %CI = dim %I, 3 : memref<?x?x?x?xf32>
+  %CO = dim %O, 3 : memref<?x?x?x?xf32>
+  affine.parallel (%x, %y, %ci, %co) = (0, 0, 0, 0) to (%X, %Y, %CI, %CO) {
+    %0 = affine.load %I[0, %x, %y, %ci] : memref<?x?x?x?xf32>
+    %1 = affine.load %K[0, 0, %ci, %co] : memref<?x?x?x?xf32>
+    %2 = mulf %0, %1 : f32
+    pxa.reduce add %2, %O[0, %x, %y, %co] : memref<?x?x?x?xf32>
+  }
+  return
+}
+
+func @conv2_tiled(%I: memref<?x?x?x?xf32>, %K: memref<?x?x?x?xf32>, %O: memref<?x?x?x?xf32>) {
+  %X = dim %I, 1 : memref<?x?x?x?xf32>
+  %Y = dim %I, 2 : memref<?x?x?x?xf32>
+  %CI = dim %I, 3 : memref<?x?x?x?xf32>
+  %CO = dim %O, 3 : memref<?x?x?x?xf32>
+  affine.parallel (%x0, %y) = (0, 0) to (%X, %Y) step (2, 1) {
+    affine.parallel (%x1, %ci, %co) = (%x0, 0, 0) to (%x0 + 2, %CI, %CO) {
+      %0 = affine.load %I[0, %x1, %y, %ci] : memref<?x?x?x?xf32>
+      %1 = affine.load %K[0, 0, %ci, %co] : memref<?x?x?x?xf32>
+      %2 = mulf %0, %1 : f32
+      pxa.reduce add %2, %O[0, %x1, %y, %co] : memref<?x?x?x?xf32>
+    }
+  }
+  return
+}
+
+func @conv2_xsmm(%I: memref<?x?x?x?xf32>, %K: memref<?x?x?x?xf32>, %O: memref<?x?x?x?xf32>) {
+  %c0 = constant 0 : index
+  %X = dim %I, 1 : memref<?x?x?x?xf32>
+  %Y = dim %I, 2 : memref<?x?x?x?xf32>
+  %m = constant 11 : i32
+  %n = constant 2 : i32
+  %k = constant 7 : i32
+  %lda = constant 35 : i32
+  %ldb = constant 11 : i32
+  %ldc = constant 55 : i32
+  affine.parallel (%x, %y) = (0, 0) to (%X, %Y) step (2, 1) {
+    %I_view = subview %I[%c0,  %x,  %y, %c0][][] : memref<?x?x?x?xf32> to memref<1x3x5x7xf32, offset: ?, strides: [?, ?, ?, ?]>
+    %K_view = subview %K[%c0, %c0, %c0, %c0][][] : memref<?x?x?x?xf32> to memref<1x1x7x11xf32, offset: ?, strides: [?, ?, ?, ?]>
+    %O_view = subview %O[%c0,  %x,  %y, %c0][][] : memref<?x?x?x?xf32> to memref<1x3x5x11xf32, offset: ?, strides: [?, ?, ?, ?]>
+    %I_ref = memref_cast %I_view : memref<1x3x5x7xf32, offset: ?, strides: [?, ?, ?, ?]> to memref<*xf32>
+    %K_ref = memref_cast %K_view : memref<1x1x7x11xf32, offset: ?, strides: [?, ?, ?, ?]> to memref<*xf32>
+    %O_ref = memref_cast %O_view : memref<1x3x5x11xf32, offset: ?, strides: [?, ?, ?, ?]> to memref<*xf32>
+    // NOTE: we need to swap the A, B and lda, ldb operands for some reason....
+    call @plaidml_rt_xsmm_gemm_f32(%K_ref, %I_ref, %O_ref, %ldb, %lda, %ldc, %m, %n, %k)
+      : (memref<*xf32>, memref<*xf32>, memref<*xf32>, i32, i32, i32, i32, i32, i32) -> ()
+  }
+  return
+}


### PR DESCRIPTION
- Improve naming of block arguments in `TestStrideInfoPass`, each argument is now given a unique name based on the inverse depth of the block in which the argument is induced.
- Add the ability to print `StrideInfo` for `AffineStoreOp` and `AffineReduceOp` in addition to `AffineLoadOp`.
- Add dot and convolution test cases to `strides.mlir`.
- Improve xsmm lowering test to include more complex input data patterns. Two are implemented, which are based on the formulas: `A[x, y] = x + y - 5` and `A[x, y] = x + y + i - 5` where `i = linear_offset(x, y)`. This is also extended to a 4D filling function to initialize convolution inputs.
