### PR TITLE
Fix contractions returning zeroes

### DIFF
--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -78,13 +78,13 @@ struct AffineParallelOpConversion : public LoweringBase<AffineParallelOp> {
     // instead put `op`'s body where `op` is.)
     auto &innerLoopOps = rewriter.getInsertionBlock()->getOperations();
     auto &stripeBodyOps = op.region().front().getOperations();
-    mlir::Block::iterator insertion_loc;
+    mlir::Block::iterator insertionLoc;
     if (op.lowerBoundsMap().getNumResults() > 0) {
-      insertion_loc = std::prev(innerLoopOps.end());
+      insertionLoc = std::prev(innerLoopOps.end());
     } else {
-      insertion_loc = mlir::Block::iterator(op);
+      insertionLoc = mlir::Block::iterator(op);
     }
-    innerLoopOps.splice(insertion_loc, stripeBodyOps, stripeBodyOps.begin(),
+    innerLoopOps.splice(insertionLoc, stripeBodyOps, stripeBodyOps.begin(),
                         std::prev(stripeBodyOps.end()));
     // Replace all uses of old values
     size_t idx = 0;

--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -93,7 +93,7 @@ struct AffineParallelOpConversion : public LoweringBase<AffineParallelOp> {
       arg.replaceAllUsesWith(ivs[idx++]);
     }
     // Replace outputs with values from yield
-    auto termIt = std::prev(stripeBodyOps.end());
+    auto termIt = std::prev(parallelBodyOps.end());
     for (size_t i = 0; i < op.getNumResults(); i++) {
       op.getResult(i).replaceAllUsesWith(termIt->getOperand(i));
     }

--- a/pmlc/conversion/pxa_to_affine/tests/contract.mlir
+++ b/pmlc/conversion/pxa_to_affine/tests/contract.mlir
@@ -2,6 +2,7 @@
 
 #src  = affine_map<(i, j) -> (i, j)>
 #sink = affine_map<(i, j) -> (j, i)>
+#sink_to_empty = affine_map<(i, j) -> ()>
 
 func @transpose(%arg0: tensor<10x20xf32>) -> tensor<20x10xf32> {
   %cst = "eltwise.sconst"() {value = 0.0 : f64} : () -> f32
@@ -17,3 +18,24 @@ func @transpose(%arg0: tensor<10x20xf32>) -> tensor<20x10xf32> {
 // CHECK: affine.for
 // CHECK-DAG: %[[X:.*]] = affine.load %[[IN]][%{{.*}}, %{{.*}}] : memref<10x20xf32>
 // CHECK-DAG: affine.store %[[X]], %[[OUT]][%{{.*}}, %{{.*}}] : memref<20x10xf32>
+
+func @global_sum(%arg0: tensor<5x10xf32>) -> tensor<f32> {
+  %cst = "eltwise.sconst"() {value = 0.0 : f64} : () -> tensor<f32>
+  %0 = tile.contract add, none, %cst, %arg0 {sink=#sink_to_empty, srcs=[#src]} :
+    tensor<f32>, tensor<5x10xf32> -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// CHECK-LABEL: func @global_sum
+// CHECK-SAME: %[[IN:.*]]: memref<5x10xf32>
+// CHECK-SAME: %[[OUT:.*]]: memref<f32>
+// CHECK: %[[CST:.*]] = constant
+// CHECK: affine.store %[[CST]], %[[OUT]]
+// CHECK: affine.for
+// CHECK: affine.for
+// CHECK-DAG: %[[OLD:.*]] = affine.load %[[OUT]][] : memref<f32>
+// CHECK-DAG: %[[UPDATE:.*]] = affine.load %[[IN]][%{{.*}}, %{{.*}}] : memref<5x10xf32>
+// CHECK: %[[NEW:.*]] = addf
+// CHECK-DAG: %[[OLD]]
+// CHECK-DAG: %[[UPDATE]]
+// CHECK: affine.store %[[NEW]], %[[OUT]][] : memref<f32>


### PR DESCRIPTION
Fixes an ordering issue in PXA to Affine where reduce ops with no indexes were having their bodies moved to the end of their containing block. In particular, this meant that reductions initializing the output of a contraction to zero were being moved after reductions doing the core work of a contraction.

This fixes the bug where most backend tests using a contraction returned tensors of all 0s.