### PR TITLE
Fixes for downstream repos

### DIFF
--- a/bzl/plaidml.bzl
+++ b/bzl/plaidml.bzl
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation.
 
 PLAIDML_COPTS = select({
-    "//:msvc": [
+    "@com_intel_plaidml//:msvc": [
         "/std:c++17",  # This MUST match all other compilation units
         "/wd4624",
         "/Zc:__cplusplus",

--- a/pmlc/compiler/BUILD
+++ b/pmlc/compiler/BUILD
@@ -16,6 +16,7 @@ plaidml_cc_library(
         "@llvm-project//mlir:ExecutionEngineUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMTransforms",
+        "@llvm-project//mlir:LoopsToGPUPass",
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:OpenMPDialect",
     ],

--- a/vendor/llvm/llvm.BUILD
+++ b/vendor/llvm/llvm.BUILD
@@ -1999,6 +1999,7 @@ cc_library(
         "include/llvm/ExecutionEngine/IntelJITEvents/*.h",
     ]),
     copts = llvm_copts,
+    linkopts = llvm_linkopts,
     deps = [
         ":config",
         ":core",


### PR DESCRIPTION
There are many more upcoming changes I plan to make to allow downstream compilers to have more modular dependencies. At the moment, things like the GPU dialect have to be consumed downstream.