### PR TITLE
Cast scalar constants for affine.store

### DIFF
--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1052,5 +1052,19 @@ TEST_F(CppEdsl, Prng) {
   // runProgram(program);
 }
 
+TEST_F(CppEdsl, ConvI8) {
+  auto I = Placeholder(DType::INT8, {1, 224, 224, 3});
+  auto K = Placeholder(DType::INT8, {3, 3, 1, 32});
+  auto program = makeProgram("convolution", {Convolution2(I, K)});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.ConvI8
+  // CHECK: func @convolution
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0 : i64} : () -> !i32
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : !i32, tensor<1x224x224x3x!eltwise.i8>, tensor<3x3x1x32x!eltwise.i8> -> tensor<1x224x224x32x!eltwise.i8>
+  // CHECK: return %{{.*}} : tensor<1x224x224x32x!eltwise.i8>
+  // clang-format on
+  runProgram(program);
+}
+
 }  // namespace
 }  // namespace plaidml::edsl

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -158,9 +158,8 @@ struct ScalarConstantOpConversion
   }
 };
 
-static Value createCastOp(ConversionPatternRewriter &rewriter, Location loc,
-                          Value from, bool fromSigned, Type intoType,
-                          bool intoSigned) {
+static Value createCastOp(OpBuilder &builder, Location loc, Value from,
+                          bool fromSigned, Type intoType, bool intoSigned) {
   auto fromType = from.getType();
   if (fromType == intoType) {
     return from;
@@ -169,14 +168,14 @@ static Value createCastOp(ConversionPatternRewriter &rewriter, Location loc,
     if (auto fromFloatType = fromType.dyn_cast<FloatType>()) {
       if (fromFloatType.getWidth() < intoFloatType.getWidth()) {
         // FPExtOp: FloatType -> wider FloatType
-        return rewriter.create<mlir::FPExtOp>(loc, from, intoType).getResult();
+        return builder.create<mlir::FPExtOp>(loc, from, intoType).getResult();
       }
       // FPTruncOp: FloatType -> narrower FloatType
-      return rewriter.create<mlir::FPTruncOp>(loc, from, intoType).getResult();
+      return builder.create<mlir::FPTruncOp>(loc, from, intoType).getResult();
     }
     if (auto fromIntType = fromType.dyn_cast<IntegerType>()) {
       // SIToFPOp: IntegerType -> FloatType
-      return rewriter.create<mlir::SIToFPOp>(loc, from, intoType).getResult();
+      return builder.create<mlir::SIToFPOp>(loc, from, intoType).getResult();
     }
   }
   if (auto intoIntType = intoType.dyn_cast<IntegerType>()) {
@@ -184,24 +183,23 @@ static Value createCastOp(ConversionPatternRewriter &rewriter, Location loc,
       if (fromIntType.getWidth() < intoIntType.getWidth()) {
         if (fromSigned) {
           // SignExtendIOp: IntegerType -> wider signed int
-          return rewriter.create<mlir::SignExtendIOp>(loc, from, intoType)
+          return builder.create<mlir::SignExtendIOp>(loc, from, intoType)
               .getResult();
         }
         // ZeroExtendIOp: IntegerType -> wider unsigned int
-        return rewriter.create<mlir::ZeroExtendIOp>(loc, from, intoType)
+        return builder.create<mlir::ZeroExtendIOp>(loc, from, intoType)
             .getResult();
       }
       // TruncateIOp: IntegerType -> narrower IntegerType
-      return rewriter.create<mlir::TruncateIOp>(loc, from, intoType)
-          .getResult();
+      return builder.create<mlir::TruncateIOp>(loc, from, intoType).getResult();
     }
     if (auto fromFloatType = fromType.dyn_cast<FloatType>()) {
       if (intoSigned) {
         // FPToSIOp: FloatType -> signed IntegerType
-        return rewriter.create<stdx::FPToSIOp>(loc, from, intoType).getResult();
+        return builder.create<stdx::FPToSIOp>(loc, from, intoType).getResult();
       } else {
         // FPToUIOp: FloatType -> unsigned IntegerType
-        return rewriter.create<stdx::FPToUIOp>(loc, from, intoType).getResult();
+        return builder.create<stdx::FPToUIOp>(loc, from, intoType).getResult();
       }
     }
   }
@@ -329,9 +327,9 @@ static DataType promoteTypes(ConversionPatternRewriter &rewriter, Location loc,
   for (unsigned i = 0; i < operands.size(); i++) {
     auto dtype = types[i];
     auto operand = operands[i];
-    auto castOp = createCastOp(rewriter, loc, operand, isSigned(dtype),
-                               targetType, intoSigned);
-    into->push_back(castOp);
+    auto castedValue = createCastOp(rewriter, loc, operand, isSigned(dtype),
+                                    targetType, intoSigned);
+    into->push_back(castedValue);
   }
   return bestType;
 }
@@ -474,6 +472,11 @@ static Value buildBroadcastLoad(OpBuilder &builder, Location loc, Value operand,
 static void buildSimpleStore(OpBuilder &builder, Location loc, Value scalar,
                              Value memRef) {
   auto body = builder.getBlock();
+  auto memRefType = memRef.getType().cast<MemRefType>();
+  auto elementType = memRefType.getElementType();
+  if (elementType != scalar.getType()) {
+    scalar = createCastOp(builder, loc, scalar, false, elementType, false);
+  }
   builder.create<AffineStoreOp>(loc, scalar, memRef, body->getArguments());
 }
 


### PR DESCRIPTION
This fixes an issue with lowering tile to affine when I8 element types are used.