### PR TITLE
Put RangeConstraints in canonical form

### DIFF
--- a/pmlc/dialect/tile/transforms/contraction.cc
+++ b/pmlc/dialect/tile/transforms/contraction.cc
@@ -209,10 +209,8 @@ static IndexAccess ConvertAffineMap(ContractionOp op, mlir::AffineMap map) {
 }
 
 Contraction::Contraction(ContractionOp op) {
-  if (VLOG_IS_ON(2)) {
-    auto op_result = op.result();
-    IVLOG(2, "Processing: " << mlir::debugString(op_result));
-  }
+  auto op_result = op.result();
+  IVLOG(2, "Processing: " << mlir::debugString(op_result));
   accesses.emplace_back(ConvertAffineMap(op, op.sink()));
   for (auto src : op.srcs()) {
     auto map = src.cast<AffineMapAttr>().getValue();

--- a/pmlc/util/math/polynomial.h
+++ b/pmlc/util/math/polynomial.h
@@ -101,6 +101,8 @@ struct RangeConstraint {
 
   SimpleConstraint lowerBound() const;
   SimpleConstraint upperBound() const;
+  RangeConstraint &canonicalize();
+  RangeConstraint &reverse();
 };
 
 inline std::string to_string(const RangeConstraint &c) {


### PR DESCRIPTION
The same RangeConstraint can be expressed in two directions (e.g. `0 <= x < 5` is equivalent to `0 <= 4 - x < 5` -- recall that `x` is integral); this canonicalizes which direction is chosen.