### PR TITLE
NFC: Tile dialect updates

### DIFF
--- a/networks/oplib/resnet50.mlir
+++ b/networks/oplib/resnet50.mlir
@@ -22,252 +22,252 @@ module {
   func @resnet50(%arg0: tensor<1000x!eltwise.f32>, %arg1: tensor<2048x1000x!eltwise.f32>, %arg2: tensor<2048x!eltwise.f32>, %arg3: tensor<1x1x1024x2048x!eltwise.f32>, %arg4: tensor<1024x!eltwise.f32>, %arg5: tensor<1x1x512x1024x!eltwise.f32>, %arg6: tensor<512x!eltwise.f32>, %arg7: tensor<1x1x256x512x!eltwise.f32>, %arg8: tensor<256x!eltwise.f32>, %arg9: tensor<1x1x64x256x!eltwise.f32>, %arg10: tensor<64x!eltwise.f32>, %arg11: tensor<7x7x3x64x!eltwise.f32>, %arg12: tensor<1x224x224x3x!eltwise.f32>, %arg13: tensor<256x!eltwise.f32>, %arg14: tensor<1x1x64x256x!eltwise.f32>, %arg15: tensor<64x!eltwise.f32>, %arg16: tensor<3x3x64x64x!eltwise.f32>, %arg17: tensor<64x!eltwise.f32>, %arg18: tensor<1x1x64x64x!eltwise.f32>, %arg19: tensor<256x!eltwise.f32>, %arg20: tensor<1x1x64x256x!eltwise.f32>, %arg21: tensor<64x!eltwise.f32>, %arg22: tensor<3x3x64x64x!eltwise.f32>, %arg23: tensor<64x!eltwise.f32>, %arg24: tensor<1x1x256x64x!eltwise.f32>, %arg25: tensor<256x!eltwise.f32>, %arg26: tensor<1x1x64x256x!eltwise.f32>, %arg27: tensor<64x!eltwise.f32>, %arg28: tensor<3x3x64x64x!eltwise.f32>, %arg29: tensor<64x!eltwise.f32>, %arg30: tensor<1x1x256x64x!eltwise.f32>, %arg31: tensor<512x!eltwise.f32>, %arg32: tensor<1x1x128x512x!eltwise.f32>, %arg33: tensor<128x!eltwise.f32>, %arg34: tensor<3x3x128x128x!eltwise.f32>, %arg35: tensor<128x!eltwise.f32>, %arg36: tensor<1x1x256x128x!eltwise.f32>, %arg37: tensor<512x!eltwise.f32>, %arg38: tensor<1x1x128x512x!eltwise.f32>, %arg39: tensor<128x!eltwise.f32>, %arg40: tensor<3x3x128x128x!eltwise.f32>, %arg41: tensor<128x!eltwise.f32>, %arg42: tensor<1x1x512x128x!eltwise.f32>, %arg43: tensor<512x!eltwise.f32>, %arg44: tensor<1x1x128x512x!eltwise.f32>, %arg45: tensor<128x!eltwise.f32>, %arg46: tensor<3x3x128x128x!eltwise.f32>, %arg47: tensor<128x!eltwise.f32>, %arg48: tensor<1x1x512x128x!eltwise.f32>, %arg49: tensor<512x!eltwise.f32>, %arg50: tensor<1x1x128x512x!eltwise.f32>, %arg51: tensor<128x!eltwise.f32>, %arg52: tensor<3x3x128x128x!eltwise.f32>, %arg53: tensor<128x!eltwise.f32>, %arg54: tensor<1x1x512x128x!eltwise.f32>, %arg55: tensor<1024x!eltwise.f32>, %arg56: tensor<1x1x256x1024x!eltwise.f32>, %arg57: tensor<256x!eltwise.f32>, %arg58: tensor<3x3x256x256x!eltwise.f32>, %arg59: tensor<256x!eltwise.f32>, %arg60: tensor<1x1x512x256x!eltwise.f32>, %arg61: tensor<1024x!eltwise.f32>, %arg62: tensor<1x1x256x1024x!eltwise.f32>, %arg63: tensor<256x!eltwise.f32>, %arg64: tensor<3x3x256x256x!eltwise.f32>, %arg65: tensor<256x!eltwise.f32>, %arg66: tensor<1x1x1024x256x!eltwise.f32>, %arg67: tensor<1024x!eltwise.f32>, %arg68: tensor<1x1x256x1024x!eltwise.f32>, %arg69: tensor<256x!eltwise.f32>, %arg70: tensor<3x3x256x256x!eltwise.f32>, %arg71: tensor<256x!eltwise.f32>, %arg72: tensor<1x1x1024x256x!eltwise.f32>, %arg73: tensor<1024x!eltwise.f32>, %arg74: tensor<1x1x256x1024x!eltwise.f32>, %arg75: tensor<256x!eltwise.f32>, %arg76: tensor<3x3x256x256x!eltwise.f32>, %arg77: tensor<256x!eltwise.f32>, %arg78: tensor<1x1x1024x256x!eltwise.f32>, %arg79: tensor<1024x!eltwise.f32>, %arg80: tensor<1x1x256x1024x!eltwise.f32>, %arg81: tensor<256x!eltwise.f32>, %arg82: tensor<3x3x256x256x!eltwise.f32>, %arg83: tensor<256x!eltwise.f32>, %arg84: tensor<1x1x1024x256x!eltwise.f32>, %arg85: tensor<1024x!eltwise.f32>, %arg86: tensor<1x1x256x1024x!eltwise.f32>, %arg87: tensor<256x!eltwise.f32>, %arg88: tensor<3x3x256x256x!eltwise.f32>, %arg89: tensor<256x!eltwise.f32>, %arg90: tensor<1x1x1024x256x!eltwise.f32>, %arg91: tensor<2048x!eltwise.f32>, %arg92: tensor<1x1x512x2048x!eltwise.f32>, %arg93: tensor<512x!eltwise.f32>, %arg94: tensor<3x3x512x512x!eltwise.f32>, %arg95: tensor<512x!eltwise.f32>, %arg96: tensor<1x1x1024x512x!eltwise.f32>, %arg97: tensor<2048x!eltwise.f32>, %arg98: tensor<1x1x512x2048x!eltwise.f32>, %arg99: tensor<512x!eltwise.f32>, %arg100: tensor<3x3x512x512x!eltwise.f32>, %arg101: tensor<512x!eltwise.f32>, %arg102: tensor<1x1x2048x512x!eltwise.f32>, %arg103: tensor<2048x!eltwise.f32>, %arg104: tensor<1x1x512x2048x!eltwise.f32>, %arg105: tensor<512x!eltwise.f32>, %arg106: tensor<3x3x512x512x!eltwise.f32>, %arg107: tensor<512x!eltwise.f32>, %arg108: tensor<1x1x2048x512x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32> {
     %c49 = "eltwise.sconst"() {value = 49 : i64} : () -> !i32
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %conv1 = tile.cion add, mul, %cst, %arg12, %arg11 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x!eltwise.f32>, tensor<7x7x3x64x!eltwise.f32> -> tensor<1x112x112x64x!eltwise.f32>
+    %conv1 = tile.contract add, mul, %cst, %arg12, %arg11 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x!eltwise.f32>, tensor<7x7x3x64x!eltwise.f32> -> tensor<1x112x112x64x!eltwise.f32>
     %0 = "eltwise.add"(%conv1, %arg10) : (tensor<1x112x112x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
     %1 = "eltwise.cmp_lt"(%0, %cst) : (tensor<1x112x112x64x!eltwise.f32>, !f32) -> tensor<1x112x112x64x!eltwise.u1>
     %2 = "eltwise.select"(%1, %cst, %0) : (tensor<1x112x112x64x!eltwise.u1>, !f32, tensor<1x112x112x64x!eltwise.f32>) -> tensor<1x112x112x64x!eltwise.f32>
-    %3 = tile.cion max, none, %cst, %2 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x112x112x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %3 = tile.contract max, none, %cst, %2 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x112x112x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %4 = "tile.trace"(%3) {msg = "res2a"} : (tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch1 = tile.cion add, mul, %cst, %4, %arg9 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
-    %res2a_branch2a = tile.cion add, mul, %cst, %4, %arg18 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch1 = tile.contract add, mul, %cst, %4, %arg9 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2a_branch2a = tile.contract add, mul, %cst, %4, %arg18 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %5 = "eltwise.add"(%res2a_branch2a, %arg17) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %6 = "eltwise.cmp_lt"(%5, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %7 = "eltwise.select"(%6, %cst, %5) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch2b = tile.cion add, mul, %cst, %7, %arg16 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2a_branch2b = tile.contract add, mul, %cst, %7, %arg16 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %8 = "eltwise.add"(%res2a_branch2b, %arg15) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %9 = "eltwise.cmp_lt"(%8, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %10 = "eltwise.select"(%9, %cst, %8) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2a_branch2c = tile.cion add, mul, %cst, %10, %arg14 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2a_branch2c = tile.contract add, mul, %cst, %10, %arg14 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
     %11 = "eltwise.add"(%res2a_branch2c, %arg13) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %12 = "eltwise.add"(%11, %res2a_branch1) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %13 = "eltwise.add"(%12, %arg8) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %14 = "eltwise.cmp_lt"(%13, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
     %15 = "eltwise.select"(%14, %cst, %13) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %16 = "tile.trace"(%15) {msg = "res2b"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res2b_branch2a = tile.cion add, mul, %cst, %16, %arg24 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2a = tile.contract add, mul, %cst, %16, %arg24 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %17 = "eltwise.add"(%res2b_branch2a, %arg23) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %18 = "eltwise.cmp_lt"(%17, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %19 = "eltwise.select"(%18, %cst, %17) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2b_branch2b = tile.cion add, mul, %cst, %19, %arg22 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2b_branch2b = tile.contract add, mul, %cst, %19, %arg22 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %20 = "eltwise.add"(%res2b_branch2b, %arg21) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %21 = "eltwise.cmp_lt"(%20, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %22 = "eltwise.select"(%21, %cst, %20) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2b_branch2c = tile.cion add, mul, %cst, %22, %arg20 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2b_branch2c = tile.contract add, mul, %cst, %22, %arg20 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
     %23 = "eltwise.add"(%res2b_branch2c, %arg19) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %24 = "eltwise.add"(%23, %16) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %25 = "eltwise.cmp_lt"(%24, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
     %26 = "eltwise.select"(%25, %cst, %24) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %27 = "tile.trace"(%26) {msg = "res2c"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res2c_branch2a = tile.cion add, mul, %cst, %27, %arg30 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2c_branch2a = tile.contract add, mul, %cst, %27, %arg30 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %28 = "eltwise.add"(%res2c_branch2a, %arg29) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %29 = "eltwise.cmp_lt"(%28, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %30 = "eltwise.select"(%29, %cst, %28) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2c_branch2b = tile.cion add, mul, %cst, %30, %arg28 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
+    %res2c_branch2b = tile.contract add, mul, %cst, %30, %arg28 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<3x3x64x64x!eltwise.f32> -> tensor<1x56x56x64x!eltwise.f32>
     %31 = "eltwise.add"(%res2c_branch2b, %arg27) : (tensor<1x56x56x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
     %32 = "eltwise.cmp_lt"(%31, %cst) : (tensor<1x56x56x64x!eltwise.f32>, !f32) -> tensor<1x56x56x64x!eltwise.u1>
     %33 = "eltwise.select"(%32, %cst, %31) : (tensor<1x56x56x64x!eltwise.u1>, !f32, tensor<1x56x56x64x!eltwise.f32>) -> tensor<1x56x56x64x!eltwise.f32>
-    %res2c_branch2c = tile.cion add, mul, %cst, %33, %arg26 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
+    %res2c_branch2c = tile.contract add, mul, %cst, %33, %arg26 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x56x56x64x!eltwise.f32>, tensor<1x1x64x256x!eltwise.f32> -> tensor<1x56x56x256x!eltwise.f32>
     %34 = "eltwise.add"(%res2c_branch2c, %arg25) : (tensor<1x56x56x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %35 = "eltwise.add"(%34, %27) : (tensor<1x56x56x256x!eltwise.f32>, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %36 = "eltwise.cmp_lt"(%35, %cst) : (tensor<1x56x56x256x!eltwise.f32>, !f32) -> tensor<1x56x56x256x!eltwise.u1>
     %37 = "eltwise.select"(%36, %cst, %35) : (tensor<1x56x56x256x!eltwise.u1>, !f32, tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
     %38 = "tile.trace"(%37) {msg = "res3a"} : (tensor<1x56x56x256x!eltwise.f32>) -> tensor<1x56x56x256x!eltwise.f32>
-    %res3a_branch1 = tile.cion add, mul, %cst, %38, %arg7 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
-    %res3a_branch2a = tile.cion add, mul, %cst, %38, %arg36 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch1 = tile.contract add, mul, %cst, %38, %arg7 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3a_branch2a = tile.contract add, mul, %cst, %38, %arg36 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x56x56x256x!eltwise.f32>, tensor<1x1x256x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %39 = "eltwise.add"(%res3a_branch2a, %arg35) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %40 = "eltwise.cmp_lt"(%39, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %41 = "eltwise.select"(%40, %cst, %39) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3a_branch2b = tile.cion add, mul, %cst, %41, %arg34 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3a_branch2b = tile.contract add, mul, %cst, %41, %arg34 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %42 = "eltwise.add"(%res3a_branch2b, %arg33) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %43 = "eltwise.cmp_lt"(%42, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %44 = "eltwise.select"(%43, %cst, %42) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3a_branch2c = tile.cion add, mul, %cst, %44, %arg32 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3a_branch2c = tile.contract add, mul, %cst, %44, %arg32 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
     %45 = "eltwise.add"(%res3a_branch2c, %arg31) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %46 = "eltwise.add"(%45, %res3a_branch1) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %47 = "eltwise.add"(%46, %arg6) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %48 = "eltwise.cmp_lt"(%47, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
     %49 = "eltwise.select"(%48, %cst, %47) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %50 = "tile.trace"(%49) {msg = "res3b"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3b_branch2a = tile.cion add, mul, %cst, %50, %arg42 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2a = tile.contract add, mul, %cst, %50, %arg42 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %51 = "eltwise.add"(%res3b_branch2a, %arg41) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %52 = "eltwise.cmp_lt"(%51, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %53 = "eltwise.select"(%52, %cst, %51) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3b_branch2b = tile.cion add, mul, %cst, %53, %arg40 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3b_branch2b = tile.contract add, mul, %cst, %53, %arg40 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %54 = "eltwise.add"(%res3b_branch2b, %arg39) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %55 = "eltwise.cmp_lt"(%54, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %56 = "eltwise.select"(%55, %cst, %54) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3b_branch2c = tile.cion add, mul, %cst, %56, %arg38 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3b_branch2c = tile.contract add, mul, %cst, %56, %arg38 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
     %57 = "eltwise.add"(%res3b_branch2c, %arg37) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %58 = "eltwise.add"(%57, %50) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %59 = "eltwise.cmp_lt"(%58, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
     %60 = "eltwise.select"(%59, %cst, %58) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %61 = "tile.trace"(%60) {msg = "res3c"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3c_branch2a = tile.cion add, mul, %cst, %61, %arg48 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2a = tile.contract add, mul, %cst, %61, %arg48 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %62 = "eltwise.add"(%res3c_branch2a, %arg47) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %63 = "eltwise.cmp_lt"(%62, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %64 = "eltwise.select"(%63, %cst, %62) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3c_branch2b = tile.cion add, mul, %cst, %64, %arg46 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3c_branch2b = tile.contract add, mul, %cst, %64, %arg46 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %65 = "eltwise.add"(%res3c_branch2b, %arg45) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %66 = "eltwise.cmp_lt"(%65, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %67 = "eltwise.select"(%66, %cst, %65) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3c_branch2c = tile.cion add, mul, %cst, %67, %arg44 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3c_branch2c = tile.contract add, mul, %cst, %67, %arg44 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
     %68 = "eltwise.add"(%res3c_branch2c, %arg43) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %69 = "eltwise.add"(%68, %61) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %70 = "eltwise.cmp_lt"(%69, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
     %71 = "eltwise.select"(%70, %cst, %69) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %72 = "tile.trace"(%71) {msg = "res3d"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res3d_branch2a = tile.cion add, mul, %cst, %72, %arg54 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2a = tile.contract add, mul, %cst, %72, %arg54 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %73 = "eltwise.add"(%res3d_branch2a, %arg53) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %74 = "eltwise.cmp_lt"(%73, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %75 = "eltwise.select"(%74, %cst, %73) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3d_branch2b = tile.cion add, mul, %cst, %75, %arg52 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
+    %res3d_branch2b = tile.contract add, mul, %cst, %75, %arg52 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<3x3x128x128x!eltwise.f32> -> tensor<1x28x28x128x!eltwise.f32>
     %76 = "eltwise.add"(%res3d_branch2b, %arg51) : (tensor<1x28x28x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
     %77 = "eltwise.cmp_lt"(%76, %cst) : (tensor<1x28x28x128x!eltwise.f32>, !f32) -> tensor<1x28x28x128x!eltwise.u1>
     %78 = "eltwise.select"(%77, %cst, %76) : (tensor<1x28x28x128x!eltwise.u1>, !f32, tensor<1x28x28x128x!eltwise.f32>) -> tensor<1x28x28x128x!eltwise.f32>
-    %res3d_branch2c = tile.cion add, mul, %cst, %78, %arg50 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
+    %res3d_branch2c = tile.contract add, mul, %cst, %78, %arg50 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x28x28x128x!eltwise.f32>, tensor<1x1x128x512x!eltwise.f32> -> tensor<1x28x28x512x!eltwise.f32>
     %79 = "eltwise.add"(%res3d_branch2c, %arg49) : (tensor<1x28x28x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %80 = "eltwise.add"(%79, %72) : (tensor<1x28x28x512x!eltwise.f32>, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %81 = "eltwise.cmp_lt"(%80, %cst) : (tensor<1x28x28x512x!eltwise.f32>, !f32) -> tensor<1x28x28x512x!eltwise.u1>
     %82 = "eltwise.select"(%81, %cst, %80) : (tensor<1x28x28x512x!eltwise.u1>, !f32, tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
     %83 = "tile.trace"(%82) {msg = "res4a"} : (tensor<1x28x28x512x!eltwise.f32>) -> tensor<1x28x28x512x!eltwise.f32>
-    %res4a_branch1 = tile.cion add, mul, %cst, %83, %arg5 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4a_branch2a = tile.cion add, mul, %cst, %83, %arg60 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch1 = tile.contract add, mul, %cst, %83, %arg5 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4a_branch2a = tile.contract add, mul, %cst, %83, %arg60 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x28x28x512x!eltwise.f32>, tensor<1x1x512x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %84 = "eltwise.add"(%res4a_branch2a, %arg59) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %85 = "eltwise.cmp_lt"(%84, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %86 = "eltwise.select"(%85, %cst, %84) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4a_branch2b = tile.cion add, mul, %cst, %86, %arg58 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4a_branch2b = tile.contract add, mul, %cst, %86, %arg58 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %87 = "eltwise.add"(%res4a_branch2b, %arg57) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %88 = "eltwise.cmp_lt"(%87, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %89 = "eltwise.select"(%88, %cst, %87) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4a_branch2c = tile.cion add, mul, %cst, %89, %arg56 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4a_branch2c = tile.contract add, mul, %cst, %89, %arg56 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %90 = "eltwise.add"(%res4a_branch2c, %arg55) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %91 = "eltwise.add"(%90, %res4a_branch1) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %92 = "eltwise.add"(%91, %arg4) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %93 = "eltwise.cmp_lt"(%92, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %94 = "eltwise.select"(%93, %cst, %92) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %95 = "tile.trace"(%94) {msg = "res4b"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4b_branch2a = tile.cion add, mul, %cst, %95, %arg66 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2a = tile.contract add, mul, %cst, %95, %arg66 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %96 = "eltwise.add"(%res4b_branch2a, %arg65) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %97 = "eltwise.cmp_lt"(%96, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %98 = "eltwise.select"(%97, %cst, %96) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4b_branch2b = tile.cion add, mul, %cst, %98, %arg64 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4b_branch2b = tile.contract add, mul, %cst, %98, %arg64 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %99 = "eltwise.add"(%res4b_branch2b, %arg63) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %100 = "eltwise.cmp_lt"(%99, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %101 = "eltwise.select"(%100, %cst, %99) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4b_branch2c = tile.cion add, mul, %cst, %101, %arg62 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4b_branch2c = tile.contract add, mul, %cst, %101, %arg62 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %102 = "eltwise.add"(%res4b_branch2c, %arg61) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %103 = "eltwise.add"(%102, %95) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %104 = "eltwise.cmp_lt"(%103, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %105 = "eltwise.select"(%104, %cst, %103) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %106 = "tile.trace"(%105) {msg = "res4c"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4c_branch2a = tile.cion add, mul, %cst, %106, %arg72 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4c_branch2a = tile.contract add, mul, %cst, %106, %arg72 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %107 = "eltwise.add"(%res4c_branch2a, %arg71) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %108 = "eltwise.cmp_lt"(%107, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %109 = "eltwise.select"(%108, %cst, %107) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4c_branch2b = tile.cion add, mul, %cst, %109, %arg70 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4c_branch2b = tile.contract add, mul, %cst, %109, %arg70 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %110 = "eltwise.add"(%res4c_branch2b, %arg69) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %111 = "eltwise.cmp_lt"(%110, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %112 = "eltwise.select"(%111, %cst, %110) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4c_branch2c = tile.cion add, mul, %cst, %112, %arg68 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4c_branch2c = tile.contract add, mul, %cst, %112, %arg68 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %113 = "eltwise.add"(%res4c_branch2c, %arg67) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %114 = "eltwise.add"(%113, %106) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %115 = "eltwise.cmp_lt"(%114, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %116 = "eltwise.select"(%115, %cst, %114) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %117 = "tile.trace"(%116) {msg = "res4d"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4d_branch2a = tile.cion add, mul, %cst, %117, %arg78 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2a = tile.contract add, mul, %cst, %117, %arg78 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %118 = "eltwise.add"(%res4d_branch2a, %arg77) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %119 = "eltwise.cmp_lt"(%118, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %120 = "eltwise.select"(%119, %cst, %118) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4d_branch2b = tile.cion add, mul, %cst, %120, %arg76 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4d_branch2b = tile.contract add, mul, %cst, %120, %arg76 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %121 = "eltwise.add"(%res4d_branch2b, %arg75) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %122 = "eltwise.cmp_lt"(%121, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %123 = "eltwise.select"(%122, %cst, %121) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4d_branch2c = tile.cion add, mul, %cst, %123, %arg74 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4d_branch2c = tile.contract add, mul, %cst, %123, %arg74 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %124 = "eltwise.add"(%res4d_branch2c, %arg73) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %125 = "eltwise.add"(%124, %117) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %126 = "eltwise.cmp_lt"(%125, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %127 = "eltwise.select"(%126, %cst, %125) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %128 = "tile.trace"(%127) {msg = "res4e"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4e_branch2a = tile.cion add, mul, %cst, %128, %arg84 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2a = tile.contract add, mul, %cst, %128, %arg84 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %129 = "eltwise.add"(%res4e_branch2a, %arg83) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %130 = "eltwise.cmp_lt"(%129, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %131 = "eltwise.select"(%130, %cst, %129) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4e_branch2b = tile.cion add, mul, %cst, %131, %arg82 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4e_branch2b = tile.contract add, mul, %cst, %131, %arg82 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %132 = "eltwise.add"(%res4e_branch2b, %arg81) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %133 = "eltwise.cmp_lt"(%132, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %134 = "eltwise.select"(%133, %cst, %132) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4e_branch2c = tile.cion add, mul, %cst, %134, %arg80 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4e_branch2c = tile.contract add, mul, %cst, %134, %arg80 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %135 = "eltwise.add"(%res4e_branch2c, %arg79) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %136 = "eltwise.add"(%135, %128) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %137 = "eltwise.cmp_lt"(%136, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %138 = "eltwise.select"(%137, %cst, %136) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %139 = "tile.trace"(%138) {msg = "res4f"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res4f_branch2a = tile.cion add, mul, %cst, %139, %arg90 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2a = tile.contract add, mul, %cst, %139, %arg90 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %140 = "eltwise.add"(%res4f_branch2a, %arg89) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %141 = "eltwise.cmp_lt"(%140, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %142 = "eltwise.select"(%141, %cst, %140) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4f_branch2b = tile.cion add, mul, %cst, %142, %arg88 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
+    %res4f_branch2b = tile.contract add, mul, %cst, %142, %arg88 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<3x3x256x256x!eltwise.f32> -> tensor<1x14x14x256x!eltwise.f32>
     %143 = "eltwise.add"(%res4f_branch2b, %arg87) : (tensor<1x14x14x256x!eltwise.f32>, tensor<256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
     %144 = "eltwise.cmp_lt"(%143, %cst) : (tensor<1x14x14x256x!eltwise.f32>, !f32) -> tensor<1x14x14x256x!eltwise.u1>
     %145 = "eltwise.select"(%144, %cst, %143) : (tensor<1x14x14x256x!eltwise.u1>, !f32, tensor<1x14x14x256x!eltwise.f32>) -> tensor<1x14x14x256x!eltwise.f32>
-    %res4f_branch2c = tile.cion add, mul, %cst, %145, %arg86 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
+    %res4f_branch2c = tile.contract add, mul, %cst, %145, %arg86 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x14x14x256x!eltwise.f32>, tensor<1x1x256x1024x!eltwise.f32> -> tensor<1x14x14x1024x!eltwise.f32>
     %146 = "eltwise.add"(%res4f_branch2c, %arg85) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %147 = "eltwise.add"(%146, %139) : (tensor<1x14x14x1024x!eltwise.f32>, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %148 = "eltwise.cmp_lt"(%147, %cst) : (tensor<1x14x14x1024x!eltwise.f32>, !f32) -> tensor<1x14x14x1024x!eltwise.u1>
     %149 = "eltwise.select"(%148, %cst, %147) : (tensor<1x14x14x1024x!eltwise.u1>, !f32, tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
     %150 = "tile.trace"(%149) {msg = "res5a"} : (tensor<1x14x14x1024x!eltwise.f32>) -> tensor<1x14x14x1024x!eltwise.f32>
-    %res5a_branch1 = tile.cion add, mul, %cst, %150, %arg3 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5a_branch2a = tile.cion add, mul, %cst, %150, %arg96 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5a_branch1 = tile.contract add, mul, %cst, %150, %arg3 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5a_branch2a = tile.contract add, mul, %cst, %150, %arg96 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map7, #map2]} : !f32, tensor<1x14x14x1024x!eltwise.f32>, tensor<1x1x1024x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %151 = "eltwise.add"(%res5a_branch2a, %arg95) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %152 = "eltwise.cmp_lt"(%151, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %153 = "eltwise.select"(%152, %cst, %151) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5a_branch2b = tile.cion add, mul, %cst, %153, %arg94 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5a_branch2b = tile.contract add, mul, %cst, %153, %arg94 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %154 = "eltwise.add"(%res5a_branch2b, %arg93) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %155 = "eltwise.cmp_lt"(%154, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %156 = "eltwise.select"(%155, %cst, %154) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5a_branch2c = tile.cion add, mul, %cst, %156, %arg92 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5a_branch2c = tile.contract add, mul, %cst, %156, %arg92 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
     %157 = "eltwise.add"(%res5a_branch2c, %arg91) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %158 = "eltwise.add"(%157, %res5a_branch1) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %159 = "eltwise.add"(%158, %arg2) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %160 = "eltwise.cmp_lt"(%159, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
     %161 = "eltwise.select"(%160, %cst, %159) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %162 = "tile.trace"(%161) {msg = "res5b"} : (tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5b_branch2a = tile.cion add, mul, %cst, %162, %arg102 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2a = tile.contract add, mul, %cst, %162, %arg102 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %163 = "eltwise.add"(%res5b_branch2a, %arg101) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %164 = "eltwise.cmp_lt"(%163, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %165 = "eltwise.select"(%164, %cst, %163) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5b_branch2b = tile.cion add, mul, %cst, %165, %arg100 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5b_branch2b = tile.contract add, mul, %cst, %165, %arg100 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %166 = "eltwise.add"(%res5b_branch2b, %arg99) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %167 = "eltwise.cmp_lt"(%166, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %168 = "eltwise.select"(%167, %cst, %166) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5b_branch2c = tile.cion add, mul, %cst, %168, %arg98 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5b_branch2c = tile.contract add, mul, %cst, %168, %arg98 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
     %169 = "eltwise.add"(%res5b_branch2c, %arg97) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %170 = "eltwise.add"(%169, %162) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %171 = "eltwise.cmp_lt"(%170, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
     %172 = "eltwise.select"(%171, %cst, %170) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %173 = "tile.trace"(%172) {msg = "res5c"} : (tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %res5c_branch2a = tile.cion add, mul, %cst, %173, %arg108 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2a = tile.contract add, mul, %cst, %173, %arg108 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x2048x!eltwise.f32>, tensor<1x1x2048x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %174 = "eltwise.add"(%res5c_branch2a, %arg107) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %175 = "eltwise.cmp_lt"(%174, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %176 = "eltwise.select"(%175, %cst, %174) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5c_branch2b = tile.cion add, mul, %cst, %176, %arg106 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
+    %res5c_branch2b = tile.contract add, mul, %cst, %176, %arg106 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map6, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<3x3x512x512x!eltwise.f32> -> tensor<1x7x7x512x!eltwise.f32>
     %177 = "eltwise.add"(%res5c_branch2b, %arg105) : (tensor<1x7x7x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
     %178 = "eltwise.cmp_lt"(%177, %cst) : (tensor<1x7x7x512x!eltwise.f32>, !f32) -> tensor<1x7x7x512x!eltwise.u1>
     %179 = "eltwise.select"(%178, %cst, %177) : (tensor<1x7x7x512x!eltwise.u1>, !f32, tensor<1x7x7x512x!eltwise.f32>) -> tensor<1x7x7x512x!eltwise.f32>
-    %res5c_branch2c = tile.cion add, mul, %cst, %179, %arg104 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
+    %res5c_branch2c = tile.contract add, mul, %cst, %179, %arg104 {idxs = ["n", "x0", "x1", "co", "k0", "k1", "ci"], sink = #map0, srcs = [#map5, #map2]} : !f32, tensor<1x7x7x512x!eltwise.f32>, tensor<1x1x512x2048x!eltwise.f32> -> tensor<1x7x7x2048x!eltwise.f32>
     %180 = "eltwise.add"(%res5c_branch2c, %arg103) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %181 = "eltwise.add"(%180, %173) : (tensor<1x7x7x2048x!eltwise.f32>, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
     %182 = "eltwise.cmp_lt"(%181, %cst) : (tensor<1x7x7x2048x!eltwise.f32>, !f32) -> tensor<1x7x7x2048x!eltwise.u1>
     %183 = "eltwise.select"(%182, %cst, %181) : (tensor<1x7x7x2048x!eltwise.u1>, !f32, tensor<1x7x7x2048x!eltwise.f32>) -> tensor<1x7x7x2048x!eltwise.f32>
-    %184 = tile.cion add, none, %cst, %183 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x7x7x2048x!eltwise.f32> -> tensor<1x2048x!eltwise.f32>
+    %184 = tile.contract add, none, %cst, %183 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x7x7x2048x!eltwise.f32> -> tensor<1x2048x!eltwise.f32>
     %185 = "eltwise.div"(%184, %c49) : (tensor<1x2048x!eltwise.f32>, !i32) -> tensor<1x2048x!eltwise.f32>
-    %186 = tile.cion add, mul, %cst, %185, %arg1 {sink = #map10, srcs = [#map11, #map12]} : !f32, tensor<1x2048x!eltwise.f32>, tensor<2048x1000x!eltwise.f32> -> tensor<1x1000x!eltwise.f32>
+    %186 = tile.contract add, mul, %cst, %185, %arg1 {sink = #map10, srcs = [#map11, #map12]} : !f32, tensor<1x2048x!eltwise.f32>, tensor<2048x1000x!eltwise.f32> -> tensor<1x1000x!eltwise.f32>
     %187 = "eltwise.add"(%186, %arg0) : (tensor<1x1000x!eltwise.f32>, tensor<1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
     %188 = "eltwise.ident"(%187) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %189 = tile.cion max, none, %cst, %188 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %189 = tile.contract max, none, %cst, %188 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %190 = "eltwise.sub"(%188, %189) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
     %191 = "eltwise.exp"(%190) : (tensor<1x1000x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
-    %192 = tile.cion add, none, %cst, %191 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %192 = tile.contract add, none, %cst, %191 {sink = #map13, srcs = [#map14]} : !f32, tensor<1x1000x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %193 = "eltwise.div"(%191, %192) : (tensor<1x1000x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x1000x!eltwise.f32>
     return %193 : tensor<1x1000x!eltwise.f32>
   }

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -73,25 +73,25 @@ CombinationKind getCombinationKind(plaidml_combo_op combo_op) {
   throw std::runtime_error("Unsupported combo_op");
 }
 
-mlir::Value MakeAffineOp(plaidml_int_op op, const std::vector<mlir::Value> operands) {
+mlir::Value MakePolyOp(plaidml_int_op op, const std::vector<mlir::Value> operands) {
   auto builder = GlobalContext::get();
   switch (op) {
     case PLAIDML_INT_OP_ADD:
-      return builder->MakeAffineAddOp(operands);
+      return builder->MakePolyAddOp(operands);
     case PLAIDML_INT_OP_DIV:
-      return builder->MakeAffineDivOp(operands);
+      return builder->MakePolyDivOp(operands);
     case PLAIDML_INT_OP_MUL:
-      return builder->MakeAffineMulOp(operands);
+      return builder->MakePolyMulOp(operands);
     case PLAIDML_INT_OP_NEG:
-      return builder->MakeAffineNegOp(operands);
+      return builder->MakePolyNegOp(operands);
     case PLAIDML_INT_OP_SUB:
-      return builder->MakeAffineSubOp(operands);
+      return builder->MakePolySubOp(operands);
     case PLAIDML_INT_OP_MAX:
-      return builder->MakeAffineMaxOp(operands);
+      return builder->MakePolyMaxOp(operands);
     case PLAIDML_INT_OP_MIN:
-      return builder->MakeAffineMinOp(operands);
+      return builder->MakePolyMinOp(operands);
   }
-  throw std::runtime_error("Unknown affine op");
+  throw std::runtime_error("Unknown polynomial op");
 }
 
 }  // namespace
@@ -615,7 +615,7 @@ plaidml_poly_expr* plaidml_poly_expr_index(  //
     const char* name) {
   return ffi_wrap<plaidml_poly_expr*>(err, nullptr, [&] {
     IVLOG(3, "plaidml_poly_expr_index");
-    return new plaidml_poly_expr{GlobalContext::get()->MakeAffineIndexOp(name)};
+    return new plaidml_poly_expr{GlobalContext::get()->MakePolyIndexOp(name)};
   });
 }
 
@@ -624,7 +624,7 @@ plaidml_poly_expr* plaidml_poly_expr_literal(  //
     int64_t value) {
   return ffi_wrap<plaidml_poly_expr*>(err, nullptr, [&] {
     IVLOG(3, "plaidml_poly_expr_literal> " << value);
-    return new plaidml_poly_expr{GlobalContext::get()->MakeAffineConstantOp(value)};
+    return new plaidml_poly_expr{GlobalContext::get()->MakeConstantOp(value)};
   });
 }
 
@@ -639,7 +639,7 @@ plaidml_poly_expr* plaidml_poly_expr_op(  //
     for (size_t i = 0; i < nargs; i++) {
       values[i] = args[i]->value;
     }
-    return new plaidml_poly_expr{MakeAffineOp(op, values)};
+    return new plaidml_poly_expr{MakePolyOp(op, values)};
   });
 }
 
@@ -676,7 +676,7 @@ plaidml_dim_expr* plaidml_dim_expr_int(  //
     int64_t value) {
   return ffi_wrap<plaidml_dim_expr*>(err, nullptr, [&] {
     IVLOG(3, "plaidml_dim_expr_int> " << value);
-    return new plaidml_dim_expr{GlobalContext::get()->MakeAffineConstantOp(value)};
+    return new plaidml_dim_expr{GlobalContext::get()->MakeConstantOp(value)};
   });
 }
 
@@ -703,7 +703,7 @@ plaidml_dim_expr* plaidml_dim_expr_op(  //
     for (size_t i = 0; i < nargs; i++) {
       values[i] = args[i]->value;
     }
-    return new plaidml_dim_expr{MakeAffineOp(op, values)};
+    return new plaidml_dim_expr{MakePolyOp(op, values)};
   });
 }
 

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -337,7 +337,7 @@ TEST_F(CppEdsl, Dot) {
   // CHECK-LABEL: CppEdsl.Dot
   // CHECK: func @dot
   // CHECK: %[[cst:.*]] = "eltwise.sconst"{{.*}}-> !f32
-  // CHECK: %[[cion:.*]] = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {{{.*}}}
+  // CHECK: %[[cion:.*]] = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {{{.*}}}
   // CHECK-SAME: !f32, tensor<3x3x!eltwise.f32>, tensor<3x3x!eltwise.f32> -> tensor<3x3x!eltwise.f32>
   // CHECK: return %[[cion]] : tensor<3x3x!eltwise.f32>
 
@@ -366,8 +366,8 @@ TEST_F(CppEdsl, DoubleDot) {
   // CHECK: func @double_dot
   // CHECK: tensor<10x20x!eltwise.f32>) -> tensor<10x40x!eltwise.f32> {
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<10x20x!eltwise.f32>, tensor<20x30x!eltwise.f32> -> tensor<10x30x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<10x30x!eltwise.f32>, tensor<30x40x!eltwise.f32> -> tensor<10x40x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<10x20x!eltwise.f32>, tensor<20x30x!eltwise.f32> -> tensor<10x30x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<10x30x!eltwise.f32>, tensor<30x40x!eltwise.f32> -> tensor<10x40x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<10x40x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -438,20 +438,20 @@ TEST_F(CppEdsl, MnistMlp) {
   // CHECK: func @mnist_mlp
   // CHECK-DAG: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
   // CHECK-DAG: %[[cst0:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> !f32
-  // CHECK: %[[X0:.*]] = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
+  // CHECK: %[[X0:.*]] = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
   // CHECK: %[[X1:.*]] = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
   // CHECK: %[[X2:.*]] = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x512x!eltwise.f32>, !f32) -> tensor<1x512x!eltwise.u1>
   // CHECK: %[[X3:.*]] = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x512x!eltwise.u1>, !f32, tensor<1x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
-  // CHECK: %[[X4:.*]] = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
+  // CHECK: %[[X4:.*]] = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
   // CHECK: %[[X5:.*]] = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
   // CHECK: %[[X6:.*]] = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x512x!eltwise.f32>, !f32) -> tensor<1x512x!eltwise.u1>
   // CHECK: %[[X7:.*]] = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x512x!eltwise.u1>, !f32, tensor<1x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
-  // CHECK: %[[X8:.*]] = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
+  // CHECK: %[[X8:.*]] = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
   // CHECK: %[[X9:.*]] = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
-  // CHECK: %[[X10:.*]] = tile.cion max, none, %[[cst0]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+  // CHECK: %[[X10:.*]] = tile.contract max, none, %[[cst0]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
   // CHECK: %[[X11:.*]] = "eltwise.sub"(%{{.*}}, %{{.*}}) : (tensor<1x10x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
   // CHECK: %[[X12:.*]] = "eltwise.exp"(%{{.*}}) : (tensor<1x10x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
-  // CHECK: %[[X13:.*]] = tile.cion add, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+  // CHECK: %[[X13:.*]] = tile.contract add, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
   // CHECK: %[[X14:.*]] = "eltwise.div"(%{{.*}}, %{{.*}}) : (tensor<1x10x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x10x!eltwise.f32>
   // clang-format on
@@ -476,7 +476,7 @@ TEST_F(CppEdsl, Convolution) {
   // CHECK-LABEL: CppEdsl.Convolution
   // CHECK: func @convolution
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x222x222x32x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -534,30 +534,30 @@ TEST_F(CppEdsl, MnistCnn) {
   // clang-format off
   // CHECK-LABEL: CppEdsl.MnistCnn
   // CHECK: func @mnist_cnn
-  // CHECK-DAG: %[[c12100:.*]] = tile.affine_const 12100
+  // CHECK-DAG: %[[c12100:.*]] = tile.constant 12100
   // CHECK-DAG: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK-DAG: %[[c1:.*]] = tile.affine_const 1
+  // CHECK-DAG: %[[c1:.*]] = tile.constant 1
   // CHECK-DAG: %[[cst_0:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x222x222x32x!eltwise.f32>, tensor<32x!eltwise.f32>) -> tensor<1x222x222x32x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x222x222x32x!eltwise.f32>, !f32) -> tensor<1x222x222x32x!eltwise.u1>
   // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x222x222x32x!eltwise.u1>, !f32, tensor<1x222x222x32x!eltwise.f32>) -> tensor<1x222x222x32x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x222x222x32x!eltwise.f32>, tensor<3x3x32x64x!eltwise.f32> -> tensor<1x220x220x64x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x222x222x32x!eltwise.f32>, tensor<3x3x32x64x!eltwise.f32> -> tensor<1x220x220x64x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x220x220x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x220x220x64x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x220x220x64x!eltwise.f32>, !f32) -> tensor<1x220x220x64x!eltwise.u1>
   // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x220x220x64x!eltwise.u1>, !f32, tensor<1x220x220x64x!eltwise.f32>) -> tensor<1x220x220x64x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion max, none, %[[cst_0]], %{{.*}} {cons = #set{{[0-9]+}}, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x220x220x64x!eltwise.f32> -> tensor<1x110x110x64x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract max, none, %[[cst_0]], %{{.*}} {cons = #set{{[0-9]+}}, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x220x220x64x!eltwise.f32> -> tensor<1x110x110x64x!eltwise.f32>
   // CHECK: %{{.*}} = "tile.reshape"(%{{.*}}, %[[c1]], %[[c12100]]) : (tensor<1x110x110x64x!eltwise.f32>, index, index) -> tensor<1x12100x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x12100x!eltwise.f32>, tensor<12100x128x!eltwise.f32> -> tensor<1x128x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x12100x!eltwise.f32>, tensor<12100x128x!eltwise.f32> -> tensor<1x128x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x128x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x128x!eltwise.f32>, !f32) -> tensor<1x128x!eltwise.u1>
   // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x128x!eltwise.u1>, !f32, tensor<1x128x!eltwise.f32>) -> tensor<1x128x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x128x!eltwise.f32>, tensor<128x100x!eltwise.f32> -> tensor<1x100x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x128x!eltwise.f32>, tensor<128x100x!eltwise.f32> -> tensor<1x100x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x100x!eltwise.f32>, tensor<100x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion max, none,  %[[cst_0]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract max, none,  %[[cst_0]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.sub"(%{{.*}}, %{{.*}}) : (tensor<1x100x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.exp"(%{{.*}}) : (tensor<1x100x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.div"(%{{.*}}, %{{.*}}) : (tensor<1x100x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x100x!eltwise.f32>
   // clang-format on
@@ -607,11 +607,11 @@ TEST_F(CppEdsl, LarsMomentum4d) {
   // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_1]]) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
   // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
   // CHECK: %{{.*}} = "eltwise.sqrt"(%{{.*}}) : (!f32) -> !f32
   // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_1]]) : (!f32, !f32) -> !f32
   // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
   // CHECK: %{{.*}} = "eltwise.sqrt"(%{{.*}}) : (!f32) -> !f32
   // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (!f32, !f32) -> !f32
   // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_0]]) : (!f32, !f32) -> !f32
@@ -640,7 +640,7 @@ TEST_F(CppEdsl, RepeatElements) {
   // CHECK-LABEL: CppEdsl.RepeatElements
   // CHECK: func @repeat_elts
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion assign, none, %[[cst]], %{{.*}} {cons = #set{{[0-9]+}}, no_reduce, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x10x10x!eltwise.f32> -> tensor<10x30x10x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract assign, none, %[[cst]], %{{.*}} {cons = #set{{[0-9]+}}, no_reduce, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x10x10x!eltwise.f32> -> tensor<10x30x10x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<10x30x10x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -659,7 +659,7 @@ TEST_F(CppEdsl, UseDefault) {
   // clang-format off
   // CHECK-LABEL: CppEdsl.UseDefault
   // CHECK: func @use_default
-  // CHECK: %{{.*}} = tile.cion assign, none, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<1x7x10x10x!eltwise.f32>, tensor<1x10x10x!eltwise.f32> -> tensor<1x7x10x10x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<1x7x10x10x!eltwise.f32>, tensor<1x10x10x!eltwise.f32> -> tensor<1x7x10x10x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x7x10x10x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -692,10 +692,10 @@ TEST_F(CppEdsl, ArgMax) {
   // CHECK-DAG: %[[cst:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> !f32
   // CHECK-DAG: %[[c0:.*]] = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
   // CHECK-DAG: %[[c1:.*]] = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
-  // CHECK: %{{.*}} = tile.cion assign, none, %[[c0]], %[[c1]] {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !i32, !i32 -> tensor<10x!eltwise.i32>
+  // CHECK: %{{.*}} = tile.contract assign, none, %[[c0]], %[[c1]] {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !i32, !i32 -> tensor<10x!eltwise.i32>
   // CHECK: %{{.*}} = "tile.index"(%{{.*}}) {dim = 0 : i64} : (tensor<10x!eltwise.i32>) -> tensor<10x!eltwise.i32>
-  // CHECK: %{{.*}} = tile.cion max, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion max, cond, %[[i64_min]], %{{.*}}, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}, #map{{[0-9]+}}]} : !i32, tensor<1x10x10x!eltwise.f32>, tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.i32> -> tensor<1x10x!eltwise.i32>
+  // CHECK: %{{.*}} = tile.contract max, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<1x10x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract max, cond, %[[i64_min]], %{{.*}}, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}, #map{{[0-9]+}}]} : !i32, tensor<1x10x10x!eltwise.f32>, tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.i32> -> tensor<1x10x!eltwise.i32>
   // CHECK: %{{.*}} = "eltwise.cast"(%{{.*}}) : (tensor<1x10x!eltwise.i32>) -> tensor<1x10x!eltwise.u32>
   // CHECK: return %{{.*}} : tensor<1x10x!eltwise.u32>
   // clang-format on
@@ -777,7 +777,7 @@ TEST_F(CppEdsl, GlobalMin) {
   // CHECK: func @global_min
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> !f32
   // CHECK: %{{.*}} = "eltwise.neg"(%{{.*}}) : (tensor<10x10x10x!eltwise.f32>) -> tensor<10x10x10x!eltwise.f32>
-  // CHECK: %{{.*}} = tile.cion max, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x10x10x!eltwise.f32> -> !f32
+  // CHECK: %{{.*}} = tile.contract max, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x10x10x!eltwise.f32> -> !f32
   // CHECK: %{{.*}} = "eltwise.neg"(%{{.*}}) : (!f32) -> !f32
   // CHECK: return %{{.*}} : !f32
   // clang-format on
@@ -797,7 +797,7 @@ TEST_F(CppEdsl, CumSum) {
   // CHECK-LABEL: CppEdsl.CumSum
   // CHECK: func @cumsum
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, none, %[[cst]], %{{.*}} {cons = #set{{[0-9]+}}, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x!eltwise.f32> -> tensor<10x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst]], %{{.*}} {cons = #set{{[0-9]+}}, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : !f32, tensor<10x!eltwise.f32> -> tensor<10x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<10x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -850,7 +850,7 @@ TEST_F(CppEdsl, ComplexConv2d) {
   // CHECK-LABEL: CppEdsl.ComplexConv2d
   // CHECK: func @complex_conv_2d
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x3x3x!eltwise.f32>, tensor<3x3x3x3x32x!eltwise.f32> -> tensor<1x112x112x3x32x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x224x224x3x3x!eltwise.f32>, tensor<3x3x3x3x32x!eltwise.f32> -> tensor<1x112x112x3x32x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x112x112x3x32x!eltwise.f32>
   // clang-format on
   runProgram(program);
@@ -982,7 +982,7 @@ TEST_F(CppEdsl, DefractLong) {
   // CHECK-LABEL: CppEdsl.DefractLong
   // CHECK: func @defract_long
   // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-  // CHECK: %{{.*}} = tile.cion add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x3x3x1x!eltwise.f32>, tensor<1x3x3x1x!eltwise.f32> -> tensor<1x5x5x1x!eltwise.f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !f32, tensor<1x3x3x1x!eltwise.f32>, tensor<1x3x3x1x!eltwise.f32> -> tensor<1x5x5x1x!eltwise.f32>
   // CHECK: return %{{.*}} : tensor<1x5x5x1x!eltwise.f32>
   // clang-format on
   runProgram(program);

--- a/plaidml/edsl/tests/edsl_test.py
+++ b/plaidml/edsl/tests/edsl_test.py
@@ -366,7 +366,7 @@ module {
 module {
   func @sum_over_axis(%arg0: tensor<1x784x!eltwise.f32>) -> tensor<784x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
     return %0 : tensor<784x!eltwise.f32>
   }
 }
@@ -386,7 +386,7 @@ module {
 module {
   func @max_over_axis(%arg0: tensor<1x784x!eltwise.f32>) -> tensor<784x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion max, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
+    %0 = tile.contract max, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
     return %0 : tensor<784x!eltwise.f32>
   }
 }
@@ -408,7 +408,7 @@ module {
 module {
   func @matmul(%arg0: tensor<784x784x!eltwise.f32>, %arg1: tensor<1x784x!eltwise.f32>) -> tensor<1x784x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x784x!eltwise.f32> -> tensor<1x784x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x784x!eltwise.f32> -> tensor<1x784x!eltwise.f32>
     return %0 : tensor<1x784x!eltwise.f32>
   }
 }
@@ -428,7 +428,7 @@ module {
 module {
   func @avg(%arg0: tensor<1x784x!eltwise.f32>) -> !f32 {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
     return %0 : !f32
   }
 }
@@ -448,8 +448,8 @@ module {
 module {
   func @avg_stages(%arg0: tensor<1x784x!eltwise.f32>) -> !f32 {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %c784 = tile.affine_const 784
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
+    %c784 = tile.constant 784
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
     %1 = "eltwise.div"(%0, %c784) : (!f32, index) -> !f32
     return %1 : !f32
   }
@@ -470,8 +470,8 @@ module {
 module {
   func @avg_merge(%arg0: tensor<1x784x!eltwise.f32>) -> !f32 {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %c784 = tile.affine_const 784
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
+    %c784 = tile.constant 784
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> !f32
     %1 = "eltwise.div"(%0, %c784) : (!f32, index) -> !f32
     return %1 : !f32
   }
@@ -493,7 +493,7 @@ module {
 module {
   func @max_pool_1d(%arg0: tensor<10x!eltwise.f32> {tile.name = "I"}) -> tensor<5x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion max, none, %cst, %arg0 {cons = #set0, sink = #map0, srcs = [#map1]} : !f32, tensor<10x!eltwise.f32> -> tensor<5x!eltwise.f32>
+    %0 = tile.contract max, none, %cst, %arg0 {cons = #set0, sink = #map0, srcs = [#map1]} : !f32, tensor<10x!eltwise.f32> -> tensor<5x!eltwise.f32>
     return %0 : tensor<5x!eltwise.f32>
   }
 }
@@ -513,7 +513,7 @@ module {
 module {
   func @skip(%arg0: tensor<1x784x!eltwise.f32>) -> tensor<784x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<1x784x!eltwise.f32> -> tensor<784x!eltwise.f32>
     return %0 : tensor<784x!eltwise.f32>
   }
 }
@@ -535,7 +535,7 @@ module {
 module {
   func @conv_1d(%arg0: tensor<3x3x1x!eltwise.f32>, %arg1: tensor<1x224x3x!eltwise.f32>) -> tensor<1x222x1x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x3x!eltwise.f32>, tensor<3x3x1x!eltwise.f32> -> tensor<1x222x1x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x3x!eltwise.f32>, tensor<3x3x1x!eltwise.f32> -> tensor<1x222x1x!eltwise.f32>
     return %0 : tensor<1x222x1x!eltwise.f32>
   }
 }
@@ -557,7 +557,7 @@ module {
 module {
   func @conv_2d_dilated(%arg0: tensor<3x3x1x32x!eltwise.f32>, %arg1: tensor<1x224x224x1x!eltwise.f32>) -> tensor<1x220x218x32x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x220x218x32x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x220x218x32x!eltwise.f32>
     return %0 : tensor<1x220x218x32x!eltwise.f32>
   }
 }
@@ -579,7 +579,7 @@ module {
 module {
   func @complex_conv_2d(%arg0: tensor<3x3x3x3x32x!eltwise.f32>, %arg1: tensor<1x224x224x3x3x!eltwise.f32>) -> tensor<1x224x112x3x32x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x3x!eltwise.f32>, tensor<3x3x3x3x32x!eltwise.f32> -> tensor<1x224x112x3x32x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x3x3x!eltwise.f32>, tensor<3x3x3x3x32x!eltwise.f32> -> tensor<1x224x112x3x32x!eltwise.f32>
     return %0 : tensor<1x224x112x3x32x!eltwise.f32>
   }
 }
@@ -621,20 +621,20 @@ module {
 module {
   func @mnist_mlp(%arg0: tensor<10x!eltwise.f32>, %arg1: tensor<512x10x!eltwise.f32>, %arg2: tensor<512x!eltwise.f32>, %arg3: tensor<512x512x!eltwise.f32>, %arg4: tensor<512x!eltwise.f32>, %arg5: tensor<784x512x!eltwise.f32>, %arg6: tensor<1x784x!eltwise.f32>) -> tensor<1x10x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg6, %arg5 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg6, %arg5 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
     %1 = "eltwise.add"(%0, %arg4) : (tensor<1x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
     %2 = "eltwise.cmp_lt"(%1, %cst) : (tensor<1x512x!eltwise.f32>, !f32) -> tensor<1x512x!eltwise.u1>
     %3 = "eltwise.select"(%2, %cst, %1) : (tensor<1x512x!eltwise.u1>, !f32, tensor<1x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
-    %4 = tile.cion add, mul, %cst, %3, %arg3 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
+    %4 = tile.contract add, mul, %cst, %3, %arg3 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
     %5 = "eltwise.add"(%4, %arg2) : (tensor<1x512x!eltwise.f32>, tensor<512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
     %6 = "eltwise.cmp_lt"(%5, %cst) : (tensor<1x512x!eltwise.f32>, !f32) -> tensor<1x512x!eltwise.u1>
     %7 = "eltwise.select"(%6, %cst, %5) : (tensor<1x512x!eltwise.u1>, !f32, tensor<1x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32>
-    %8 = tile.cion add, mul, %cst, %7, %arg1 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
+    %8 = tile.contract add, mul, %cst, %7, %arg1 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x512x!eltwise.f32>, tensor<512x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
     %9 = "eltwise.add"(%8, %arg0) : (tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
-    %10 = tile.cion max, none, %cst, %9 {sink = #map3, srcs = [#map4]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %10 = tile.contract max, none, %cst, %9 {sink = #map3, srcs = [#map4]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %11 = "eltwise.sub"(%9, %10) : (tensor<1x10x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
     %12 = "eltwise.exp"(%11) : (tensor<1x10x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
-    %13 = tile.cion add, none, %cst, %12 {sink = #map3, srcs = [#map4]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %13 = tile.contract add, none, %cst, %12 {sink = #map3, srcs = [#map4]} : !f32, tensor<1x10x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %14 = "eltwise.div"(%12, %13) : (tensor<1x10x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x10x!eltwise.f32>
     return %14 : tensor<1x10x!eltwise.f32>
   }
@@ -683,29 +683,29 @@ module {
 !i32 = type tensor<!eltwise.i32>
 module {
   func @mnist_cnn(%arg0: tensor<100x!eltwise.f32>, %arg1: tensor<128x100x!eltwise.f32>, %arg2: tensor<128x!eltwise.f32>, %arg3: tensor<12100x128x!eltwise.f32>, %arg4: tensor<64x!eltwise.f32>, %arg5: tensor<3x3x32x64x!eltwise.f32>, %arg6: tensor<32x!eltwise.f32>, %arg7: tensor<3x3x1x32x!eltwise.f32>, %arg8: tensor<1x224x224x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32> {
-    %c12100 = tile.affine_const 12100
+    %c12100 = tile.constant 12100
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
     %c1 = "eltwise.sconst"() {value = 1 : i64} : () -> !i32
-    %0 = tile.cion add, mul, %cst, %arg8, %arg7 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg8, %arg7 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x224x224x1x!eltwise.f32>, tensor<3x3x1x32x!eltwise.f32> -> tensor<1x222x222x32x!eltwise.f32>
     %1 = "eltwise.add"(%0, %arg6) : (tensor<1x222x222x32x!eltwise.f32>, tensor<32x!eltwise.f32>) -> tensor<1x222x222x32x!eltwise.f32>
     %2 = "eltwise.cmp_lt"(%1, %cst) : (tensor<1x222x222x32x!eltwise.f32>, !f32) -> tensor<1x222x222x32x!eltwise.u1>
     %3 = "eltwise.select"(%2, %cst, %1) : (tensor<1x222x222x32x!eltwise.u1>, !f32, tensor<1x222x222x32x!eltwise.f32>) -> tensor<1x222x222x32x!eltwise.f32>
-    %4 = tile.cion add, mul, %cst, %3, %arg5 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x222x222x32x!eltwise.f32>, tensor<3x3x32x64x!eltwise.f32> -> tensor<1x220x220x64x!eltwise.f32>
+    %4 = tile.contract add, mul, %cst, %3, %arg5 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x222x222x32x!eltwise.f32>, tensor<3x3x32x64x!eltwise.f32> -> tensor<1x220x220x64x!eltwise.f32>
     %5 = "eltwise.add"(%4, %arg4) : (tensor<1x220x220x64x!eltwise.f32>, tensor<64x!eltwise.f32>) -> tensor<1x220x220x64x!eltwise.f32>
     %6 = "eltwise.cmp_lt"(%5, %cst) : (tensor<1x220x220x64x!eltwise.f32>, !f32) -> tensor<1x220x220x64x!eltwise.u1>
     %7 = "eltwise.select"(%6, %cst, %5) : (tensor<1x220x220x64x!eltwise.u1>, !f32, tensor<1x220x220x64x!eltwise.f32>) -> tensor<1x220x220x64x!eltwise.f32>
-    %8 = tile.cion max, none, %cst, %7 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x220x220x64x!eltwise.f32> -> tensor<1x110x110x64x!eltwise.f32>
+    %8 = tile.contract max, none, %cst, %7 {cons = #set0, sink = #map3, srcs = [#map4]} : !f32, tensor<1x220x220x64x!eltwise.f32> -> tensor<1x110x110x64x!eltwise.f32>
     %9 = "tile.reshape"(%8, %c1, %c12100) : (tensor<1x110x110x64x!eltwise.f32>, !i32, index) -> tensor<1x12100x!eltwise.f32>
-    %10 = tile.cion add, mul, %cst, %9, %arg3 {sink = #map5, srcs = [#map6, #map7]} : !f32, tensor<1x12100x!eltwise.f32>, tensor<12100x128x!eltwise.f32> -> tensor<1x128x!eltwise.f32>
+    %10 = tile.contract add, mul, %cst, %9, %arg3 {sink = #map5, srcs = [#map6, #map7]} : !f32, tensor<1x12100x!eltwise.f32>, tensor<12100x128x!eltwise.f32> -> tensor<1x128x!eltwise.f32>
     %11 = "eltwise.add"(%10, %arg2) : (tensor<1x128x!eltwise.f32>, tensor<128x!eltwise.f32>) -> tensor<1x128x!eltwise.f32>
     %12 = "eltwise.cmp_lt"(%11, %cst) : (tensor<1x128x!eltwise.f32>, !f32) -> tensor<1x128x!eltwise.u1>
     %13 = "eltwise.select"(%12, %cst, %11) : (tensor<1x128x!eltwise.u1>, !f32, tensor<1x128x!eltwise.f32>) -> tensor<1x128x!eltwise.f32>
-    %14 = tile.cion add, mul, %cst, %13, %arg1 {sink = #map5, srcs = [#map6, #map7]} : !f32, tensor<1x128x!eltwise.f32>, tensor<128x100x!eltwise.f32> -> tensor<1x100x!eltwise.f32>
+    %14 = tile.contract add, mul, %cst, %13, %arg1 {sink = #map5, srcs = [#map6, #map7]} : !f32, tensor<1x128x!eltwise.f32>, tensor<128x100x!eltwise.f32> -> tensor<1x100x!eltwise.f32>
     %15 = "eltwise.add"(%14, %arg0) : (tensor<1x100x!eltwise.f32>, tensor<100x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
-    %16 = tile.cion max, none, %cst, %15 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %16 = tile.contract max, none, %cst, %15 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %17 = "eltwise.sub"(%15, %16) : (tensor<1x100x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
     %18 = "eltwise.exp"(%17) : (tensor<1x100x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
-    %19 = tile.cion add, none, %cst, %18 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
+    %19 = tile.contract add, none, %cst, %18 {sink = #map8, srcs = [#map9]} : !f32, tensor<1x100x!eltwise.f32> -> tensor<1x1x!eltwise.f32>
     %20 = "eltwise.div"(%18, %19) : (tensor<1x100x!eltwise.f32>, tensor<1x1x!eltwise.f32>) -> tensor<1x100x!eltwise.f32>
     return %20 : tensor<1x100x!eltwise.f32>
   }
@@ -730,10 +730,10 @@ module {
 module {
   func @arg_max(%arg0: !f32, %arg1: tensor<1x10x10x!eltwise.f32>) -> tensor<1x10x!eltwise.u32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion assign, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, !f32 -> tensor<10x!eltwise.f32>
+    %0 = tile.contract assign, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, !f32 -> tensor<10x!eltwise.f32>
     %1 = "tile.index"(%0) {dim = 0 : i64} : (tensor<10x!eltwise.f32>) -> tensor<10x!eltwise.i32>
-    %2 = tile.cion max, none, %cst, %arg1 {sink = #map2, srcs = [#map3]} : !f32, tensor<1x10x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
-    %3 = tile.cion max, cond, %cst, %arg1, %2, %1 {sink = #map2, srcs = [#map3, #map2, #map4]} : !f32, tensor<1x10x10x!eltwise.f32>, tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.i32> -> tensor<1x10x!eltwise.i32>
+    %2 = tile.contract max, none, %cst, %arg1 {sink = #map2, srcs = [#map3]} : !f32, tensor<1x10x10x!eltwise.f32> -> tensor<1x10x!eltwise.f32>
+    %3 = tile.contract max, cond, %cst, %arg1, %2, %1 {sink = #map2, srcs = [#map3, #map2, #map4]} : !f32, tensor<1x10x10x!eltwise.f32>, tensor<1x10x!eltwise.f32>, tensor<10x!eltwise.i32> -> tensor<1x10x!eltwise.i32>
     %4 = "eltwise.cast"(%3) : (tensor<1x10x!eltwise.i32>) -> tensor<1x10x!eltwise.u32>
     return %4 : tensor<1x10x!eltwise.u32>
   }
@@ -755,7 +755,7 @@ module {
   func @global_min(%arg0: tensor<10x10x10x!eltwise.f32> {tile.name = "I"}) -> !f32 {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
     %0 = "eltwise.neg"(%arg0) : (tensor<10x10x10x!eltwise.f32>) -> tensor<10x10x10x!eltwise.f32>
-    %1 = tile.cion max, none, %cst, %0 {sink = #map0, srcs = [#map1]} : !f32, tensor<10x10x10x!eltwise.f32> -> !f32
+    %1 = tile.contract max, none, %cst, %0 {sink = #map0, srcs = [#map1]} : !f32, tensor<10x10x10x!eltwise.f32> -> !f32
     %2 = "eltwise.neg"(%1) : (!f32) -> !f32
     return %2 : !f32
   }
@@ -777,7 +777,7 @@ module {
 module {
   func @cum_sum(%arg0: tensor<10x!eltwise.f32> {tile.name = "I"}) -> tensor<10x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, none, %cst, %arg0 {cons = #set0, sink = #map0, srcs = [#map1]} : !f32, tensor<10x!eltwise.f32> -> tensor<10x!eltwise.f32>
+    %0 = tile.contract add, none, %cst, %arg0 {cons = #set0, sink = #map0, srcs = [#map1]} : !f32, tensor<10x!eltwise.f32> -> tensor<10x!eltwise.f32>
     return %0 : tensor<10x!eltwise.f32>
   }
 }
@@ -834,11 +834,11 @@ module {
     %0 = "eltwise.mul"(%arg0, %cst_1) : (tensor<4x7x3x9x!eltwise.f32>, !f32) -> tensor<4x7x3x9x!eltwise.f32>
     %1 = "eltwise.add"(%arg1, %0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
     %2 = "eltwise.mul"(%arg0, %arg0) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %3 = tile.cion add, none, %cst_2, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %3 = tile.contract add, none, %cst_2, %2 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %4 = "eltwise.sqrt"(%3) : (!f32) -> !f32
     %5 = "eltwise.mul"(%4, %cst_1) : (!f32, !f32) -> !f32
     %6 = "eltwise.mul"(%arg1, %arg1) : (tensor<4x7x3x9x!eltwise.f32>, tensor<4x7x3x9x!eltwise.f32>) -> tensor<4x7x3x9x!eltwise.f32>
-    %7 = tile.cion add, none, %cst_2, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
+    %7 = tile.contract add, none, %cst_2, %6 {sink = #map0, srcs = [#map1]} : !f32, tensor<4x7x3x9x!eltwise.f32> -> !f32
     %8 = "eltwise.sqrt"(%7) : (!f32) -> !f32
     %9 = "eltwise.add"(%8, %5) : (!f32, !f32) -> !f32
     %10 = "eltwise.mul"(%arg2, %cst_0) : (!f32, !f32) -> !f32
@@ -874,7 +874,7 @@ module {
 module {
   func @repeat_elts(%arg0: tensor<10x10x10x!eltwise.f32>) -> tensor<10x30x10x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion assign, none, %cst, %arg0 {cons = #set0, no_reduce, sink = #map0, srcs = [#map1]} : !f32, tensor<10x10x10x!eltwise.f32> -> tensor<10x30x10x!eltwise.f32>
+    %0 = tile.contract assign, none, %cst, %arg0 {cons = #set0, no_reduce, sink = #map0, srcs = [#map1]} : !f32, tensor<10x10x10x!eltwise.f32> -> tensor<10x30x10x!eltwise.f32>
     return %0 : tensor<10x30x10x!eltwise.f32>
   }
 }
@@ -898,7 +898,7 @@ module {
 
 module {
   func @use_default(%arg0: tensor<1x10x10x!eltwise.f32>, %arg1: tensor<1x7x10x10x!eltwise.f32>) -> tensor<1x7x10x10x!eltwise.f32> {
-    %0 = tile.cion assign, none, %arg1, %arg0 {sink = #map0, srcs = [#map1]} : tensor<1x7x10x10x!eltwise.f32>, tensor<1x10x10x!eltwise.f32> -> tensor<1x7x10x10x!eltwise.f32>
+    %0 = tile.contract assign, none, %arg1, %arg0 {sink = #map0, srcs = [#map1]} : tensor<1x7x10x10x!eltwise.f32>, tensor<1x10x10x!eltwise.f32> -> tensor<1x7x10x10x!eltwise.f32>
     return %0 : tensor<1x7x10x10x!eltwise.f32>
   }
 }
@@ -922,7 +922,7 @@ module {
 module {
   func @defract_test(%arg0: tensor<3x!eltwise.f32> {tile.name = "K"}, %arg1: tensor<3x!eltwise.f32> {tile.name = "I"}) -> tensor<5x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<3x!eltwise.f32>, tensor<3x!eltwise.f32> -> tensor<5x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<3x!eltwise.f32>, tensor<3x!eltwise.f32> -> tensor<5x!eltwise.f32>
     return %0 : tensor<5x!eltwise.f32>
   }
 }
@@ -951,7 +951,7 @@ module {
 module {
   func @defract_short_test(%arg0: tensor<3x!eltwise.f32> {tile.name = "I"}) -> tensor<6x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<3x!eltwise.f32> -> tensor<6x!eltwise.f32>
+    %0 = tile.contract add, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : !f32, tensor<3x!eltwise.f32> -> tensor<6x!eltwise.f32>
     return %0 : tensor<6x!eltwise.f32>
   }
 }
@@ -983,7 +983,7 @@ module {
 module {
   func @defract_long(%arg0: tensor<1x3x3x1x!eltwise.f32> {tile.name = "K"}, %arg1: tensor<1x3x3x1x!eltwise.f32> {tile.name = "I"}) -> tensor<1x5x5x1x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x3x3x1x!eltwise.f32>, tensor<1x3x3x1x!eltwise.f32> -> tensor<1x5x5x1x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<1x3x3x1x!eltwise.f32>, tensor<1x3x3x1x!eltwise.f32> -> tensor<1x5x5x1x!eltwise.f32>
     return %0 : tensor<1x5x5x1x!eltwise.f32>
   }
 }
@@ -1032,7 +1032,7 @@ module {
 module {
   func @"this-is-not an identifier"(%arg0: tensor<3x!eltwise.f32> {tile.name = "K"}, %arg1: tensor<3x!eltwise.f32> {tile.name = "I"}) -> tensor<5x!eltwise.f32> {
     %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> !f32
-    %0 = tile.cion add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<3x!eltwise.f32>, tensor<3x!eltwise.f32> -> tensor<5x!eltwise.f32>
+    %0 = tile.contract add, mul, %cst, %arg1, %arg0 {sink = #map0, srcs = [#map1, #map2]} : !f32, tensor<3x!eltwise.f32>, tensor<3x!eltwise.f32> -> tensor<5x!eltwise.f32>
     return %0 : tensor<5x!eltwise.f32>
   }
 }

--- a/pmlc/conversion/tile_to_pxa/tests/dot.mlir
+++ b/pmlc/conversion/tile_to_pxa/tests/dot.mlir
@@ -8,9 +8,9 @@
 !i32 = type !eltwise.i32
 func @dot(%arg0: tensor<1x784x!eltwise.f32>, %arg1: tensor<784x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.affine_const 512
-  %1 = tile.affine_const 1
-  %2 = tile.cion add, mul, %c0, %arg0, %arg1 {sink=#map0, srcs=[#map1, #map2]} :
+  %0 = tile.constant 512
+  %1 = tile.constant 1
+  %2 = tile.contract add, mul, %c0, %arg0, %arg1 {sink=#map0, srcs=[#map1, #map2]} :
     !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
   return %2 : tensor<1x512x!eltwise.f32>
 }

--- a/pmlc/conversion/tile_to_pxa/tests/double_dot.mlir
+++ b/pmlc/conversion/tile_to_pxa/tests/double_dot.mlir
@@ -12,9 +12,9 @@ func @double_dot(
   %arg2: tensor<30x40x!eltwise.f32>
 ) -> tensor<10x40x!eltwise.f32> {
   %cst = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion add, mul, %cst, %arg0, %arg1 {sink = #map0, srcs = [#map1, #map2]} :
+  %0 = tile.contract add, mul, %cst, %arg0, %arg1 {sink = #map0, srcs = [#map1, #map2]} :
     !f32, tensor<10x20x!eltwise.f32>, tensor<20x30x!eltwise.f32> -> tensor<10x30x!eltwise.f32>
-  %1 = tile.cion add, mul, %cst, %0, %arg2 {sink = #map0, srcs = [#map1, #map2]} :
+  %1 = tile.contract add, mul, %cst, %0, %arg2 {sink = #map0, srcs = [#map1, #map2]} :
     !f32, tensor<10x30x!eltwise.f32>, tensor<30x40x!eltwise.f32> -> tensor<10x40x!eltwise.f32>
   return %1 : tensor<10x40x!eltwise.f32>
 }

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -24,11 +24,12 @@ namespace pmlc::conversion::tile_to_pxa {
 
 namespace ew = dialect::eltwise;
 namespace pxa = dialect::pxa;
+using namespace mlir; // NOLINT
 
 using dialect::eltwise::ScalarType;
-using dialect::tile::AffineConstantOp;
 using dialect::tile::AggregationKind;
 using dialect::tile::CombinationKind;
+using dialect::tile::ConstantOp;
 using dialect::tile::ContractionOp;
 using dialect::tile::ContractionOpOperandAdaptor;
 using dialect::tile::IndexOp;
@@ -36,48 +37,6 @@ using dialect::tile::ShapeOp;
 using dialect::tile::ShapeOpOperandAdaptor;
 using dialect::tile::TraceOp;
 using util::DataType;
-
-using llvm::Optional;
-using llvm::SmallVector;
-using mlir::AffineConstantExpr;
-using mlir::AffineIfOp;
-using mlir::AffineLoadOp;
-using mlir::AffineMap;
-using mlir::AffineMapAttr;
-using mlir::AffineParallelOp;
-using mlir::AffineStoreOp;
-using mlir::AllocOp;
-using mlir::ArrayRef;
-using mlir::Attribute;
-using mlir::CallOp;
-using mlir::CmpFPredicate;
-using mlir::CmpIPredicate;
-using mlir::ConversionPattern;
-using mlir::ConversionPatternRewriter;
-using mlir::FlatSymbolRefAttr;
-using mlir::FloatAttr;
-using mlir::FloatType;
-using mlir::FuncOp;
-using mlir::FunctionType;
-using mlir::IntegerAttr;
-using mlir::IntegerType;
-using mlir::Location;
-using mlir::MemRefType;
-using mlir::MLIRContext;
-using mlir::ModuleOp;
-using mlir::NamedAttribute;
-using mlir::OpBuilder;
-using mlir::OpConversionPattern;
-using mlir::Operation;
-using mlir::OwningRewritePatternList;
-using mlir::Pattern;
-using mlir::PatternMatchResult;
-using mlir::RankedTensorType;
-using mlir::ReturnOp;
-using mlir::StringAttr;
-using mlir::SymbolRefAttr;
-using mlir::Type;
-using mlir::Value;
 
 namespace {
 
@@ -147,12 +106,11 @@ struct FuncOpConversion : public OpConversionPattern<FuncOp> {
   }
 };
 
-struct AffineConstantOpConversion
-    : public OpConversionPattern<AffineConstantOp> {
-  using OpConversionPattern<AffineConstantOp>::OpConversionPattern;
+struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
+  using OpConversionPattern<ConstantOp>::OpConversionPattern;
 
   PatternMatchResult
-  matchAndRewrite(AffineConstantOp op, ArrayRef<Value> operands,
+  matchAndRewrite(ConstantOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
     auto value = op.getValue().cast<IntegerAttr>().getInt();
     rewriter.replaceOpWithNewOp<mlir::ConstantIndexOp>(op, value);
@@ -884,7 +842,7 @@ struct LoweringPass : public mlir::ModulePass<LoweringPass> {
         CmpIntInequalityOp<CmpIPredicate::sge, CmpIPredicate::uge>;
     OwningRewritePatternList patterns;
     patterns.insert<
-        AffineConstantOpConversion, CastOpConversion, FuncOpConversion,
+        ConstantOpConversion, CastOpConversion, FuncOpConversion,
         IndexOpConversion, ReturnOpConversion, ScalarConstantOpConversion,
         ShapeOpConversion,
         TraceOpConversion, // TODO: PrngOpConversion

--- a/pmlc/dialect/eltwise/ir/ops.td
+++ b/pmlc/dialect/eltwise/ir/ops.td
@@ -19,21 +19,11 @@ def EltwiseDialect : Dialect {
   let cppNamespace = "pmlc::dialect::eltwise";
 }
 
-class EltwiseBuilderImpl {
-  code EltwiseBuilderImpl_create = [{
-    static Operation* create(OpBuilder* builder, Location loc, ValueRange operands) {
-      OperationState state(loc, getOperationName());
-      state.addOperands(operands);
-      state.addTypes(getResultType(operands));
-      return builder->createOperation(state);
-    }
-  }];
-}
-
 class EltwiseOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
-    Op<EltwiseDialect, mnemonic, !listconcat(traits, [EltwiseOpInterface, GenericBuilderInterface])>,
-    EltwiseBuilderImpl {
-}
+    Op<EltwiseDialect, mnemonic, !listconcat(traits, [
+      EltwiseOpInterface,
+      GenericBuilderInterface
+    ])>;
 
 def ScalarConstantOp :
     Op<EltwiseDialect, "sconst", [NoSideEffect]>,
@@ -82,7 +72,7 @@ class EW_UnaryOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
     static Type getResultType(ValueRange operands) {
       return ComputeResultType(operands);
     }
-  }] # EltwiseBuilderImpl_create;
+  }];
 }
 
 class EW_BinaryOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
@@ -102,7 +92,7 @@ class EW_BinaryOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
     static Type getResultType(ValueRange operands) {
       return ComputeResultType(operands);
     }
-  }] # EltwiseBuilderImpl_create;
+  }];
 }
 
 def EW_CastOp : Op<EltwiseDialect, "cast", [EltwiseOpInterface, NoSideEffect]>,
@@ -129,7 +119,7 @@ class EW_CompareOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
     static Type getResultType(ValueRange operands) {
       return ComputeResultType(operands, DataType::u1);
     }
-  }] # EltwiseBuilderImpl_create;
+  }];
 }
 
 class EW_UnaryIntOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
@@ -207,7 +197,7 @@ def EW_SelectOp : EltwiseOp<"select">, HasCanonicalizer {
 
   let extraClassDeclaration = [{
     static Type getResultType(ValueRange operands);
-  }] # EltwiseBuilderImpl_create;
+  }];
 }
 
 #endif // __PML_ELTWISE_OPS__

--- a/pmlc/dialect/tile/builder.cc
+++ b/pmlc/dialect/tile/builder.cc
@@ -262,11 +262,11 @@ void TileBuilder::BindTensorDims(Value from, ArrayRef<Value *> intos) {
         if (!op) {
           throw std::runtime_error("No defining op");
         }
-        if (auto const_op = llvm::dyn_cast<AffineConstantOp>(op)) {
+        if (auto const_op = llvm::dyn_cast<ConstantOp>(op)) {
           auto attr = const_op.getValue().dyn_cast<IntegerAttr>();
           if (!attr) {
             throw std::runtime_error(
-                "Expected IntegerAttr for value of AffineConstantOp");
+                "Expected IntegerAttr for value of ConstantOp");
           }
           IVLOG(6, "dim: " << i << ", from: " << fromSize
                            << ", into: " << attr.getInt());
@@ -457,51 +457,50 @@ Value TileBuilder::MakePlaceholderOp(RankedTensorType type, BufferPtr buffer,
   return op.result();
 }
 
-Value TileBuilder::MakeAffineConstantOp(int64_t value) {
-  IVLOG(5, "TileBuilder::MakeAffineConstantOp> " << value);
-  return impl->builder.create<AffineConstantOp>(impl->loc, value).result();
+Value TileBuilder::MakeConstantOp(int64_t value) {
+  IVLOG(5, "TileBuilder::MakeConstantOp> " << value);
+  return impl->builder.create<ConstantOp>(impl->loc, value).result();
 }
 
-Value TileBuilder::MakeAffineIndexOp(StringRef name) {
-  IVLOG(5, "TileBuilder::MakeAffineIndexOp> " << name.str());
-  return impl->builder
-      .create<AffineIndexOp>(impl->loc, impl->idxCounter++, name)
+Value TileBuilder::MakePolyIndexOp(StringRef name) {
+  IVLOG(5, "TileBuilder::MakePolyIndexOp> " << name.str());
+  return impl->builder.create<PolyIndexOp>(impl->loc, impl->idxCounter++, name)
       .result();
 }
 
-Value TileBuilder::MakeAffineAddOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineAddOp>");
-  return impl->builder.create<AffineAddOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyAddOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyAddOp>");
+  return impl->builder.create<PolyAddOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineSubOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineSubOp>");
-  return impl->builder.create<AffineSubOp>(impl->loc, args).result();
+Value TileBuilder::MakePolySubOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolySubOp>");
+  return impl->builder.create<PolySubOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineMulOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineMulOp>");
-  return impl->builder.create<AffineMulOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyMulOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyMulOp>");
+  return impl->builder.create<PolyMulOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineDivOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineDivOp>");
-  return impl->builder.create<AffineDivOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyDivOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyDivOp>");
+  return impl->builder.create<PolyDivOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineNegOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineNegOp>");
-  return impl->builder.create<AffineNegOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyNegOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyNegOp>");
+  return impl->builder.create<PolyNegOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineMaxOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineMaxOp>");
-  return impl->builder.create<AffineMaxOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyMaxOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyMaxOp>");
+  return impl->builder.create<PolyMaxOp>(impl->loc, args).result();
 }
 
-Value TileBuilder::MakeAffineMinOp(ArrayRef<Value> args) {
-  IVLOG(5, "TileBuilder::MakeAffineMinOp>");
-  return impl->builder.create<AffineMinOp>(impl->loc, args).result();
+Value TileBuilder::MakePolyMinOp(ArrayRef<Value> args) {
+  IVLOG(5, "TileBuilder::MakePolyMinOp>");
+  return impl->builder.create<PolyMinOp>(impl->loc, args).result();
 }
 
 Value TileBuilder::MakeAffineTensorMapOp(Value tensor, ArrayRef<Value> idxs) {
@@ -802,7 +801,7 @@ std::vector<Value> TileBuilder::ComputeGradients(ArrayRef<Value> wrt,
   if (ndims) {
     std::vector<Value> src_idxs;
     for (size_t i = 0; i < ndims; ++i) {
-      src_idxs.emplace_back(MakeAffineIndexOp(""));
+      src_idxs.emplace_back(MakePolyIndexOp(""));
     }
     auto src = MakeAffineTensorMapOp(loss, src_idxs);
     auto sink = MakeAffineMapOp(ArrayRef<Value>{});

--- a/pmlc/dialect/tile/builder.h
+++ b/pmlc/dialect/tile/builder.h
@@ -91,15 +91,15 @@ public:
   mlir::Value MakePlaceholderOp(mlir::RankedTensorType type,
                                 pmlc::util::BufferPtr buffer,
                                 llvm::StringRef name);
-  mlir::Value MakeAffineConstantOp(int64_t value);
-  mlir::Value MakeAffineIndexOp(llvm::StringRef name = "");
-  mlir::Value MakeAffineAddOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineSubOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineMulOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineDivOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineNegOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineMaxOp(llvm::ArrayRef<mlir::Value> args);
-  mlir::Value MakeAffineMinOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakeConstantOp(int64_t value);
+  mlir::Value MakePolyIndexOp(llvm::StringRef name = "");
+  mlir::Value MakePolyAddOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolySubOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolyMulOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolyDivOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolyNegOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolyMaxOp(llvm::ArrayRef<mlir::Value> args);
+  mlir::Value MakePolyMinOp(llvm::ArrayRef<mlir::Value> args);
   mlir::Value MakeAffineTensorMapOp(mlir::Value tensor,
                                     llvm::ArrayRef<mlir::Value> idxs);
   mlir::Value MakeAffineMapOp(llvm::ArrayRef<mlir::Value> idxs);

--- a/pmlc/dialect/tile/gradient.cc
+++ b/pmlc/dialect/tile/gradient.cc
@@ -28,12 +28,12 @@ Gradient::Gradient(mlir::Value loss, TileBuilder *builder) : builder_(builder) {
         // TODO: This is an ad hoc list of what to filter out; make it
         // principled
         return !mlir::isa<AffineConstraintsOp>(op) &&
-               !mlir::isa<AffineMapOp>(op) && !mlir::isa<AffineIndexOp>(op) &&
-               !mlir::isa<DimOp>(op) && !mlir::isa<AffineConstantOp>(op) &&
-               !mlir::isa<AffineAddOp>(op) && !mlir::isa<AffineDivOp>(op) &&
-               !mlir::isa<AffineMulOp>(op) && !mlir::isa<AffineNegOp>(op) &&
-               !mlir::isa<AffineSubOp>(op) && !mlir::isa<AffineMaxOp>(op) &&
-               !mlir::isa<AffineMinOp>(op) &&
+               !mlir::isa<AffineMapOp>(op) && !mlir::isa<PolyIndexOp>(op) &&
+               !mlir::isa<DimOp>(op) && !mlir::isa<ConstantOp>(op) &&
+               !mlir::isa<PolyAddOp>(op) && !mlir::isa<PolyDivOp>(op) &&
+               !mlir::isa<PolyMulOp>(op) && !mlir::isa<PolyNegOp>(op) &&
+               !mlir::isa<PolySubOp>(op) && !mlir::isa<PolyMaxOp>(op) &&
+               !mlir::isa<PolyMinOp>(op) &&
                !mlir::isa<eltwise::ScalarConstantOp>(op);
       }});
   for (auto def = defs.rbegin(); def != defs.rend(); def++) {
@@ -64,7 +64,7 @@ void Gradient::ComputeOperandDerivs(mlir::Value val) {
   // TODO: Throw on ops with multiple results?
   auto op = val.getDefiningOp();
   if (mlir::isa<AffineConstraintsOp>(op) || mlir::isa<AffineMapOp>(op) ||
-      mlir::isa<AffineIndexOp>(op) || mlir::isa<PrngOp>(op) ||
+      mlir::isa<PolyIndexOp>(op) || mlir::isa<PrngOp>(op) ||
       mlir::isa<ShapeOp>(op)) {
     // TODO: Make the list of which ops these are more principled. Also, should
     // these all be caught in the backwards slice filter? If so, probably throw

--- a/pmlc/dialect/tile/ir/BUILD
+++ b/pmlc/dialect/tile/ir/BUILD
@@ -8,7 +8,10 @@ load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
 filegroup(
     name = "td_files",
     srcs = [
+        "base.td",
+        "builder.td",
         "interfaces.td",
+        "ops.td",
         "//pmlc/dialect/eltwise/ir:td_files",
     ],
 )

--- a/pmlc/dialect/tile/ir/base.td
+++ b/pmlc/dialect/tile/ir/base.td
@@ -1,0 +1,54 @@
+// Copyright 2020 Intel Corporation
+
+#ifndef __PML_TILE_BASE__
+#define __PML_TILE_BASE__
+
+#ifndef AFFINE_OPS_BASE
+include "mlir/Dialect/AffineOps/AffineOpsBase.td"
+#endif
+
+include "pmlc/util/enums.td"
+include "pmlc/util/interfaces.td"
+include "pmlc/dialect/eltwise/ir/interfaces.td"
+include "pmlc/dialect/eltwise/ir/predicates.td"
+include "pmlc/dialect/tile/ir/interfaces.td"
+
+// TODO: this should be defined upstream
+def IntegerSetAttr : Attr<
+    CPred<"$_self.isa<IntegerSetAttr>()">, "IntegerSet attribute"> {
+  let storageType = [{ IntegerSetAttr }];
+  let returnType = [{ IntegerSet }];
+  let constBuilderCall = "IntegerSetAttr::get($0)";
+}
+
+// TODO: this should be defined upstream
+def IndexAttr : Attr<
+      And<[CPred<"$_self.isa<IntegerAttr>()">,
+           CPred<"$_self.cast<IntegerAttr>().getType().isIndex()">]>,
+      "index attribute"> {
+  let constBuilderCall = "$_builder.getIntegerAttr($_builder.getIndexType(), $0)";
+  let storageType = "IntegerAttr";
+  let returnType = [{ APInt }];
+}
+
+def TileDialect : Dialect {
+  let name = "tile";
+  let cppNamespace = "pmlc::dialect::tile";
+}
+
+def AffineMap : Type<CPred<"$_self.isa<AffineMapType>()">, "affine-map">;
+def AffineConstraints : Type<CPred<"$_self.isa<AffineConstraintsType>()">, "affine-constraints">;
+def AffineTensorMap : Type<CPred<"$_self.isa<AffineTensorMapType>()">, "affine-tensor-map">;
+def StrType : Type<CPred<"$_self.isa<StringType>()">, "string">;
+
+class TileOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
+    Op<TileDialect, mnemonic, traits> {}
+
+class TileOpWithPPV<string mnemonic, list<OpTrait> traits = []> :
+    TileOp<mnemonic, traits> {
+  let printer = [{ print$cppClass(&p, *this); }];
+  let parser = [{ return parse$cppClass(&parser, result); }];
+  let verifier = [{ return verify$cppClass(*this); }];
+}
+
+#endif // __PML_TILE_BASE__

--- a/pmlc/dialect/tile/ir/builder.td
+++ b/pmlc/dialect/tile/ir/builder.td
@@ -1,0 +1,172 @@
+// Copyright 2020 Intel Corporation
+
+#ifndef __PML_TILE_BASE__
+include "pmlc/dialect/tile/ir/base.td"
+#endif
+
+def PlaceholderOp : TileOp<"var"> {
+  let summary = "placeholder operation";
+  let results = (outs RankedTensorOf<[AnyScalar]>:$result);
+}
+
+def TupleOp : TileOp<"tuple"> {
+  let arguments = (ins Variadic<AnyType>:$elts);
+  let results = (outs AnyTuple:$result);
+}
+
+def NoneOp : TileOp<"none"> {
+  let results = (outs NoneType:$result);
+}
+
+def StringOp : TileOp<"str"> {
+  let arguments = (ins StrAttr:$value);
+  let results = (outs StrType:$result);
+  let extraClassDeclaration = [{
+    StringAttr getValue() { return getAttrOfType<StringAttr>("value"); }
+  }];
+}
+
+def DimOp : TileOpWithPPV<"dim", [NoSideEffect]>, HasFolder {
+  let summary = "dimension index operation";
+  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, IndexAttr:$dim);
+  let results = (outs IndexLike:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, Value tensor, int64_t value", [{
+      auto indexType = builder->getIndexType();
+      result.addOperands(tensor);
+      result.addAttribute("dim", builder->getIntegerAttr(indexType, value));
+      result.addTypes(indexType);
+    }]
+  >];
+
+  let extraClassDeclaration = [{
+    IntegerAttr resolve();
+  }];
+}
+
+def PolyIndexOp : TileOpWithPPV<"idx", [NoSideEffect]> {
+  let summary = "polynomial index operation";
+  let arguments = (ins I64Attr:$id, OptionalAttr<StrAttr>:$name);
+  let results = (outs IndexLike:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, int64_t id, StringRef name", [{
+      result.addTypes(builder->getIndexType());
+      result.addAttribute("id", builder->getI64IntegerAttr(id));
+      if (name.size()) {
+        result.addAttribute("name", builder->getStringAttr(name));
+      }
+    }]
+  >];
+}
+
+class PolyOp<string mnemonic, list<OpTrait> traits = []> :
+    TileOp<mnemonic, !listconcat(traits, [NoSideEffect])>,
+    HasFolder {
+  let results = (outs IndexLike:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, ArrayRef<Value> operands", [{
+      result.addOperands(operands);
+      result.addTypes(builder->getIndexType());
+    }]
+  >];
+}
+
+class PolyUnaryOp<string mnemonic, list<OpTrait> traits = []> :
+    PolyOp<mnemonic, traits> {
+  let arguments = (ins IndexLike:$in);
+}
+
+class PolyBinaryOp<string mnemonic, list<OpTrait> traits = []> :
+    PolyOp<mnemonic, traits> {
+  let arguments = (ins IndexLike:$lhs, IndexLike:$rhs);
+  let printer = [{ printPolyBinaryOp(&p, *this); }];
+  let parser = [{ return parsePolyBinaryOp(&parser, result); }];
+}
+
+def PolyAddOp : PolyBinaryOp<"poly_add", [Commutative]> {
+  let summary = "Polynomial addition operation";
+}
+
+def PolyDivOp : PolyBinaryOp<"poly_div"> {
+  let summary = "Polynomial division operation";
+}
+
+def PolyMulOp : PolyBinaryOp<"poly_mul", [Commutative]> {
+  let summary = "Polynomial multiplication operation";
+}
+
+def PolyNegOp : PolyUnaryOp<"poly_neg"> {
+  let summary = "Polynomial negative operation";
+  let arguments = (ins IndexLike:$input);
+}
+
+def PolySubOp : PolyBinaryOp<"poly_sub"> {
+  let summary = "Polynomial subtraction operation";
+}
+
+def PolyMaxOp : PolyBinaryOp<"poly_max", [Commutative]> {
+  let summary = "Polynomial max operation";
+}
+
+def PolyMinOp : PolyBinaryOp<"poly_min", [Commutative]> {
+  let summary = "Polynomial min operation";
+}
+
+def AffineTensorMapOp : TileOpWithPPV<"tmap", [NoSideEffect]> {
+  let summary = "affine tensor map operation";
+  let arguments = (ins EltwiseAny:$tensor, Variadic<Index>:$dims);
+  let results = (outs AffineTensorMap:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, Value tensor, ArrayRef<Value> dims", [{
+      result.addOperands(tensor);
+      result.addOperands(dims);
+      result.addTypes(builder->getType<AffineTensorMapType>());
+    }]
+  >];
+}
+
+def AffineMapOp : TileOpWithPPV<"map", [NoSideEffect]> {
+  let summary = "affine map operation";
+  let arguments = (ins Variadic<Index>:$dims);
+  let results = (outs AffineMap:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result, ArrayRef<Value> dims", [{
+      result.addOperands(dims);
+      result.addTypes(builder->getType<AffineMapType>());
+    }]
+  >];
+}
+
+def AffineConstraintsOp : TileOpWithPPV<"cons", [NoSideEffect]> {
+  let summary = "affine constraint operation";
+  let arguments = (ins Variadic<Index>:$pairs);
+  let results = (outs AffineConstraints:$result);
+
+  let builders = [OpBuilder<
+    "Builder* builder, OperationState& result", [{
+      result.setOperandListToResizable();
+      result.addTypes(builder->getType<AffineConstraintsType>());
+    }]
+  >];
+}
+
+def SymbolicContractionOp : TileOpWithPPV<"sym_contract", [NoSideEffect]>,
+    HasCanonicalizer {
+  let arguments = (ins
+    EltwiseAny:$init,
+    AffineConstraints:$cons,
+    AffineMap:$size,
+    AffineMap:$sink,
+    Variadic<AffineTensorMap>:$srcs,
+    AggregationKind:$agg,
+    CombinationKind:$combo,
+    OptionalAttr<UnitAttr>:$no_reduce,
+    OptionalAttr<StrAttr>:$name
+  );
+  let results = (outs RankedTensorOf<[AnyScalar]>:$result);
+}

--- a/pmlc/dialect/tile/ir/dialect.cc
+++ b/pmlc/dialect/tile/ir/dialect.cc
@@ -24,9 +24,9 @@ struct OpAsmInterface : public mlir::OpAsmDialectInterface {
                          mlir::OpAsmSetValueNameFn setNameFn) const final {
     llvm::SmallString<32> osbuf;
     llvm::raw_svector_ostream os(osbuf);
-    if (auto constOp = llvm::dyn_cast<AffineConstantOp>(op)) {
+    if (auto constOp = llvm::dyn_cast<ConstantOp>(op)) {
       os << 'c' << constOp.value().getSExtValue();
-    } else if (auto indexOp = llvm::dyn_cast<AffineIndexOp>(op)) {
+    } else if (auto indexOp = llvm::dyn_cast<PolyIndexOp>(op)) {
       if (indexOp.name().hasValue()) {
         os << *indexOp.name();
       }
@@ -97,7 +97,7 @@ Operation *Dialect::materializeConstant(mlir::OpBuilder &builder,
   if (auto attr = value.dyn_cast<IntegerAttr>()) {
     auto indexType = builder.getIndexType();
     auto indexAttr = builder.getIntegerAttr(indexType, attr.getInt());
-    return builder.create<AffineConstantOp>(loc, indexType, indexAttr);
+    return builder.create<ConstantOp>(loc, indexType, indexAttr);
   }
   return nullptr;
 }

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -96,13 +96,6 @@ class SpecialOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
 
   let extraClassDeclaration = [{
     static Type getResultType(ArrayRef<Value> operands);
-
-    static Operation* create(OpBuilder* builder, Location loc, ArrayRef<Value> operands) {
-      OperationState state(loc, getOperationName());
-      state.addOperands(operands);
-      state.addTypes(getResultType(operands));
-      return builder->createOperation(state);
-    }
   }];
 }
 

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -1,95 +1,13 @@
-// Copyright 2019, Intel Corporation
+// Copyright 2020 Intel Corporation
 
-#ifndef AFFINE_OPS_BASE
-include "mlir/Dialect/AffineOps/AffineOpsBase.td"
+#ifndef __PML_TILE_BASE__
+include "pmlc/dialect/tile/ir/base.td"
 #endif
 
-include "pmlc/util/enums.td"
-include "pmlc/util/interfaces.td"
-include "pmlc/dialect/eltwise/ir/interfaces.td"
-include "pmlc/dialect/eltwise/ir/predicates.td"
-include "pmlc/dialect/tile/ir/interfaces.td"
+include "pmlc/dialect/tile/ir/builder.td"
 
-// TODO: this should be defined upstream
-def IntegerSetAttr : Attr<
-    CPred<"$_self.isa<IntegerSetAttr>()">, "IntegerSet attribute"> {
-  let storageType = [{ IntegerSetAttr }];
-  let returnType = [{ IntegerSet }];
-  let constBuilderCall = "IntegerSetAttr::get($0)";
-}
-
-def TileDialect : Dialect {
-  let name = "tile";
-  let cppNamespace = "pmlc::dialect::tile";
-}
-
-def AffineMap : Type<CPred<"$_self.isa<AffineMapType>()">, "affine-map">;
-def AffineConstraints : Type<CPred<"$_self.isa<AffineConstraintsType>()">, "affine-constraints">;
-def AffineTensorMap : Type<CPred<"$_self.isa<AffineTensorMapType>()">, "affine-tensor-map">;
-def StrType : Type<CPred<"$_self.isa<StringType>()">, "string">;
-
-def IndexAttr : Attr<
-      And<[CPred<"$_self.isa<IntegerAttr>()">,
-           CPred<"$_self.cast<IntegerAttr>().getType().isIndex()">]>,
-      "index attribute"> {
-  let constBuilderCall = "$_builder.getIntegerAttr($_builder.getIndexType(), $0)";
-  let storageType = "IntegerAttr";
-  let returnType = [{ APInt }];
-}
-
-class TileOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
-    Op<TileDialect, mnemonic, traits> {}
-
-class TileOpWithPPV<string mnemonic, list<OpTrait> traits = []> :
-    TileOp<mnemonic, traits> {
-  let printer = [{ print$cppClass(&p, *this); }];
-  let parser = [{ return parse$cppClass(&parser, result); }];
-  let verifier = [{ return verify$cppClass(*this); }];
-}
-
-def PlaceholderOp : TileOp<"var"> {
-  let summary = "placeholder operation";
-  let results = (outs RankedTensorOf<[AnyScalar]>:$result);
-}
-
-def TupleOp : TileOp<"tuple"> {
-  let arguments = (ins Variadic<AnyType>:$elts);
-  let results = (outs AnyTuple:$result);
-}
-
-def NoneOp : TileOp<"none"> {
-  let results = (outs NoneType:$result);
-}
-
-def StringOp : TileOp<"str"> {
-  let arguments = (ins StrAttr:$value);
-  let results = (outs StrType:$result);
-  let extraClassDeclaration = [{
-    StringAttr getValue() { return getAttrOfType<StringAttr>("value"); }
-  }];
-}
-
-def DimOp : TileOpWithPPV<"dim", [NoSideEffect]>, HasFolder {
-  let summary = "dimension index operation";
-  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, IndexAttr:$dim);
-  let results = (outs IndexLike:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result, Value tensor, int64_t value", [{
-      auto indexType = builder->getIndexType();
-      result.addOperands(tensor);
-      result.addAttribute("dim", builder->getIntegerAttr(indexType, value));
-      result.addTypes(indexType);
-    }]
-  >];
-
-  let extraClassDeclaration = [{
-    IntegerAttr resolve();
-  }];
-}
-
-def AffineConstantOp : TileOpWithPPV<"affine_const", [NoSideEffect]>, HasFolder {
-  let summary = "affine constant";
+def ConstantOp : TileOpWithPPV<"constant", [NoSideEffect]>, HasFolder {
+  let summary = "constant operation";
   let arguments = (ins IndexAttr:$value);
   let results = (outs IndexLike:$result);
 
@@ -106,130 +24,7 @@ def AffineConstantOp : TileOpWithPPV<"affine_const", [NoSideEffect]>, HasFolder 
   }];
 }
 
-def AffineIndexOp : TileOpWithPPV<"idx", [NoSideEffect]> {
-  let summary = "affine index";
-  let arguments = (ins I64Attr:$id, OptionalAttr<StrAttr>:$name);
-  let results = (outs IndexLike:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result, int64_t id, StringRef name", [{
-      result.addTypes(builder->getIndexType());
-      result.addAttribute("id", builder->getI64IntegerAttr(id));
-      if (name.size()) {
-        result.addAttribute("name", builder->getStringAttr(name));
-      }
-    }]
-  >];
-}
-
-class AffineOp<string mnemonic, list<OpTrait> traits = []> :
-    TileOp<mnemonic, !listconcat(traits, [NoSideEffect])>,
-    HasFolder {
-  let results = (outs IndexLike:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result, ArrayRef<Value> operands", [{
-      result.addOperands(operands);
-      result.addTypes(builder->getIndexType());
-    }]
-  >];
-}
-
-class AffineUnaryOp<string mnemonic, list<OpTrait> traits = []> : AffineOp<mnemonic, traits> {
-  let arguments = (ins IndexLike:$in);
-}
-
-class AffineBinaryOp<string mnemonic, list<OpTrait> traits = []> : AffineOp<mnemonic, traits> {
-  let arguments = (ins IndexLike:$lhs, IndexLike:$rhs);
-  let printer = [{ printAffineBinaryOp(&p, *this); }];
-  let parser = [{ return parseAffineBinaryOp(&parser, result); }];
-}
-
-def AffineAddOp : AffineBinaryOp<"affine_add", [Commutative]> {
-  let summary = "Affine addition operation";
-}
-
-def AffineDivOp : AffineBinaryOp<"affine_div"> {
-  let summary = "Affine division operation";
-}
-
-def AffineMulOp : AffineBinaryOp<"affine_mul", [Commutative]> {
-  let summary = "Affine multiplication operation";
-}
-
-def AffineNegOp : AffineUnaryOp<"affine_neg"> {
-  let summary = "Affine negative operation";
-  let arguments = (ins IndexLike:$input);
-}
-
-def AffineSubOp : AffineBinaryOp<"affine_sub"> {
-  let summary = "Affine subtraction operation";
-}
-
-def AffineMaxOp : AffineBinaryOp<"affine_max", [Commutative]> {
-  let summary = "Affine max operation";
-}
-
-def AffineMinOp : AffineBinaryOp<"affine_min", [Commutative]> {
-  let summary = "Affine min operation";
-}
-
-def AffineTensorMapOp : TileOpWithPPV<"tmap", [NoSideEffect]> {
-  let summary = "affine tensor map operation";
-  let arguments = (ins EltwiseAny:$tensor, Variadic<Index>:$dims);
-  let results = (outs AffineTensorMap:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result, Value tensor, ArrayRef<Value> dims", [{
-      result.addOperands(tensor);
-      result.addOperands(dims);
-      result.addTypes(builder->getType<AffineTensorMapType>());
-    }]
-  >];
-}
-
-def AffineMapOp : TileOpWithPPV<"map", [NoSideEffect]> {
-  let summary = "affine map operation";
-  let arguments = (ins Variadic<Index>:$dims);
-  let results = (outs AffineMap:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result, ArrayRef<Value> dims", [{
-      result.addOperands(dims);
-      result.addTypes(builder->getType<AffineMapType>());
-    }]
-  >];
-}
-
-def AffineConstraintsOp : TileOpWithPPV<"cons", [NoSideEffect]> {
-  let summary = "affine constraint operation";
-  let arguments = (ins Variadic<Index>:$pairs);
-  let results = (outs AffineConstraints:$result);
-
-  let builders = [OpBuilder<
-    "Builder* builder, OperationState& result", [{
-      result.setOperandListToResizable();
-      result.addTypes(builder->getType<AffineConstraintsType>());
-    }]
-  >];
-}
-
-def SymbolicContractionOp : TileOpWithPPV<"sym_cion", [NoSideEffect]>, HasCanonicalizer {
-  let arguments = (ins
-    EltwiseAny:$init,
-    AffineConstraints:$cons,
-    AffineMap:$size,
-    AffineMap:$sink,
-    Variadic<AffineTensorMap>:$srcs,
-    AggregationKind:$agg,
-    CombinationKind:$combo,
-    OptionalAttr<UnitAttr>:$no_reduce,
-    OptionalAttr<StrAttr>:$name
-  );
-  let results = (outs RankedTensorOf<[AnyScalar]>:$result);
-}
-
-def ContractionOp : TileOpWithPPV<"cion", [NoSideEffect]> {
+def ContractionOp : TileOpWithPPV<"contract", [NoSideEffect]> {
   let arguments = (ins
     EltwiseAny:$init,
     Variadic<AnyType>:$operands,
@@ -294,7 +89,10 @@ def IndexOp : TileOp<"index", [NoSideEffect]>, HasCanonicalizer {
 }
 
 class SpecialOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
-    Op<TileDialect, mnemonic, !listconcat(traits, [SpecialOpInterface, GenericBuilderInterface])> {
+    Op<TileDialect, mnemonic, !listconcat(traits, [
+      SpecialOpInterface,
+      GenericBuilderInterface
+  ])> {
 
   let extraClassDeclaration = [{
     static Type getResultType(ArrayRef<Value> operands);
@@ -310,19 +108,27 @@ class SpecialOp<string mnemonic, list<OpTrait> traits = [NoSideEffect]> :
 
 def GatherOp : SpecialOp<"gather">, HasCanonicalizer {
   let summary = "special gather operation";
-  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, RankedTensorOf<[ScalarIndex]>:$dims);
+  let arguments = (ins
+    RankedTensorOf<[AnyScalar]>:$tensor,
+    RankedTensorOf<[ScalarIndex]>:$dims);
   let results = (outs RankedTensorOf<[AnyScalar]>:$result);
 }
 
 def PrngOp : SpecialOp<"prng", []>, HasCanonicalizer {
   let summary = "pseudorandom number generator";
-  let arguments = (ins RankedTensorOf<[ScalarUINT32]>:$state, Variadic<EltwiseIndex>:$dims);
-  let results = (outs RankedTensorOf<[AnyScalarFloat]>:$result, RankedTensorOf<[ScalarUINT32]>:$new_state);
+  let arguments = (ins
+    RankedTensorOf<[ScalarUINT32]>:$state,
+    Variadic<EltwiseIndex>:$dims);
+  let results = (outs
+    RankedTensorOf<[AnyScalarFloat]>:$result,
+    RankedTensorOf<[ScalarUINT32]>:$new_state);
 }
 
 def ReshapeOp : SpecialOp<"reshape">, HasCanonicalizer {
   let summary = "tensor reshape operation";
-  let arguments = (ins RankedTensorOf<[AnyScalar]>:$tensor, Variadic<EltwiseIndex>:$dims);
+  let arguments = (ins
+    RankedTensorOf<[AnyScalar]>:$tensor,
+    Variadic<EltwiseIndex>:$dims);
   let results = (outs RankedTensorOf<[AnyScalar]>:$result);
 }
 

--- a/pmlc/dialect/tile/tests/build-cion.mlir
+++ b/pmlc/dialect/tile/tests/build-cion.mlir
@@ -14,7 +14,7 @@ func @dot(%arg0: tensor<1x2x!eltwise.f32>, %arg1: tensor<2x3x!eltwise.f32>) -> t
   %7 = tile.map %3, %4
   %8 = tile.map %0, %1
   %9 = tile.cons ()
-  %10 = tile.sym_cion add, mul, %c0, %9, %7, %8, %5, %6 : !f32 -> tensor<?x?x!eltwise.f32>
+  %10 = tile.sym_contract add, mul, %c0, %9, %7, %8, %5, %6 : !f32 -> tensor<?x?x!eltwise.f32>
   return %10 : tensor<?x?x!eltwise.f32>
 }
 
@@ -24,7 +24,7 @@ func @dot(%arg0: tensor<1x2x!eltwise.f32>, %arg1: tensor<2x3x!eltwise.f32>) -> t
 
 // CHECK: func @dot(%arg0: tensor<1x2x!eltwise.f32>, %arg1: tensor<2x3x!eltwise.f32>) -> tensor<1x3x!eltwise.f32> {
 // CHECK:   %[[CST:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f32} : () -> !f32
-// CHECK:   %[[CION:.*]] = tile.cion add, mul, %[[CST]], %arg0, %arg1
+// CHECK:   %[[CION:.*]] = tile.contract add, mul, %[[CST]], %arg0, %arg1
 // CHECK-SAME: {sink = #[[MAP0]], srcs = [#[[MAP1]], #[[MAP2]]]}
 // CHECK-SAME: !f32, tensor<1x2x!eltwise.f32>, tensor<2x3x!eltwise.f32> -> tensor<1x3x!eltwise.f32>
 // CHECK:   return %[[CION]] : tensor<1x3x!eltwise.f32>
@@ -42,9 +42,9 @@ func @cumsum(%arg0: tensor<10x!eltwise.f32>) -> tensor<?x!eltwise.f32> {
   %3 = tile.tmap %arg0[%0] : tensor<10x!eltwise.f32>
   %4 = tile.map %2
   %5 = tile.map %1
-  %6 = tile.affine_sub %1, %0
+  %6 = tile.poly_sub %1, %0
   %7 = tile.cons (%6, %2)
-  %8 = tile.sym_cion add, none, %c0, %7, %4, %5, %3 : !f32 -> tensor<?x!eltwise.f32>
+  %8 = tile.sym_contract add, none, %c0, %7, %4, %5, %3 : !f32 -> tensor<?x!eltwise.f32>
   return %8 : tensor<?x!eltwise.f32>
 }
 
@@ -54,7 +54,7 @@ func @cumsum(%arg0: tensor<10x!eltwise.f32>) -> tensor<?x!eltwise.f32> {
 
 // CHECK: func @cumsum(%arg0: tensor<10x!eltwise.f32>) -> tensor<10x!eltwise.f32> {
 // CHECK:   %[[CST:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f32} : () -> !f32
-// CHECK:   %[[CION:.*]] = tile.cion add, none, %[[CST]], %arg0
+// CHECK:   %[[CION:.*]] = tile.contract add, none, %[[CST]], %arg0
 // CHECK-SAME: {cons = #[[SET0]], sink = #[[MAP0]], srcs = [#[[MAP1]]]}
 // CHECK-SAME: !f32, tensor<10x!eltwise.f32> -> tensor<10x!eltwise.f32>
 // CHECK:   return %[[CION]] : tensor<10x!eltwise.f32>

--- a/pmlc/dialect/tile/tests/compute-bounds.mlir
+++ b/pmlc/dialect/tile/tests/compute-bounds.mlir
@@ -8,9 +8,9 @@
 
 func @dot(%arg0: tensor<1x784x!eltwise.f32>, %arg1: tensor<784x512x!eltwise.f32>) -> tensor<1x512x!eltwise.f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.affine_const 512
-  %1 = tile.affine_const 1
-  %2 = tile.cion add, mul, %c0, %arg0, %arg1 {sink=#map0, srcs=[#map1, #map2]} :
+  %0 = tile.constant 512
+  %1 = tile.constant 1
+  %2 = tile.contract add, mul, %c0, %arg0, %arg1 {sink=#map0, srcs=[#map1, #map2]} :
     !f32, tensor<1x784x!eltwise.f32>, tensor<784x512x!eltwise.f32> -> tensor<1x512x!eltwise.f32>
   return %2 : tensor<1x512x!eltwise.f32>
 }
@@ -21,7 +21,7 @@ func @dot(%arg0: tensor<1x784x!eltwise.f32>, %arg1: tensor<784x512x!eltwise.f32>
 // CHECK: #map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK: #map4 = affine_map<() -> (783, 0, 511)>
 // CHECK-LABEL: func @dot
-// CHECK: tile.cion
+// CHECK: tile.contract
 // CHECK-SAME: lowerBounds = #map0
 // CHECK-SAME: sink = #map1
 // CHECK-SAME: srcs = [#map2, #map3]

--- a/pmlc/dialect/tile/tests/constant-fold.mlir
+++ b/pmlc/dialect/tile/tests/constant-fold.mlir
@@ -2,44 +2,44 @@
 
 // CHECK-LABEL: @basic
 func @basic(%arg0: index) -> index {
-  %c1 = tile.affine_const 1
-  %0 = tile.affine_add %arg0, %arg0
-  %1 = tile.affine_mul %0, %c1
+  %c1 = tile.constant 1
+  %0 = tile.poly_add %arg0, %arg0
+  %1 = tile.poly_mul %0, %c1
   return %1 : index
-  // CHECK-NEXT: %0 = tile.affine_add %arg0, %arg0
+  // CHECK-NEXT: %0 = tile.poly_add %arg0, %arg0
   // CHECK-NEXT: return %0
 }
 
 // CHECK-LABEL: @fold_mul_1
 func @fold_mul_1(%arg0: index) -> index {
-  %cst = tile.affine_const 1
-  %0 = tile.affine_mul %arg0, %cst
+  %cst = tile.constant 1
+  %0 = tile.poly_mul %arg0, %cst
   return %0 : index
   // CHECK-NEXT: return %arg0
 }
 
 // CHECK-LABEL: @fold_add_0
 func @fold_add_0(%arg0: index) -> index {
-  %cst = tile.affine_const 0
-  %0 = tile.affine_add %arg0, %cst
+  %cst = tile.constant 0
+  %0 = tile.poly_add %arg0, %cst
   return %0 : index
   // CHECK-NEXT: return %arg0
 }
 
 // CHECK-LABEL: @fold_add_cst_cst
 func @fold_add_cst_cst() -> index {
-  %c0 = tile.affine_const 1
-  %c1 = tile.affine_const 3
-  %0 = tile.affine_add %c0, %c1
+  %c0 = tile.constant 1
+  %c1 = tile.constant 3
+  %0 = tile.poly_add %c0, %c1
   return %0 : index
-  // CHECK-NEXT: %c4 = tile.affine_const 4
+  // CHECK-NEXT: %c4 = tile.constant 4
   // CHECK-NEXT: return %c4 : index
 }
 
 // CHECK-LABEL: @fold_sub_x_x
 func @fold_sub_x_x(%arg0: index) -> index {
-  %0 = tile.affine_sub %arg0, %arg0
+  %0 = tile.poly_sub %arg0, %arg0
   return %0 : index
-  // CHECK-NEXT: %c0 = tile.affine_const 0
+  // CHECK-NEXT: %c0 = tile.constant 0
   // CHECK-NEXT: return %c0
 }

--- a/pmlc/dialect/tile/tests/padding.mlir
+++ b/pmlc/dialect/tile/tests/padding.mlir
@@ -12,7 +12,7 @@
 
 func @test_pad_input(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion add, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract add, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_input
   // CHECK: eltwise.ident
@@ -24,7 +24,7 @@ func @test_pad_input(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 func @test_in_place(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
   %0 = "eltwise.sin"(%arg0) : (tensor<10x!f32>) -> tensor<10x!f32>
-  %1 = tile.cion add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %1 = tile.contract add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %1 : tensor<10x!f32>
   // CHECK-LABEL: func @test_in_place
   // CHECK: eltwise.sin
@@ -36,7 +36,7 @@ func @test_in_place(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 func @test_justify(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
   %0 = "eltwise.sin"(%arg0) : (tensor<10x!f32>) -> tensor<10x!f32>
-  %1 = tile.cion add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %1 = tile.contract add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %1 : tensor<10x!f32>
   // CHECK-LABEL: func @test_justify
   // CHECK: eltwise.sin
@@ -47,16 +47,16 @@ func @test_justify(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 func @test_valid_no_pad(%arg0: tensor<12x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
   %0 = "eltwise.sin"(%arg0) : (tensor<12x!f32>) -> tensor<12x!f32>
-  %1 = tile.cion add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<12x!f32> -> tensor<10x!f32>
+  %1 = tile.contract add, none, %c0, %0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<12x!f32> -> tensor<10x!f32>
   return %1 : tensor<10x!f32>
   // CHECK-LABEL: func @test_valid_no_pad
-  // CHECK-NOT: ident 
+  // CHECK-NOT: ident
   // CHECK-NOT: pad
 }
 
 func @test_pad_max(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_max
   // CHECK: padType = 2
@@ -64,7 +64,7 @@ func @test_pad_max(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 
 func @test_pad_min(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_min
   // CHECK: padType = 3
@@ -72,28 +72,28 @@ func @test_pad_min(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 
 func @test_no_pad_assign(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion assign, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract assign, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_no_pad_assign
-  // CHECK-NOT: ident 
+  // CHECK-NOT: ident
   // CHECK-NOT: pad
 }
 
 func @test_no_pad_conflict(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
-  %1 = tile.cion max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %1 = tile.contract max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   %2 = "eltwise.add" (%0, %1) : (tensor<10x!f32>, tensor<10x!f32>) -> tensor<10x!f32>
   return %2 : tensor<10x!f32>
   // CHECK-LABEL: func @test_no_pad_conflict
-  // CHECK-NOT: ident 
+  // CHECK-NOT: ident
   // CHECK-NOT: pad
 }
 
 func @test_pad_fake_conflict(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion min, none, %c0, %arg0 {cons=#jis0, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
-  %1 = tile.cion max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract min, none, %c0, %arg0 {cons=#jis0, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %1 = tile.contract max, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   %2 = "eltwise.add" (%0, %1) : (tensor<10x!f32>, tensor<10x!f32>) -> tensor<10x!f32>
   return %2 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_fake_conflict
@@ -102,20 +102,20 @@ func @test_pad_fake_conflict(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
 
 func @test_pad_worst_case(%arg0: tensor<10x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
-  %1 = tile.cion min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %0 = tile.contract min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1dcenter], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
+  %1 = tile.contract min, none, %c0, %arg0 {cons=#jin0to3, srcs=[#conv1djustify], sink=#first} : !f32, tensor<10x!f32> -> tensor<10x!f32>
   %2 = "eltwise.add" (%0, %1) : (tensor<10x!f32>, tensor<10x!f32>) -> tensor<10x!f32>
   return %2 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_worst_case
   // CHECK: ident
   // CHECK-SAME: padAbove = [2]
   // CHECK-SAME: padBelow = [1]
-  // CHECK-SAME: padType = 3 
+  // CHECK-SAME: padType = 3
 }
 
 func @test_pad_add_mul(%arg0: tensor<10x!f32>, %arg1: tensor<3x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion add, mul, %c0, %arg0, %arg1 {srcs=[#conv1dcenter, #second], sink=#first} : !f32, tensor<10x!f32>, tensor<3x!f32> -> tensor<10x!f32>
+  %0 = tile.contract add, mul, %c0, %arg0, %arg1 {srcs=[#conv1dcenter, #second], sink=#first} : !f32, tensor<10x!f32>, tensor<3x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_pad_add_mul
   // CHECK: ident
@@ -126,11 +126,9 @@ func @test_pad_add_mul(%arg0: tensor<10x!f32>, %arg1: tensor<3x!f32>) -> tensor<
 
 func @test_no_pad_add_add(%arg0: tensor<10x!f32>, %arg1: tensor<3x!f32>) -> tensor<10x!f32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f64} : () -> !f32
-  %0 = tile.cion add, add, %c0, %arg0, %arg1 {srcs=[#conv1dcenter, #second], sink=#first} : !f32, tensor<10x!f32>, tensor<3x!f32> -> tensor<10x!f32>
+  %0 = tile.contract add, add, %c0, %arg0, %arg1 {srcs=[#conv1dcenter, #second], sink=#first} : !f32, tensor<10x!f32>, tensor<3x!f32> -> tensor<10x!f32>
   return %0 : tensor<10x!f32>
   // CHECK-LABEL: func @test_no_pad_add_add
   // CHECK-NOT: ident
-  // CHECK-NOT: pad 
+  // CHECK-NOT: pad
 }
-
-

--- a/pmlc/util/interfaces.h
+++ b/pmlc/util/interfaces.h
@@ -13,6 +13,7 @@ using mlir::ArrayRef;
 using mlir::Location;
 using mlir::OpBuilder;
 using mlir::Operation;
+using mlir::OperationState;
 using mlir::OpInterface;
 using mlir::Type;
 using mlir::Value;

--- a/pmlc/util/interfaces.td
+++ b/pmlc/util/interfaces.td
@@ -7,12 +7,27 @@ include "mlir/IR/OpBase.td"
 
 def GenericBuilderInterface : OpInterface<"GenericBuilder"> {
   let methods = [
-    StaticInterfaceMethod<"TODO", "Type", "getResultType", (ins "ArrayRef<Value>":$operands)>,
-    StaticInterfaceMethod<"TODO", "Operation*", "create", (ins
-      "OpBuilder*":$builder,
-      "Location":$loc,
-      "ArrayRef<Value>":$operands
-    )>,
+    StaticInterfaceMethod<
+      /*desc=*/"TODO",
+      /*retTy=*/"Type",
+      /*methodName=*/"getResultType",
+      /*args=*/(ins "ArrayRef<Value>":$operands)
+    >,
+    StaticInterfaceMethod<
+      /*desc=*/"TODO",
+      /*retTy=*/"Operation*",
+      /*methodName=*/"create",
+      /*args=*/(ins
+        "OpBuilder*":$builder,
+        "Location":$loc,
+        "ArrayRef<Value>":$operands),
+      /*methodBody=*/[{
+        OperationState state(loc, ConcreteOp::getOperationName());
+        state.addOperands(operands);
+        state.addTypes(getResultType(operands));
+        return builder->createOperation(state);
+      }]
+    >,
   ];
 }
 


### PR DESCRIPTION
Rename and reorganize tile dialect ops so that they are less confusing. Split the dialect into two `.td` files so its clear which ops are used by the builder vs the rest of the system.