### PR TITLE
Fix Keras pooling

### DIFF
--- a/plaidml/bridge/keras/__init__.py
+++ b/plaidml/bridge/keras/__init__.py
@@ -1206,7 +1206,7 @@ def pool2d(x, pool_size, strides=(1, 1), padding='valid', data_format=None, pool
                 strides=strides,
                 padding=padding,
                 data_format=data_format,
-                pool_mode=_normalize_pool_mode(pool_mode))
+                pool_mode=pool_mode)
 
 
 @_log_call
@@ -1216,7 +1216,7 @@ def pool3d(x, pool_size, strides=(1, 1, 1), padding='valid', data_format=None, p
                 strides=strides,
                 padding=padding,
                 data_format=data_format,
-                pool_mode=_normalize_pool_mode(pool_mode))
+                pool_mode=pool_mode)
 
 
 @_log_call


### PR DESCRIPTION
Properly handle sending the pool mode (i.e. average or max) through the Keras backend to the FFI.

This partially fixes PlaidML-v1 PlaidBench Keras ResNet50 (a full fix will at a minimum also require https://github.com/plaidml/plaidml/pull/1044)