### PR TITLE
Add Unsqueeze to OpenVINO plugin

### DIFF
--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/unsqueeze.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/unsqueeze.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset1.hpp"
+
+#include "plaidml/op/op.h"
+#include "pmlc/util/logging.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("unsqueeze", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 2);
+  auto I = ctx.operands.at(0);
+  auto axes = get_axes_from_constant_operand(1, ctx.layer);
+  std::vector<edsl::TensorDim> I_dims(I.rank());
+  size_t new_rank = I.rank() + axes.size();
+  I.bind_dims(I_dims);
+  std::vector<edsl::TensorDim> O_dims;
+  size_t src_loc = 0;
+  for (size_t dst_loc = 0; dst_loc < new_rank; dst_loc++) {
+    if (axes.count(dst_loc)) {
+      O_dims.push_back(edsl::TensorDim(1));
+    } else {
+      O_dims.push_back(I_dims[src_loc]);
+      src_loc++;
+    }
+  }
+  IE_ASSERT(src_loc == I.rank());  // Need to have used exactly all the input dims
+  return edsl::make_tuple(op::reshape(I, edsl::make_tuple(O_dims)));
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_util.cpp
@@ -4,12 +4,24 @@
 
 #include "plaidml_util.hpp"
 
+#include "ngraph/op/constant.hpp"
+
 #include "plaidml/edsl/edsl.h"
 
 using plaidml::edsl::LogicalShape;
 using namespace InferenceEngine;  // NOLINT[build/namespaces]
 
 namespace PlaidMLPlugin {
+
+ngraph::AxisSet get_axes_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
+  auto axis_ngraph_op =
+      std::dynamic_pointer_cast<ngraph::op::Constant>(layer->input_value(operand_idx).get_node_shared_ptr());
+  if (axis_ngraph_op) {
+    return axis_ngraph_op->get_axis_set_val();
+  } else {
+    THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
+  }
+}
 
 plaidml::DType to_plaidml(const ngraph::element::Type& ng_type) {
   switch (ng_type) {

--- a/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_util.hpp
@@ -9,6 +9,8 @@
 #include "ie_layouts.h"  // NOLINT[build/include_subdir]
 #include "ie_precision.hpp"
 
+#include "ngraph/axis_set.hpp"
+#include "ngraph/node.hpp"
 #include "ngraph/op/util/attr_types.hpp"
 #include "ngraph/type/element_type.hpp"
 
@@ -17,6 +19,7 @@
 
 namespace PlaidMLPlugin {
 
+ngraph::AxisSet get_axes_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
 plaidml::DType to_plaidml(const ngraph::element::Type& ng_type);
 
 plaidml::op::AutoPadMode to_plaidml(const ngraph::op::PadType& ng_type);

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 cc_test(
     name = "single_layer_tests",
     srcs = glob(
-        ["*.cpp"],
+        ["unsqueeze.cpp"],
         exclude = [
             "convolution_backprop_data.cpp",
             "cum_sum.cpp",

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 cc_test(
     name = "single_layer_tests",
     srcs = glob(
-        ["unsqueeze.cpp"],
+        ["*.cpp"],
         exclude = [
             "convolution_backprop_data.cpp",
             "cum_sum.cpp",

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/unsqueeze.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/unsqueeze.cpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/unsqueeze.hpp"
+
+using LayerTestsDefinitions::UnsqueezeLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::FP16   // TODO: Not working yet
+};
+
+INSTANTIATE_TEST_CASE_P(UnsqueezeCheck, UnsqueezeLayerTest,
+                        ::testing::Combine(::testing::Values(std::vector<int64_t>({0}),
+                                                             std::vector<int64_t>({0, 2})),      //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(std::vector<size_t>({3, 4})),       //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        UnsqueezeLayerTest::getTestCaseName);
+}  // namespace

--- a/vendor/openvino/workspace.bzl
+++ b/vendor/openvino/workspace.bzl
@@ -25,8 +25,8 @@ def openvino_workspace():
 
     http_archive(
         name = "openvino",
-        sha256 = "f1c838f387e8beb8a97be24fd51840ef07b9796d43aef0804501477be8a21062",
-        strip_prefix = "openvino-2e784ff4aa5a9b9242435179a528627aa61661d6",
-        url = "https://github.com/PlaidML/openvino/archive/2e784ff4aa5a9b9242435179a528627aa61661d6.zip",
+        # sha256 = "f1c838f387e8beb8a97be24fd51840ef07b9796d43aef0804501477be8a21062",
+        strip_prefix = "openvino-339d2efc962516a6699d72b909ead9fe04384344",
+        url = "https://github.com/PlaidML/openvino/archive/339d2efc962516a6699d72b909ead9fe04384344.zip",
         build_file = clean_dep("//vendor/openvino:openvino.BUILD"),
     )

--- a/vendor/openvino/workspace.bzl
+++ b/vendor/openvino/workspace.bzl
@@ -25,8 +25,8 @@ def openvino_workspace():
 
     http_archive(
         name = "openvino",
-        # sha256 = "f1c838f387e8beb8a97be24fd51840ef07b9796d43aef0804501477be8a21062",
-        strip_prefix = "openvino-339d2efc962516a6699d72b909ead9fe04384344",
-        url = "https://github.com/PlaidML/openvino/archive/339d2efc962516a6699d72b909ead9fe04384344.zip",
+        sha256 = "d063141832cca74c9bd9baae21aca86b9d48a4980ecebcbfaf62bedac998385a",
+        strip_prefix = "openvino-f03ef795f3064834a688b41125ae5d31c93df903",
+        url = "https://github.com/PlaidML/openvino/archive/f03ef795f3064834a688b41125ae5d31c93df903.zip",
         build_file = clean_dep("//vendor/openvino:openvino.BUILD"),
     )


### PR DESCRIPTION
Includes the axes-reading code previously in #1105.

This depends on the new unsqueeze test in https://github.com/plaidml/openvino/pull/4 and so is a draft until that lands.