### PR TITLE
Add the pass to lower TanhOp to a runtime call.

### DIFF
--- a/ci/plan.yml
+++ b/ci/plan.yml
@@ -208,6 +208,7 @@ SUITES:
           - TestBackendOps.testSoftmax
           - TestBackendOps.testSigmoid
           - TestBackendOps.testSign
+          - TestBackendOps.testTanh
           - TestBackendOps.testExp
           - TestBackendOps.testLog
           - TestBackendOps.testLogSumExp

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -6,6 +6,7 @@
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -155,6 +156,9 @@ void addToPipeline(OpPassManager &pm) {
   if (pmlc::util::getEnvVar("PLAIDML_BOUNDS_CHECK") == "1") {
     pm.addPass(pmlc::dialect::stdx::createBoundsCheckPass());
   }
+
+  pm.addPass(createTanhLowerPass());
+
   pm.addPass(ConvertToLLVMPass::create());
   pm.addPass(createTraceLinkingPass());
 }


### PR DESCRIPTION
This should be done before Stdx--->LLVM conversion.

This is a draft PR, because it needs to go after https://github.com/plaidml/llvm-project/pull/10 PR.
Once the dependent PR lands, I'll make this a normal PR and push it.