### PR TITLE
Add fusion tests

### DIFF
--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -92,8 +92,8 @@ def plaidml_workspace():
         strip_prefix = "jsonnet-0.13.0",
     )
 
-    LLVM_COMMIT = "14f6cd85ead596a4c71f23f41af822d96561db0e"
-    LLVM_SHA256 = "6c59c8d4b88a14c6128918e3364ae93e7e69ba8913da758024f44ef8b51c732d"
+    LLVM_COMMIT = "d26bfee56b315043e03627ad179fe6eb6ebfe7e9"
+    LLVM_SHA256 = "5a758eaff559d8bc4341d74de6260334c071280294ff084d5aa091a0964507bf"
     LLVM_URL = "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)
     http_archive(
         name = "llvm-project",

--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -92,8 +92,8 @@ def plaidml_workspace():
         strip_prefix = "jsonnet-0.13.0",
     )
 
-    LLVM_COMMIT = "563136a5a2f9acfb53c0a54179d0971466a9049f"
-    LLVM_SHA256 = "dd852052f2c01d78c41a2c6e381846bc62a5b86118baee4ea87820b024a4b4ef"
+    LLVM_COMMIT = "14f6cd85ead596a4c71f23f41af822d96561db0e"
+    LLVM_SHA256 = "6c59c8d4b88a14c6128918e3364ae93e7e69ba8913da758024f44ef8b51c732d"
     LLVM_URL = "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)
     http_archive(
         name = "llvm-project",

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -42,7 +42,7 @@ StrideInfo &StrideInfo::operator+=(const StrideInfo &rhs) {
   return *this;
 }
 
-void StrideInfo::print(raw_ostream &os, Block *relative) {
+void StrideInfo::print(raw_ostream &os, Block *relative) const {
   std::map<std::string, unsigned> ordered;
   std::map<Block *, unsigned> blockIds;
   for (auto kvp : strides) {

--- a/pmlc/dialect/pxa/analysis/strides.h
+++ b/pmlc/dialect/pxa/analysis/strides.h
@@ -23,7 +23,7 @@ struct StrideInfo {
   StrideInfo &operator*=(int64_t factor);
   StrideInfo &operator+=(const StrideInfo &rhs);
 
-  void print(raw_ostream &os, Block *relative = nullptr);
+  void print(raw_ostream &os, Block *relative = nullptr) const;
 };
 
 // Compute stride info for a given affine value (such an an induction variable

--- a/pmlc/dialect/pxa/tests/autotile.mlir
+++ b/pmlc/dialect/pxa/tests/autotile.mlir
@@ -1,4 +1,4 @@
-// RUN: pmlc-opt -canonicalize -autotile-10 %s | FileCheck %s
+// RUN: pmlc-opt -canonicalize -pxa-autotile-example %s | FileCheck %s
 
 // CHECK-LABEL: @dot0
 func @dot0(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> memref<100x100xf32> {

--- a/pmlc/dialect/pxa/tests/fusion.mlir
+++ b/pmlc/dialect/pxa/tests/fusion.mlir
@@ -1,0 +1,126 @@
+// RUN: pmlc-opt -canonicalize -pxa-fusion -canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: func @simple_fusion
+func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32>, %D: memref<2x3xf32>) {
+  %T = alloc() : memref<2x3xf32>
+  %4 = affine.parallel (%i, %j) = (0, 0) to (2, 3) : memref<2x3xf32> {
+    %0 = affine.load %A[%i, %j] : memref<2x3xf32>
+    %1 = affine.load %B[%i, %j] : memref<2x3xf32>
+    %2 = addf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %T[%i, %j] : memref<2x3xf32>
+    affine.yield %3 : memref<2x3xf32>
+  }
+  %5 = affine.parallel (%i, %j) = (0, 0) to (2, 3) : memref<2x3xf32> {
+    %0 = affine.load %4[%i, %j] : memref<2x3xf32>
+    %1 = affine.load %C[%i, %j] : memref<2x3xf32>
+    %2 = mulf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %D[%i, %j] : memref<2x3xf32>
+    affine.yield %3 : memref<2x3xf32>
+  }
+  return
+  // CHECK: affine.parallel (%[[i:.*]], %[[j:.*]]) = (0, 0) to (2, 3)
+  // CHECK: affine.load
+  // CHECK: affine.load
+  // CHECK: addf
+  // CHECK: pxa.reduce
+  // CHECK: affine.load
+  // CHECK: affine.load
+  // CHECK: mulf
+  // CHECK: pxa.reduce
+  // CHECK: affine.yield
+}
+
+// CHECK-LABEL: func @grn
+func @grn(%arg0: memref<1x4x4x3xf16>) -> memref<1x4x4x3xf16> {
+  %cst = constant 1.001360e-05 : f16
+  %cst_0 = constant 0.000000e+00 : f16
+  %cst_1 = constant 1.000000e+00 : f16
+  %0 = alloc() : memref<1x4x4x3xf16>
+  %1 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 3) : memref<1x4x4x3xf16> {
+    %15 = affine.load %arg0[0, %arg2, %arg3, %arg4] : memref<1x4x4x3xf16>
+    %16 = affine.load %arg0[0, %arg2, %arg3, %arg4] : memref<1x4x4x3xf16>
+    %17 = mulf %15, %16 : f16
+    %18 = pxa.reduce assign %17, %0[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x3xf16>
+    affine.yield %18 : memref<1x4x4x3xf16>
+  }
+  %2 = alloc() : memref<1x4x4x1xf16>
+  %3 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 1) : memref<1x4x4x1xf16> {
+    %15 = pxa.reduce assign %cst_0, %2[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xf16>
+    affine.yield %15 : memref<1x4x4x1xf16>
+  }
+  %4 = affine.parallel (%arg1, %arg2, %arg3, %arg4, %arg5) = (0, 0, 0, 0, 0) to (1, 4, 4, 1, 3) : memref<1x4x4x1xf16> {
+    %15 = affine.load %1[%arg1, %arg2, %arg3, %arg5] : memref<1x4x4x3xf16>
+    %16 = pxa.reduce add %15, %3[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xf16>
+    affine.yield %16 : memref<1x4x4x1xf16>
+  }
+  %5 = alloc() : memref<1x4x4x1xf16>
+  %6 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 1) : memref<1x4x4x1xf16> {
+    %15 = affine.load %4[0, %arg2, %arg3, 0] : memref<1x4x4x1xf16>
+    %16 = addf %15, %cst_1 : f16
+    %17 = pxa.reduce assign %16, %5[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xf16>
+    affine.yield %17 : memref<1x4x4x1xf16>
+  }
+  %7 = alloc() : memref<1x4x4x1xf16>
+  %8 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 1) : memref<1x4x4x1xf16> {
+    %15 = affine.load %6[0, %arg2, %arg3, 0] : memref<1x4x4x1xf16>
+    %16 = sqrt %15 : f16
+    %17 = pxa.reduce assign %16, %7[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xf16>
+    affine.yield %17 : memref<1x4x4x1xf16>
+  }
+  %9 = alloc() : memref<1x4x4x1xi1>
+  %10 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 1) : memref<1x4x4x1xi1> {
+    %15 = affine.load %8[0, %arg2, %arg3, 0] : memref<1x4x4x1xf16>
+    %16 = cmpf "olt", %15, %cst : f16
+    %17 = pxa.reduce assign %16, %9[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xi1>
+    affine.yield %17 : memref<1x4x4x1xi1>
+  }
+  %11 = alloc() : memref<1x4x4x1xf16>
+  %12 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 1) : memref<1x4x4x1xf16> {
+    %15 = affine.load %10[0, %arg2, %arg3, 0] : memref<1x4x4x1xi1>
+    %16 = affine.load %8[0, %arg2, %arg3, 0] : memref<1x4x4x1xf16>
+    %17 = select %15, %cst, %16 : f16
+    %18 = pxa.reduce assign %17, %11[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x1xf16>
+    affine.yield %18 : memref<1x4x4x1xf16>
+  }
+  %13 = alloc() : memref<1x4x4x3xf16>
+  %14 = affine.parallel (%arg1, %arg2, %arg3, %arg4) = (0, 0, 0, 0) to (1, 4, 4, 3) : memref<1x4x4x3xf16> {
+    %15 = affine.load %arg0[0, %arg2, %arg3, %arg4] : memref<1x4x4x3xf16>
+    %16 = affine.load %12[0, %arg2, %arg3, 0] : memref<1x4x4x1xf16>
+    %17 = divf %15, %16 : f16
+    %18 = pxa.reduce assign %17, %13[%arg1, %arg2, %arg3, %arg4] : memref<1x4x4x3xf16>
+    affine.yield %18 : memref<1x4x4x3xf16>
+  }
+  return %14 : memref<1x4x4x3xf16>
+
+  // CHECK: affine.parallel (%{{.*}}, %{{.*}}) = (0, 0) to (4, 4)
+  // CHECK:   pxa.reduce assign
+  // CHECK:   affine.parallel (%{{.*}}) = (0) to (3)
+  // CHECK:     affine.load
+  // CHECK:     affine.load
+  // CHECK:     mulf
+  // CHECK:     pxa.reduce assign
+  // CHECK:     affine.load
+  // CHECK:     pxa.reduce add
+  // CHECK:     affine.yield
+  // CHECK:   affine.load
+  // CHECK:   addf
+  // CHECK:   pxa.reduce assign
+  // CHECK:   affine.load
+  // CHECK:   sqrt
+  // CHECK:   pxa.reduce assign
+  // CHECK:   affine.load
+  // CHECK:   cmpf "olt"
+  // CHECK:   pxa.reduce assign
+  // CHECK:   affine.load
+  // CHECK:   affine.load
+  // CHECK:   select
+  // CHECK:   pxa.reduce assign
+  // CHECK:   affine.parallel (%{{.*}}) = (0) to (3)
+  // CHECK:     affine.load
+  // CHECK:     affine.load
+  // CHECK:     divf
+  // CHECK:     pxa.reduce assign
+  // CHECK:     affine.yield
+  // CHECK:   affine.yield
+  // CHECK: return
+}

--- a/pmlc/dialect/pxa/tests/fusion.mlir
+++ b/pmlc/dialect/pxa/tests/fusion.mlir
@@ -18,7 +18,7 @@ func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32
     affine.yield %3 : memref<2x3xf32>
   }
   return
-  // CHECK: affine.parallel (%[[i:.*]], %[[j:.*]]) = (0, 0) to (2, 3)
+  // CHECK: affine.parallel (%{{.*}}, %{{.*}}) = (0, 0) to (2, 3)
   // CHECK: affine.load
   // CHECK: affine.load
   // CHECK: addf

--- a/pmlc/dialect/pxa/tests/stencil.mlir
+++ b/pmlc/dialect/pxa/tests/stencil.mlir
@@ -4,102 +4,100 @@
 #map1 = affine_map<() -> (0, 0, 0)>
 #map2 = affine_map<() -> (100, 100, 100)>
 
-module {
-  // CHECK-LABEL: @no_gemm_mul_reduce_operation
-  func @no_gemm_mul_reduce_operation(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      %2 = mulf %0, %1 : f32
-      pxa.reduce mul %2, %arg2[%i, %j] : memref<100x100xf32>
-    }
-    return
+// CHECK-LABEL: @no_gemm_mul_reduce_operation
+func @no_gemm_mul_reduce_operation(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    pxa.reduce mul %2, %arg2[%i, %j] : memref<100x100xf32>
   }
-  // CHECK: affine.parallel
-  // CHECK-NOT: xsmm 
-
-
-  // CHECK-LABEL: @no_gemm_no_mul_before_reduce_operation
-  func @no_gemm_no_mul_before_reduce_operation(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      %2 = addf %0, %1 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK-NOT: xsmm 
-
-  // CHECK-LABEL: @no_gemm_mul_params_not_affine_loads
-  func @no_gemm_mul_params_not_affine_loads(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      %3 = addf %0, %1 :f32
-      %2 = mulf %0, %3 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-      "affine.yield"() : () -> ()
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK-NOT: xsmm 
-
-  // CHECK-LABEL: @no_gemm_no_stride_one_1
-  func @no_gemm_no_stride_one_1(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%k, %i] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      %3 = addf %0, %1 :f32
-      %2 = mulf %0, %3 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-      "affine.yield"() : () -> ()
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK-NOT: xsmm 
-
-  // CHECK-LABEL: @no_gemm_no_stride_one_2
-  func @no_gemm_no_stride_one_2(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%k, %i] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, 2*%j] : memref<100x100xf32>
-      %3 = addf %0, %1 :f32
-      %2 = mulf %0, %3 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-      "affine.yield"() : () -> ()
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK-NOT: xsmm 
-
-  // CHECK-LABEL: @gemm_operation_rewrite_i32
-  func @gemm_operation_rewrite_i32(%arg0: memref<100x100xi32>, %arg1: memref<100x100xi32>, %arg2: memref<100x100xi32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xi32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xi32>
-      %2 = muli %0, %1 : i32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xi32>
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK: xsmm 
-
-  // CHECK-LABEL: @gemm_operation_rewrite_fl32
-  func @gemm_operation_rewrite_fl32(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      %2 = mulf %0, %1 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-    }
-    return
-  }
-  // CHECK: affine.parallel
-  // CHECK: xsmm 
+  return
 }
+// CHECK: affine.parallel
+// CHECK-NOT: xsmm 
+
+
+// CHECK-LABEL: @no_gemm_no_mul_before_reduce_operation
+func @no_gemm_no_mul_before_reduce_operation(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = addf %0, %1 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK-NOT: xsmm 
+
+// CHECK-LABEL: @no_gemm_mul_params_not_affine_loads
+func @no_gemm_mul_params_not_affine_loads(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %3 = addf %0, %1 :f32
+    %2 = mulf %0, %3 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+    "affine.yield"() : () -> ()
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK-NOT: xsmm 
+
+// CHECK-LABEL: @no_gemm_no_stride_one_1
+func @no_gemm_no_stride_one_1(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%k, %i] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %3 = addf %0, %1 :f32
+    %2 = mulf %0, %3 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+    "affine.yield"() : () -> ()
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK-NOT: xsmm 
+
+// CHECK-LABEL: @no_gemm_no_stride_one_2
+func @no_gemm_no_stride_one_2(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%k, %i] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, 2*%j] : memref<100x100xf32>
+    %3 = addf %0, %1 :f32
+    %2 = mulf %0, %3 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+    "affine.yield"() : () -> ()
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK-NOT: xsmm 
+
+// CHECK-LABEL: @gemm_operation_rewrite_i32
+func @gemm_operation_rewrite_i32(%arg0: memref<100x100xi32>, %arg1: memref<100x100xi32>, %arg2: memref<100x100xi32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xi32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xi32>
+    %2 = muli %0, %1 : i32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xi32>
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK: xsmm 
+
+// CHECK-LABEL: @gemm_operation_rewrite_fl32
+func @gemm_operation_rewrite_fl32(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+  }
+  return
+}
+// CHECK: affine.parallel
+// CHECK: xsmm 

--- a/pmlc/dialect/pxa/tests/strides.mlir
+++ b/pmlc/dialect/pxa/tests/strides.mlir
@@ -1,111 +1,109 @@
-// RUN: pmlc-opt -test-stride-info  %s | FileCheck %s
+// RUN: pmlc-opt -pxa-stride-info  %s | FileCheck %s
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<() -> (0, 0, 0)>
 #map2 = affine_map<() -> (100, 100, 100)>
 
-module {
-  func @simple(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-    affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
-      %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg2=1]
-      %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg1=1, ^bb0:%arg2=100]
+func @simple(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg2=1]
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg1=1, ^bb0:%arg2=100]
+    %2 = mulf %0, %1 : f32
+    pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg1=1]
+  }
+  return
+}
+
+func @symbolic_fail(%arg0: memref<100x?xf32>) {
+  %d1 = dim %arg0, 0 : memref<100x?xf32>
+  affine.parallel (%i, %j) = (0, 0) to (100, symbol(%d1)) {
+    %0 = affine.load %arg0[%i, %j] : memref<100x?xf32>
+    // CHECK: strides: none
+  }
+  return
+}
+
+func @for_diagonal(%arg0: memref<100x100xf32>) {
+  affine.for %i = 0 to 10 {
+    %0 = affine.load %arg0[%i, %i] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=101]
+  }
+  return
+}
+
+func @for_step(%arg0: memref<100x100xf32>) {
+  affine.for %i = 0 to 10 step 2 {
+    %0 = affine.load %arg0[%i, %i] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=202]
+  }
+  return
+}
+
+func @parallel_step(%arg0: memref<100x100xf32>) {
+  affine.parallel (%i, %j) = (0, 0) to (10, 10) step (2, 5) {
+    %0 = affine.load %arg0[%i, %j] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=200, ^bb0:%arg1=5]
+  }
+  return
+}
+
+func @parallel_tile(%arg0: memref<100x100xf32>) {
+  affine.parallel (%i, %j) = (0, 0) to (100, 100) step (10, 10) {
+    affine.parallel (%i2, %j2) = (%i, %j) to (%i + 10, %j + 10) {
+      %0 = affine.load %arg0[%i2, %j2] : memref<100x100xf32>
+      // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg1=1, ^bb1:%arg0=1000, ^bb1:%arg1=10]
+    }
+  }
+  return
+}
+
+func @affine_apply(%arg0: memref<100x100xf32>) {
+  affine.for %i = 0 to 10 {
+    %0 = affine.apply affine_map<(d1) -> (5 * d1)>(%i)
+    %1 = affine.load %arg0[%0, %i] : memref<100x100xf32>
+    // CHECK: strides: 0:[^bb0:%arg0=501]
+  }
+  return
+}
+
+func @affine_apply_add(%arg0: memref<100x100xf32>) {
+  affine.for %i = 0 to 10 {
+    %0 = affine.apply affine_map<(d1) -> (d1 + 10)>(%i)
+    %1 = affine.load %arg0[%0, %i] : memref<100x100xf32>
+    // CHECK: strides: 1000:[^bb0:%arg0=101]
+  }
+  return
+}
+
+func @dot_tiled(%A: memref<8x8xf32>, %B: memref<8x8xf32>, %C: memref<8x8xf32>) {
+  affine.parallel (%i0, %j0, %k0) = (0, 0, 0) to (8, 8, 8) step (2, 2, 2) {
+    affine.parallel (%i1, %j1, %k1) = (%i0, %j0, %k0) to (%i0 + 2, %j0 + 2, %k0 + 2) {
+      %0 = affine.load %A[%i1, %k1] : memref<8x8xf32>
+      // CHECK: strides: 0:[^bb0:%arg0=8, ^bb0:%arg2=1, ^bb1:%arg0=16, ^bb1:%arg2=2]
+      %1 = affine.load %B[%k1, %j1] : memref<8x8xf32>
+      // CHECK: strides: 0:[^bb0:%arg1=1, ^bb0:%arg2=8, ^bb1:%arg1=2, ^bb1:%arg2=16]
       %2 = mulf %0, %1 : f32
-      pxa.reduce add %2, %arg2[%i, %j] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg1=1]
+      pxa.reduce add %2, %C[%i1, %j1] : memref<8x8xf32>
+      // CHECK: strides: 0:[^bb0:%arg0=8, ^bb0:%arg1=1, ^bb1:%arg0=16, ^bb1:%arg1=2]        
     }
-    return
   }
+  return
+}
 
-  func @symbolic_fail(%arg0: memref<100x?xf32>) {
-    %d1 = dim %arg0, 0 : memref<100x?xf32>
-    affine.parallel (%i, %j) = (0, 0) to (100, symbol(%d1)) {
-      %0 = affine.load %arg0[%i, %j] : memref<100x?xf32>
-      // CHECK: strides: none
+func @conv2_tiled(%I: memref<1x6x5x7xf32>, %K: memref<1x1x7x11xf32>, %O: memref<1x6x5x11xf32>) {
+  affine.parallel (%x0, %y) = (0, 0) to (6, 5) step (2, 1) {
+    affine.parallel (%x1, %ci, %co) = (%x0, 0, 0) to (%x0 + 2, 7, 11) {
+      %0 = affine.load %I[0, %x1, %y, %ci] : memref<1x6x5x7xf32>
+      // CHECK: strides: 0:[^bb0:%arg0=35, ^bb0:%arg1=1, ^bb1:%arg0=70, ^bb1:%arg1=7]
+      %1 = affine.load %K[0, 0, %ci, %co] : memref<1x1x7x11xf32>
+      // CHECK: strides: 0:[^bb0:%arg1=11, ^bb0:%arg2=1]
+      %2 = mulf %0, %1 : f32
+      pxa.reduce add %2, %O[0, %x1, %y, %co] : memref<1x6x5x11xf32>
+      // CHECK: strides: 0:[^bb0:%arg0=55, ^bb0:%arg2=1, ^bb1:%arg0=110, ^bb1:%arg1=11]
     }
-    return
   }
-
-  func @for_diagonal(%arg0: memref<100x100xf32>) {
-    affine.for %i = 0 to 10 {
-      %0 = affine.load %arg0[%i, %i] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=101]
-    }
-    return
-  }
-
-  func @for_step(%arg0: memref<100x100xf32>) {
-    affine.for %i = 0 to 10 step 2 {
-      %0 = affine.load %arg0[%i, %i] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=202]
-    }
-    return
-  }
-
-  func @parallel_step(%arg0: memref<100x100xf32>) {
-    affine.parallel (%i, %j) = (0, 0) to (10, 10) step (2, 5) {
-      %0 = affine.load %arg0[%i, %j] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=200, ^bb0:%arg1=5]
-    }
-    return
-  }
-
-  func @parallel_tile(%arg0: memref<100x100xf32>) {
-    affine.parallel (%i, %j) = (0, 0) to (100, 100) step (10, 10) {
-      affine.parallel (%i2, %j2) = (%i, %j) to (%i + 10, %j + 10) {
-        %0 = affine.load %arg0[%i2, %j2] : memref<100x100xf32>
-        // CHECK: strides: 0:[^bb0:%arg0=100, ^bb0:%arg1=1, ^bb1:%arg0=1000, ^bb1:%arg1=10]
-      }
-    }
-    return
-  }
-
-  func @affine_apply(%arg0: memref<100x100xf32>) {
-    affine.for %i = 0 to 10 {
-      %0 = affine.apply affine_map<(d1) -> (5 * d1)>(%i)
-      %1 = affine.load %arg0[%0, %i] : memref<100x100xf32>
-      // CHECK: strides: 0:[^bb0:%arg0=501]
-    }
-    return
-  }
-
-  func @affine_apply_add(%arg0: memref<100x100xf32>) {
-    affine.for %i = 0 to 10 {
-      %0 = affine.apply affine_map<(d1) -> (d1 + 10)>(%i)
-      %1 = affine.load %arg0[%0, %i] : memref<100x100xf32>
-      // CHECK: strides: 1000:[^bb0:%arg0=101]
-    }
-    return
-  }
-
-  func @dot_tiled(%A: memref<8x8xf32>, %B: memref<8x8xf32>, %C: memref<8x8xf32>) {
-    affine.parallel (%i0, %j0, %k0) = (0, 0, 0) to (8, 8, 8) step (2, 2, 2) {
-      affine.parallel (%i1, %j1, %k1) = (%i0, %j0, %k0) to (%i0 + 2, %j0 + 2, %k0 + 2) {
-        %0 = affine.load %A[%i1, %k1] : memref<8x8xf32>
-        // CHECK: strides: 0:[^bb0:%arg0=8, ^bb0:%arg2=1, ^bb1:%arg0=16, ^bb1:%arg2=2]
-        %1 = affine.load %B[%k1, %j1] : memref<8x8xf32>
-        // CHECK: strides: 0:[^bb0:%arg1=1, ^bb0:%arg2=8, ^bb1:%arg1=2, ^bb1:%arg2=16]
-        %2 = mulf %0, %1 : f32
-        pxa.reduce add %2, %C[%i1, %j1] : memref<8x8xf32>
-        // CHECK: strides: 0:[^bb0:%arg0=8, ^bb0:%arg1=1, ^bb1:%arg0=16, ^bb1:%arg1=2]        
-      }
-    }
-    return
-  }
-
-  func @conv2_tiled(%I: memref<1x6x5x7xf32>, %K: memref<1x1x7x11xf32>, %O: memref<1x6x5x11xf32>) {
-    affine.parallel (%x0, %y) = (0, 0) to (6, 5) step (2, 1) {
-      affine.parallel (%x1, %ci, %co) = (%x0, 0, 0) to (%x0 + 2, 7, 11) {
-        %0 = affine.load %I[0, %x1, %y, %ci] : memref<1x6x5x7xf32>
-        // CHECK: strides: 0:[^bb0:%arg0=35, ^bb0:%arg1=1, ^bb1:%arg0=70, ^bb1:%arg1=7]
-        %1 = affine.load %K[0, 0, %ci, %co] : memref<1x1x7x11xf32>
-        // CHECK: strides: 0:[^bb0:%arg1=11, ^bb0:%arg2=1]
-        %2 = mulf %0, %1 : f32
-        pxa.reduce add %2, %O[0, %x1, %y, %co] : memref<1x6x5x11xf32>
-        // CHECK: strides: 0:[^bb0:%arg0=55, ^bb0:%arg2=1, ^bb1:%arg0=110, ^bb1:%arg1=11]
-      }
-    }
-    return
-  }
+  return
 }

--- a/pmlc/dialect/pxa/transforms/fusion.cc
+++ b/pmlc/dialect/pxa/transforms/fusion.cc
@@ -2,19 +2,15 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Support/DebugStringHelper.h"
 #include "pmlc/dialect/pxa/analysis/strides.h"
 #include "pmlc/dialect/pxa/ir/ops.h"
 #include "pmlc/dialect/pxa/transforms/pass_detail.h"
 #include "pmlc/util/logging.h"
 
-namespace pmlc::dialect::pxa {
+using namespace mlir; // NOLINT[build/namespaces]
 
-using mlir::AffineLoadOp;
-using mlir::AffineParallelOp;
-using mlir::Block;
-using mlir::BlockArgument;
-using mlir::Operation;
-using mlir::StrideInfo;
+namespace pmlc::dialect::pxa {
 
 namespace {
 
@@ -22,46 +18,47 @@ using WriteRead = std::pair<AffineReduceOp, AffineLoadOp>;
 using WriteWrite = std::pair<AffineReduceOp, AffineReduceOp>;
 
 struct FusionInfo {
-  // The parallel for ops
-  AffineParallelOp apA;
-  AffineParallelOp apB;
-  // The loop sizes for apA and apB
-  llvm::SmallVector<int64_t, 4> sizesA;
-  llvm::SmallVector<int64_t, 4> sizesB;
+  struct AffineParallelInfo {
+    // The affine.parallel op itself.
+    AffineParallelOp op;
+    // The loop sizes for the corresponding affine.parallel op.
+    SmallVector<int64_t, 4> sizes;
+    // The tile for the corresponding affine.parallel.op (pre-fusion).
+    SmallVector<int64_t, 8> tile;
+  };
+
+  AffineParallelInfo aInfo;
+  AffineParallelInfo bInfo;
   // The load and store ops
-  llvm::SmallVector<WriteRead, 4> readAfterWrites;
-  llvm::SmallVector<WriteWrite, 4> writeAfterWrites;
+  SmallVector<WriteRead, 4> readAfterWrites;
+  SmallVector<WriteWrite, 4> writeAfterWrites;
   // Current state (whether we have a plan or not)
   bool hasPlan;
-  // Tiling's for A + B (pre-fusion)
-  llvm::SmallVector<int64_t, 8> tileA;
-  llvm::SmallVector<int64_t, 8> tileB;
   // Specifies the mapping from A's index space into B's index space (post
   // tiling)
-  llvm::DenseMap<BlockArgument, BlockArgument> aToB;
-  llvm::DenseMap<BlockArgument, BlockArgument> bToA;
+  DenseMap<BlockArgument, BlockArgument> aToB;
+  DenseMap<BlockArgument, BlockArgument> bToA;
 
   FusionInfo(AffineParallelOp apA, AffineParallelOp apB)
-      : apA(apA), apB(apB), hasPlan(false) {}
+      : aInfo{apA}, bInfo{apB}, hasPlan(false) {}
 
   // Helper method to find the original source write of a state update.
   static AffineReduceOp findSourceWrite(Value val) {
-    auto opRes = val.dyn_cast<mlir::OpResult>();
-    if (auto op = mlir::dyn_cast_or_null<AffineReduceOp>(opRes.getOwner())) {
+    auto opRes = val.dyn_cast<OpResult>();
+    if (auto op = dyn_cast_or_null<AffineReduceOp>(opRes.getOwner())) {
       return op;
     }
-    if (auto op = mlir::dyn_cast<AffineParallelOp>(opRes.getOwner())) {
-      auto retOp =
-          mlir::cast<mlir::AffineYieldOp>(op.getBody()->getTerminator());
+    if (auto op = dyn_cast<AffineParallelOp>(opRes.getOwner())) {
+      auto retOp = cast<AffineYieldOp>(op.getBody()->getTerminator());
       return findSourceWrite(retOp.getOperand(opRes.getResultNumber()));
     }
-    return AffineReduceOp();
+    return nullptr;
   }
 
   // Helper method to remove elements from a stride info that are not part of
   // a specific block's arguments.
   static void cleanStrideInfo(Block *block, StrideInfo &si) {
-    for (auto &pair : llvm::make_early_inc_range(si.strides)) {
+    for (auto &pair : make_early_inc_range(si.strides)) {
       if (pair.first.getOwner() != block) {
         si.strides.erase(pair.first);
       }
@@ -70,7 +67,7 @@ struct FusionInfo {
 
   // Helper to get a clean version of the strides for a specific op (or fail)
   template <typename OpA>
-  static bool getStrides(llvm::SmallVectorImpl<StrideInfo> &out, OpA op,
+  static bool getStrides(SmallVectorImpl<StrideInfo> &out, OpA op,
                          AffineParallelOp ap) {
     auto strides = computeStrideInfo(op.getAffineMap(), op.getMapOperands());
     if (!strides) {
@@ -90,12 +87,16 @@ struct FusionInfo {
     if (hasPlan)
       return true;
 
+    IVLOG(1, "considerPlan>");
+    IVLOG(1, "  A: " << debugString(*opA));
+    IVLOG(1, "  B: " << debugString(*opB));
+
     // Extract the per-dimension strides for the two ops
-    llvm::SmallVector<StrideInfo, 4> stridesA;
-    llvm::SmallVector<StrideInfo, 4> stridesB;
-    if (!getStrides(stridesA, opA, apA))
+    SmallVector<StrideInfo, 4> stridesA;
+    if (!getStrides(stridesA, opA, aInfo.op))
       return false;
-    if (!getStrides(stridesB, opB, apB))
+    SmallVector<StrideInfo, 4> stridesB;
+    if (!getStrides(stridesB, opB, bInfo.op))
       return false;
 
     assert(stridesA.size() == stridesB.size() &&
@@ -114,6 +115,8 @@ struct FusionInfo {
       if (sa.strides.size() == 0 && sb.strides.size() == 0)
         continue;
       // If there are multiple indexes, give up
+      IVLOG(1, "sa: " << debugString(sa));
+      IVLOG(1, "sb: " << debugString(sb));
       if (sa.strides.size() != 1 || sb.strides.size() != 1) {
         opB.emitRemark("Failed to fuse with def due to multiple indexes, i = ")
             << i;
@@ -123,10 +126,10 @@ struct FusionInfo {
       // Extract the details we care about
       BlockArgument argA = sa.strides.begin()->first;
       int64_t mulA = sa.strides.begin()->second;
-      int64_t sizeA = sizesA[argA.getArgNumber()];
+      int64_t sizeA = aInfo.sizes[argA.getArgNumber()];
       BlockArgument argB = sb.strides.begin()->first;
       int64_t mulB = sb.strides.begin()->second;
-      int64_t sizeB = sizesB[argB.getArgNumber()];
+      int64_t sizeB = bInfo.sizes[argB.getArgNumber()];
 
       // Fail if the total range of the two arguments doesn't match
       if (mulA * sizeA != mulB * sizeB) {
@@ -145,16 +148,16 @@ struct FusionInfo {
 
       // Also fail if the AP's don't have the same lower bound
       AffineValueMap lowerA(
-          apA.lowerBoundsMap().getSubMap({argA.getArgNumber()}),
-          apA.getLowerBoundsOperands());
+          aInfo.op.lowerBoundsMap().getSubMap({argA.getArgNumber()}),
+          aInfo.op.getLowerBoundsOperands());
       AffineValueMap lowerB(
-          apB.lowerBoundsMap().getSubMap({argB.getArgNumber()}),
-          apB.getLowerBoundsOperands());
+          bInfo.op.lowerBoundsMap().getSubMap({argB.getArgNumber()}),
+          bInfo.op.getLowerBoundsOperands());
       AffineValueMap diff;
       AffineValueMap::difference(lowerA, lowerB, &diff);
       if (!diff.getAffineMap().isSingleConstant() ||
           diff.getAffineMap().getSingleConstantResult() != 0) {
-        apB.emitRemark("Lower bounds mismatch");
+        bInfo.op.emitRemark("Lower bounds mismatch");
         return false;
       }
 
@@ -165,14 +168,14 @@ struct FusionInfo {
                                        << ") = " << aToB.count(argA));
         IVLOG(1, "Failed, bToA.count(" << argB.getArgNumber()
                                        << ") = " << bToA.count(argB));
-        apB.emitRemark("Mapping is not 1 to 1");
+        bInfo.op.emitRemark("Mapping is not 1 to 1");
         return false;
       }
       aToB[argA] = argB;
       bToA[argB] = argA;
     }
     if (aToB.size() == 0) {
-      apB.emitRemark("No index matches");
+      bInfo.op.emitRemark("No index matches");
       return false;
     }
     hasPlan = true;
@@ -181,42 +184,42 @@ struct FusionInfo {
 
   bool computeFusion() {
     // Get initial information setup
-    auto rangesA = apA.getConstantRanges();
+    auto rangesA = aInfo.op.getConstantRanges();
     if (!rangesA) {
-      apA.emitRemark("Op does not have constant ranges");
+      aInfo.op.emitRemark("Op does not have constant ranges");
       return false;
     }
-    std::swap(sizesA, *rangesA);
-    auto rangesB = apB.getConstantRanges();
+    std::swap(aInfo.sizes, *rangesA);
+    auto rangesB = bInfo.op.getConstantRanges();
     if (!rangesB) {
-      apB.emitRemark("Op does not have constant ranges");
+      bInfo.op.emitRemark("Op does not have constant ranges");
       return false;
     }
-    std::swap(sizesB, *rangesB);
+    std::swap(bInfo.sizes, *rangesB);
     // First, we find all the write/read and write/write pairs, where block A
     // writes to a value that block B reads from or writes into.
     IVLOG(1, "Collectiong read/write information");
     // For each output from loop
-    for (auto res : apA.results()) {
+    for (auto res : aInfo.op.results()) {
       // Find the source write
       auto write = findSourceWrite(res);
       // If it's not a proper affine reduce, give up
       if (!write) {
-        apA.emitRemark("Not all results can be traced to writes");
+        aInfo.op.emitRemark("Not all results can be traced to writes");
         return false;
       }
       // For each use of the write:
       for (auto user : res.getUsers()) {
         // Check if it is inside B, if not, we don't care, check next use.
-        if (!apB.getOperation()->isAncestor(user))
+        if (!bInfo.op.getOperation()->isAncestor(user))
           continue;
         // Now we make sure it's a read or a write, if not, we can't do fusion,
         // bail.
-        if (auto read = mlir::dyn_cast<AffineLoadOp>(user)) {
+        if (auto read = dyn_cast<AffineLoadOp>(user)) {
           if (!considerPlan(write, read))
             return false;
           readAfterWrites.emplace_back(write, read);
-        } else if (auto write2 = mlir::dyn_cast<AffineReduceOp>(user)) {
+        } else if (auto write2 = dyn_cast<AffineReduceOp>(user)) {
           if (!considerPlan(write, write2))
             return false;
           writeAfterWrites.emplace_back(write, write2);
@@ -230,67 +233,75 @@ struct FusionInfo {
   }
 
   AffineParallelOp applyFusion() {
-    OpBuilder builder(apB);
+    OpBuilder builder(bInfo.op);
     // The output types of the combined op is the union of the two inputs
-    llvm::SmallVector<mlir::Type, 6> typesC;
+    SmallVector<Type, 6> typesC;
 
     // First we need to find which results op A are used outside of B.  Those
     // results must also be outputs of the merged block.
-    for (auto res : apA.getResults()) {
+    for (auto res : aInfo.op.getResults()) {
       bool keep = false;
       for (auto &use : res.getUses()) {
-        if (!apB.getOperation()->isAncestor(use.getOwner()))
+        if (!bInfo.op.getOperation()->isAncestor(use.getOwner()))
           keep = true;
       }
       if (keep)
         typesC.push_back(res.getType());
     }
     // All outputs of B are to be kept
-    typesC.insert(typesC.end(), apB.getResultTypes().begin(),
-                  apB.getResultTypes().end());
+    typesC.insert(typesC.end(), bInfo.op.getResultTypes().begin(),
+                  bInfo.op.getResultTypes().end());
 
-    // Use apA's lower + upper bounds (they must be equivelant to apB's due to
-    // prior checks).  We output the new indexes in map order
-    llvm::SmallVector<AffineExpr, 4> lowerExprsC;
-    llvm::SmallVector<AffineExpr, 4> upperExprsC;
-    llvm::SmallVector<int64_t, 4> stepsC;
-    llvm::DenseMap<BlockArgument, size_t> aToNew;
+    // Use A's lower + upper bounds (they must be equivelant to B's due to
+    // prior checks).  We output the new indexes in block argument number order.
+    SmallVector<std::pair<BlockArgument, BlockArgument>, 4> orderedIVs;
     for (auto &pair : aToB) {
+      orderedIVs.push_back(pair);
+    }
+    std::sort(orderedIVs.begin(), orderedIVs.end(),
+              [](const auto &a, const auto &b) {
+                return a.first.getArgNumber() < b.first.getArgNumber();
+              });
+    SmallVector<AffineExpr, 4> lowerExprsC;
+    SmallVector<AffineExpr, 4> upperExprsC;
+    SmallVector<int64_t, 4> stepsC;
+    DenseMap<BlockArgument, size_t> aToNew;
+    for (auto &pair : orderedIVs) {
       aToNew[pair.first] = aToNew.size();
       auto idx = pair.first.getArgNumber();
-      lowerExprsC.push_back(apA.lowerBoundsMap().getResult(idx));
-      upperExprsC.push_back(apA.upperBoundsMap().getResult(idx));
-      stepsC.push_back(apA.steps()[idx].cast<IntegerAttr>().getInt());
+      lowerExprsC.push_back(aInfo.op.lowerBoundsMap().getResult(idx));
+      upperExprsC.push_back(aInfo.op.upperBoundsMap().getResult(idx));
+      stepsC.push_back(aInfo.op.steps()[idx].cast<IntegerAttr>().getInt());
     }
     // Compute B mappings to new
-    llvm::DenseMap<BlockArgument, size_t> bToNew;
+    DenseMap<BlockArgument, size_t> bToNew;
     for (auto &pair : bToA) {
       bToNew[pair.first] = aToNew.lookup(pair.second);
     }
 
     // Construct the new outer parallel op
-    auto lowerC = AffineMap::get(apA.lowerBoundsMap().getNumDims(), 0,
-                                 lowerExprsC, apA.getContext());
-    auto upperC = AffineMap::get(apA.upperBoundsMap().getNumDims(), 0,
-                                 upperExprsC, apA.getContext());
+    auto lowerC = AffineMap::get(aInfo.op.lowerBoundsMap().getNumDims(), 0,
+                                 lowerExprsC, aInfo.op.getContext());
+    auto upperC = AffineMap::get(aInfo.op.upperBoundsMap().getNumDims(), 0,
+                                 upperExprsC, aInfo.op.getContext());
     auto apC = builder.create<AffineParallelOp>(
-        apA.getLoc(), typesC, lowerC, apA.getLowerBoundsOperands(), upperC,
-        apA.getUpperBoundsOperands(), stepsC);
+        aInfo.op.getLoc(), typesC, lowerC, aInfo.op.getLowerBoundsOperands(),
+        upperC, aInfo.op.getUpperBoundsOperands(), stepsC);
 
     // Move the two parallel for's inside the new op
-    apA.getOperation()->moveBefore(apC.getBody(), apC.getBody()->end());
-    apB.getOperation()->moveBefore(apC.getBody(), apC.getBody()->end());
+    aInfo.op.getOperation()->moveBefore(apC.getBody(), apC.getBody()->end());
+    bInfo.op.getOperation()->moveBefore(apC.getBody(), apC.getBody()->end());
     // Fixup uses of A's  return values.  These uses are either in B (and thus
     // local to C now) or some other op (and thus need to be moved to a return
     // of C).  Basically, for each return, we go over all uses, and adjust to
     // the appropriate new value.  As we go, we add things that escape the the
     // yield output.
-    llvm::SmallVector<Value, 6> returnVals;
-    for (auto res : apA.getResults()) {
+    SmallVector<Value, 6> returnVals;
+    for (auto res : aInfo.op.getResults()) {
       bool keep = false;
-      for (mlir::OpOperand &use : llvm::make_early_inc_range(res.getUses())) {
+      for (OpOperand &use : make_early_inc_range(res.getUses())) {
         // If it's not inside B, swith the use external return value
-        if (!apB.getOperation()->isAncestor(use.getOwner())) {
+        if (!bInfo.op.getOperation()->isAncestor(use.getOwner())) {
           keep = true;
           use.set(apC.getResult(returnVals.size()));
         }
@@ -300,21 +311,21 @@ struct FusionInfo {
         returnVals.push_back(res);
     }
     // Replace all uses of B's outputs with C's outputs
-    for (auto res : apB.getResults()) {
+    for (auto res : bInfo.op.getResults()) {
       res.replaceAllUsesWith(apC.getResult(returnVals.size()));
       returnVals.push_back(res);
     }
     // Next we make a new return op for the values that escape this block
-    builder.setInsertionPointAfter(apB);
-    builder.create<AffineYieldOp>(apB.getLoc(), returnVals);
+    builder.setInsertionPointAfter(bInfo.op);
+    builder.create<AffineYieldOp>(bInfo.op.getLoc(), returnVals);
 
     // Now, we need to update the actual loop bounds for everything
     auto fixupLoops = [&](auto apOp, const auto &toNew) {
       auto origNumArgs = apOp.getBody()->getArguments().size();
       size_t curArgNum = 0;
-      llvm::SmallVector<AffineExpr, 6> newLowerBounds;
-      llvm::SmallVector<AffineExpr, 6> newUpperBounds;
-      llvm::SmallVector<int64_t, 6> newSteps;
+      SmallVector<AffineExpr, 6> newLowerBounds;
+      SmallVector<AffineExpr, 6> newUpperBounds;
+      SmallVector<int64_t, 6> newSteps;
       for (size_t i = 0; i < origNumArgs; i++) {
         auto curArg = apOp.getBody()->getArgument(curArgNum);
         auto it = toNew.find(curArg);
@@ -340,8 +351,8 @@ struct FusionInfo {
       apOp.setAttr(AffineParallelOp::getStepsAttrName(),
                    builder.getI64ArrayAttr(newSteps));
     };
-    fixupLoops(apA, aToNew);
-    fixupLoops(apB, bToNew);
+    fixupLoops(aInfo.op, aToNew);
+    fixupLoops(bInfo.op, bToNew);
 
     return apC;
   }
@@ -367,47 +378,45 @@ struct FusionPass : public FusionBase<FusionPass> {
     // blocks to consider?
     auto &block = func.getBody().front();
     // First we 'number' every op
-    llvm::DenseMap<Operation *, size_t> pos;
-    for (auto opIt = block.begin(); opIt != block.end(); ++opIt) {
-      pos[&*opIt] = pos.size();
+    DenseMap<Operation *, size_t> opOrder;
+    for (auto &op : block) {
+      opOrder[&op] = opOrder.size();
     }
 
-    for (auto opIt = block.begin(); opIt != block.end();) {
-      // See if the top op is an affine parallel
-      auto fuseA = mlir::dyn_cast<AffineParallelOp>(*opIt);
+    for (auto itOp = block.begin(); itOp != block.end();) {
+      auto fuseA = dyn_cast<AffineParallelOp>(*itOp);
       // Kick the iterator forward right away so if we end up fusing the op
       // down into a successor, we don't cause issues
-      ++opIt;
-      // If it's not a AF, continue
+      ++itOp;
+      // Only consider affine.parallel ops
       if (!fuseA)
         continue;
       // Find the 'nearest reader' block:  Walk over each output, find any
-      // blocks that ther output. pick the block closest to the writer.  This
+      // blocks that they output. pick the block closest to the writer.  This
       // block is legal to fuse into, since there are no intermediating
       // dependencies.
       Operation *nearestReader = nullptr;
       for (auto res : fuseA.results()) {
         for (auto user : res.getUsers()) {
           Operation *op = block.findAncestorOpInBlock(*user);
-          if (nearestReader == nullptr || pos[op] < pos[nearestReader]) {
+          if (!nearestReader || opOrder[op] < opOrder[nearestReader]) {
             nearestReader = op;
           }
         }
       }
       // Check if the closest reader is also and affine parallel, in which case,
       // attempt to merge
-      if (auto fuseB =
-              mlir::dyn_cast_or_null<AffineParallelOp>(nearestReader)) {
-        bool merge_immediate = (&*opIt == nearestReader);
-        // Put the new op at the position of B
-        size_t newPos = pos[fuseB.getOperation()];
+      if (auto fuseB = dyn_cast_or_null<AffineParallelOp>(nearestReader)) {
+        bool merge_immediate = (&*itOp == nearestReader);
+        // Put the new op at the opOrderition of B
+        size_t newOpOrder = opOrder[fuseB.getOperation()];
         // Attempt the actual fusion
         AffineParallelOp newOp = attemptFusion(fuseA, fuseB);
         // If it worked, update positions
         if (newOp) {
-          pos[newOp.getOperation()] = newPos;
+          opOrder[newOp.getOperation()] = newOpOrder;
           if (merge_immediate) {
-            opIt = Block::iterator(newOp.getOperation());
+            itOp = Block::iterator(newOp.getOperation());
           }
         }
       }
@@ -417,7 +426,7 @@ struct FusionPass : public FusionBase<FusionPass> {
 
 } // namespace
 
-std::unique_ptr<mlir::Pass> createFusionPass() {
+std::unique_ptr<Pass> createFusionPass() {
   return std::make_unique<FusionPass>();
 }
 

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -3,17 +3,17 @@
 
 include "mlir/Pass/PassBase.td"
 
-def AutoTileExample : FunctionPass<"autotile-10"> {
+def AutoTileExample : FunctionPass<"pxa-autotile-example"> {
   let summary = "Tile all dimensions by 10";
   let constructor = "pmlc::dialect::pxa::createAutoTileExamplePass()";
 }
 
-def Fusion : FunctionPass<"fusion"> {
+def Fusion : FunctionPass<"pxa-fusion"> {
   let summary = "Fuse blocks that are compatible";
   let constructor = "pmlc::dialect::pxa::createFusionPass()";
 }
 
-def TestStrideInfo : Pass<"test-stride-info"> {
+def TestStrideInfo : Pass<"pxa-stride-info"> {
   let summary = "Report stride data for all loads/stores for unit tests";
   let constructor = "pmlc::dialect::pxa::createTestStrideInfoPass()";
 }

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -157,7 +157,7 @@ void addToPipeline(OpPassManager &pm) {
     pm.addPass(pmlc::dialect::stdx::createBoundsCheckPass());
   }
 
-  pm.addPass(createTanhLowerPass());
+  pm.addPass(createTanhLoweringPass());
 
   pm.addPass(ConvertToLLVMPass::create());
   pm.addPass(createTraceLinkingPass());


### PR DESCRIPTION
* Enforce stable order for fused IVs (to make tests deterministic)
* Prefix PXA transforms with `pxa-` for `pmlc-opt`
* Bump to latest plaidml/llvm-project