### PR TITLE
Fix max contractions of negatives

### DIFF
--- a/plaidml/bridge/keras/backend_test.py
+++ b/plaidml/bridge/keras/backend_test.py
@@ -1173,7 +1173,7 @@ class TestBackendOps(unittest.TestCase):
         ]
 
     @opTest([
-        [m(1, 4, 4, 1)],
+        [m(1, 4, 4, 1) - 33.],
         [m(1, 9, 9, 1)],
         [m(1, 8, 10, 1)],
         [m(2, 9, 11, 3)],

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -417,12 +417,12 @@ static Value createInit(OpBuilder &builder, Location loc, Type type,
     }
     case AggregationKind::min: {
       auto value = convertFloatUsingType(
-          llvm::APFloat(std::numeric_limits<float>::max()), floatType);
+          llvm::APFloat(std::numeric_limits<double>::infinity()), floatType);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     case AggregationKind::max: {
       auto value = convertFloatUsingType(
-          llvm::APFloat(std::numeric_limits<float>::min()), floatType);
+          llvm::APFloat(-std::numeric_limits<double>::infinity()), floatType);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     default:

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -417,12 +417,12 @@ static Value createInit(OpBuilder &builder, Location loc, Type type,
     }
     case AggregationKind::min: {
       auto value = convertFloatUsingType(
-          llvm::APFloat(std::numeric_limits<double>::infinity()), floatType);
+          llvm::APFloat::getInf(llvm::APFloat::IEEEdouble(), false), floatType);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     case AggregationKind::max: {
       auto value = convertFloatUsingType(
-          llvm::APFloat(-std::numeric_limits<double>::infinity()), floatType);
+          llvm::APFloat::getInf(llvm::APFloat::IEEEdouble(), true), floatType);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     default:

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -416,13 +416,11 @@ static Value createInit(OpBuilder &builder, Location loc, Type type,
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     case AggregationKind::min: {
-      auto value = convertFloatUsingType(
-          llvm::APFloat::getInf(llvm::APFloat::IEEEdouble(), false), floatType);
+      auto value = llvm::APFloat::getInf(floatType.getFloatSemantics(), false);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     case AggregationKind::max: {
-      auto value = convertFloatUsingType(
-          llvm::APFloat::getInf(llvm::APFloat::IEEEdouble(), true), floatType);
+      auto value = llvm::APFloat::getInf(floatType.getFloatSemantics(), true);
       return builder.create<mlir::ConstantFloatOp>(loc, value, floatType);
     }
     default:


### PR DESCRIPTION
Fixes the smallest positive vs most negative problem identified in https://github.com/plaidml/plaidml/pull/1063 by switching to +/-infinity for the initialization of min and max contractions respectively. Updates the test for max pool to find the previous error.