### PR TITLE
Fix system library lookup for MacOS

### DIFF
--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1090,6 +1090,30 @@ TEST_F(CppEdsl, PrngResultNotNegative) {
   }
 }
 
+TEST_F(CppEdsl, Cos) {
+  auto S = Placeholder(DType::FLOAT32, {3, 3});
+  TensorDim I, J;
+  TensorIndex i("i"), j("j");
+  S.bind_dims(I, J);
+  auto O = cos(S);
+  auto program = makeProgram("cos", {O});
+  std::cout << program << std::endl;
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.Cos
+  // clang-format on
+
+  std::vector<float> input = {
+      5.0, 6.0, 7.0,  //
+      4.0, 5.0, 6.0,  //
+      7.0, 8.0, 9.0,  //
+  };
+
+  auto binder = exec::Binder(program);
+  auto executable = binder.compile();
+  binder.input(S).copy_from(input.data());
+  executable->run();
+}
+
 TEST_F(CppEdsl, ConvI8) {
   auto I = Placeholder(DType::INT8, {1, 224, 224, 3});
   auto K = Placeholder(DType::INT8, {3, 3, 1, 32});

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1102,16 +1102,15 @@ TEST_F(CppEdsl, Cos) {
   // CHECK-LABEL: CppEdsl.Cos
   // clang-format on
 
-  std::vector<float> input = {
+  std::vector<float> A_input = {
       5.0, 6.0, 7.0,  //
       4.0, 5.0, 6.0,  //
       7.0, 8.0, 9.0,  //
   };
 
-  auto binder = exec::Binder(program);
-  auto executable = binder.compile();
-  binder.input(S).copy_from(input.data());
-  executable->run();
+  std::vector<float> C_output = {0.283662, 0.96017,  0.753902, -0.653644, 0.283662,
+                                 0.96017,  0.753902, -0.1455,  -0.91113};
+  checkProgram(program, {{S, A_input}}, {{O, C_output}});
 }
 
 TEST_F(CppEdsl, ConvI8) {

--- a/pmlc/compiler/executable.cc
+++ b/pmlc/compiler/executable.cc
@@ -164,7 +164,19 @@ static void *tryResolveSymbol(StringRef symbol) {
     if (auto ptr = resolveSymbol(symbol.drop_front()))
       return ptr;
   }
-  return llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(symbol.str());
+
+  auto ptr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(symbol.str());
+  if (ptr)
+    return ptr;
+
+  if (symbol[0] == '_') {
+    if (auto ptr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(
+            symbol.drop_front().str())) {
+      return ptr;
+    }
+  }
+
+  return nullptr;
 }
 
 struct MCJITEngineImpl : EngineImpl {

--- a/pmlc/testing/BUILD
+++ b/pmlc/testing/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation.
+# Copyright 2020 Intel Corporation.
 
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 

--- a/pmlc/testing/BUILD
+++ b/pmlc/testing/BUILD
@@ -1,3 +1,5 @@
+# Copyright 2019 Intel Corporation.
+
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
The compiler adds an underscore, but on MacOS system symbols have no one. The Stripe code did similar thing.
Thanks Mars!