### PR TITLE
Fix an assertion that stop crashing tests

### DIFF
--- a/pmlc/dialect/tile/ir/ops.cc
+++ b/pmlc/dialect/tile/ir/ops.cc
@@ -481,19 +481,25 @@ AffineMap ContractionOp::getSourceMap(unsigned i) {
 
 void ContractionOp::setLowerBounds(ArrayRef<int64_t> bounds) {
   SmallVector<AffineExpr, 6> exprs;
-  for (auto dim : bounds) {
-    exprs.push_back(mlir::getAffineConstantExpr(dim, getContext()));
+  AffineMap map = AffineMap::get(getContext());
+  if (bounds.size() != 0) {
+    for (auto dim : bounds) {
+      exprs.push_back(mlir::getAffineConstantExpr(dim, getContext()));
+    }
+    map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/0, exprs);
   }
-  auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/0, exprs);
   setAttr(getLowerBoundsAttrName(), AffineMapAttr::get(map));
 }
 
 void ContractionOp::setUpperBounds(ArrayRef<int64_t> bounds) {
   SmallVector<AffineExpr, 6> exprs;
-  for (auto dim : bounds) {
-    exprs.push_back(mlir::getAffineConstantExpr(dim, getContext()));
+  AffineMap map = AffineMap::get(getContext());
+  if (bounds.size() != 0) {
+    for (auto dim : bounds) {
+      exprs.push_back(mlir::getAffineConstantExpr(dim, getContext()));
+    }
+    map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/0, exprs);
   }
-  auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/0, exprs);
   setAttr(getUpperBoundsAttrName(), AffineMapAttr::get(map));
 }
 


### PR DESCRIPTION
Always set the AffineMap to empty one in case there are empty lower and upper bounds.