### PR TITLE
Use a simple pattern match replacer for coinstant types rewrites

### DIFF
--- a/ci/plan.yml
+++ b/ci/plan.yml
@@ -203,6 +203,7 @@ SUITES:
           - TestBackendOps.testSelfMult
           - TestBackendOps.testL2Normalize
           - TestBackendOps.testZerosLike
+          - TestBackendOps.testConv2dSpecial
           - TestBackendOps.testConvParameterRankExceptions
           - TestBackendOps.testCastToInt
           - TestBackendOps.testCastToFloat

--- a/plaidml/bridge/keras/backend_test.py
+++ b/plaidml/bridge/keras/backend_test.py
@@ -1076,7 +1076,6 @@ class TestBackendOps(unittest.TestCase):
             b.conv1d(im, km, padding='causal', dilation_rate=2, data_format=df),
         ]
 
-    @unittest.skip("Cull crashing tests")
     @opTest([
         _conv_inp(IN=2, IC=2, OC=4, IS=[4, 7], KS=[3, 3]),
         _conv_inp(IN=3, IC=3, OC=1, IS=[9, 8], KS=[2, 2], data_format='channels_last'),
@@ -1124,7 +1123,6 @@ class TestBackendOps(unittest.TestCase):
             b.conv2d_transpose(x, k, os, strides=st, padding=pd, data_format=df, dilation_rate=dr)
         ]
 
-    @unittest.skip("Cull crashing tests")
     @opTest([_conv_inp(IN=1, IC=1, OC=1, IS=[1, 6], KS=[1, 1], data_format='channels_last')],
             1e-04,
             skip_theano=True)
@@ -1134,7 +1132,6 @@ class TestBackendOps(unittest.TestCase):
         If we're not concerned with Keras 2.0.8 we probably don't need to retain this.'''
         return [b.conv2d(im, km, padding='same', strides=(2, 3), data_format=df)]
 
-    @unittest.skip("Cull crashing tests")
     @opTest([
         _conv_inp(IN=3, IC=1, OC=3, IS=[4, 7, 5], KS=[3, 3, 3]),
         _conv_inp(IN=3, IC=4, OC=2, IS=[3, 6, 3], KS=[2, 1, 2], data_format='channels_last'),
@@ -1558,7 +1555,6 @@ class TestBackendOps(unittest.TestCase):
     def testResizeImages(self, b, x, h, w, df):
         return [b.resize_images(x, h, w, df)]
 
-    @unittest.skip("Cull crashing tests")
     @opTest([
         [m(3, 2, 5, 11), 3, 1, 'channels_last'],
         [m(1, 3, 7, 5), 2, 3, 'channels_first'],

--- a/pmlc/dialect/tile/transforms/passes.td
+++ b/pmlc/dialect/tile/transforms/passes.td
@@ -8,7 +8,7 @@ def ComputeBounds : FunctionPass<"tile-compute-bounds"> {
   let constructor = "pmlc::dialect::tile::createComputeBoundsPass()";
 }
 
-def ConstantTypes : Pass<"tile-constant-types"> {
+def ConstantTypes : FunctionPass<"tile-constant-types"> {
   let summary = "Set constant types precision";
   let constructor = "pmlc::dialect::tile::createConstantTypesPass()";
   let options = [


### PR DESCRIPTION
Using of the GreedyPatternRewriteDriver is an overkill and exposed (at least on MacOS) an issue with not removing dependent operations when a triviallyDeadOperation is erased. This lead
s to inconsistent state in the workList for the pass that causes a destroyed operation to be processed.