### PR TITLE
implementation of tile.reshape via memcpy

### DIFF
--- a/plaidml/plaidml_link.jsonnet
+++ b/plaidml/plaidml_link.jsonnet
@@ -1,5 +1,6 @@
 local exports = [
   // rt 
+  'plaidml_rt_copy_f32',
   'plaidml_rt_trace',
   'plaidml_rt_xsmm_gemm_f32',
   'print_memref_f32',

--- a/pmlc/rt/plaidml_rt.jsonnet
+++ b/pmlc/rt/plaidml_rt.jsonnet
@@ -1,4 +1,5 @@
 local exports = [
+    'plaidml_rt_copy_f32',
     'plaidml_rt_trace',
     'plaidml_rt_xsmm_gemm_f32',
     'print_memref_f32',

--- a/pmlc/rt/runtime.cc
+++ b/pmlc/rt/runtime.cc
@@ -1,5 +1,7 @@
 // Copyright 2020 Intel Corporation
 
+#include <stddef.h>
+
 #include "llvm/Support/raw_ostream.h"
 
 #include "pmlc/rt/memref.h"
@@ -7,4 +9,23 @@
 extern "C" void plaidml_rt_trace(const char *msg) {
   llvm::outs() << msg << "\n";
   llvm::outs().flush();
+}
+
+namespace {
+template <typename T>
+void plaidml_rt_copy(StridedMemRefType<T, 0> *dest,
+                     StridedMemRefType<T, 0> *src, int32_t count) {
+  auto destPtr = dest->data + dest->offset;
+  auto srcPtr = src->data + src->offset;
+  size_t bytes = count * sizeof(T);
+  memcpy(destPtr, srcPtr, bytes);
+}
+} // namespace
+
+extern "C" void plaidml_rt_copy_f32(size_t destRank,
+                                    StridedMemRefType<float, 0> *dest,
+                                    size_t srcRank,
+                                    StridedMemRefType<float, 0> *src,
+                                    int32_t count) {
+  plaidml_rt_copy<float>(dest, src, count);
 }


### PR DESCRIPTION
Currently supports f32 only. Will expand for other element types if the basic approach is good.