### PR TITLE
Fix support for clang toolchain on linux

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,20 +37,24 @@ load("@bazel_latex//:repositories.bzl", "latex_repositories")
 
 latex_repositories()
 
-# http_archive(
-#     name = "com_grail_bazel_toolchain",
-#     sha256 = "015454eb86330cd20bce951468652ce572e8c04421eda456926ea658d861a939",
-#     strip_prefix = "bazel-toolchain-8570c4ccb39f750452b0b5607c9f54a093214f26",
-#     urls = ["https://github.com/grailbio/bazel-toolchain/archive/8570c4ccb39f750452b0b5607c9f54a093214f26.zip"],
-# )
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "7ca9ecdb45466163ffc53bf36b83ef4db6ff07be4fa4cd2ec4ab2f535365c02f",
+    strip_prefix = "bazel-toolchain-6f99e79bb4f8ad1c8c362745d648197e536826ab",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/6f99e79bb4f8ad1c8c362745d648197e536826ab.zip"],
+)
 
-# load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
 
-# llvm_toolchain(
-#     name = "llvm_toolchain",
-#     llvm_version = "8.0.0",
-# )
+bazel_toolchain_dependencies()
 
-# load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
-# llvm_register_toolchains()
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "8.0.0",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ latex_repositories()
 
 http_archive(
     name = "com_grail_bazel_toolchain",
-    sha256 = "7ca9ecdb45466163ffc53bf36b83ef4db6ff07be4fa4cd2ec4ab2f535365c02f",
-    strip_prefix = "bazel-toolchain-6f99e79bb4f8ad1c8c362745d648197e536826ab",
-    urls = ["https://github.com/grailbio/bazel-toolchain/archive/6f99e79bb4f8ad1c8c362745d648197e536826ab.zip"],
+    sha256 = "17e12dfba5ae4fc735dded73500e24546ca74459bac68b8d6f68c7785e3e4500",
+    strip_prefix = "bazel-toolchain-7abc442059ea5b08f9c9bc7f0c1450b914aca090",
+    urls = ["https://github.com/plaidml/bazel-toolchain/archive/7abc442059ea5b08f9c9bc7f0c1450b914aca090.zip"],
 )
 
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")

--- a/pmlc/tools/pmlc-jit/BUILD
+++ b/pmlc/tools/pmlc-jit/BUILD
@@ -7,7 +7,6 @@ load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
 plaidml_cc_library(
     name = "lib",
     srcs = ["pmlc-jit.cc"],
-    linkopts = ["-ldl"],
     deps = [
         "//pmlc/rt:rt_shlib",
         "//pmlc/target/x86",

--- a/pmlc/tools/pmlc-vulkan-runner/BUILD
+++ b/pmlc/tools/pmlc-vulkan-runner/BUILD
@@ -13,9 +13,6 @@ plaidml_cc_library(
         "vulkan_fn.h",
         "vulkan_runner.h",
     ],
-    linkopts = [
-        "-ldl",
-    ],
     tags = [
         "skip_windows",
     ],
@@ -33,9 +30,6 @@ plaidml_cc_test(
     name = "vulkan_runner_tests",
     srcs = [
         "vulkan_runner_tests.cc",
-    ],
-    linkopts = [
-        "-ldl",
     ],
     tags = [
         "manual",

--- a/vendor/mlir/mlir.BUILD
+++ b/vendor/mlir/mlir.BUILD
@@ -23,6 +23,14 @@ exports_files([
     "run_lit.sh",
 ])
 
+LINKOPTS = select({
+    "@bazel_tools//src/conditions:windows": [],
+    "//conditions:default": [
+        "-lm",
+        "-pthread",
+    ],
+})
+
 cc_library(
     name = "DialectSymbolRegistry",
     # strip_include_prefix does not apply to textual_hdrs.
@@ -85,10 +93,7 @@ cc_library(
         "include/mlir/Analysis/Verifier.h",
     ],
     includes = ["include"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
+    linkopts = LINKOPTS,
     deps = [
         ":IR",
         ":Support",
@@ -1847,10 +1852,7 @@ cc_binary(
         "tools/mlir-tblgen/*.h",
         "tools/mlir-tblgen/*.cpp",
     ]),
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
+    linkopts = LINKOPTS,
     deps = [
         ":MlirTableGenMain",
         ":Support",


### PR DESCRIPTION
This toolchain is useful for local development work on linux (mostly because ASAN is awesome).

This PR fixes the `llvm_toolchain` so that it continues to work on Windows (where it's just a NO-OP).