### PR TITLE
Add broadcast to op lib

### DIFF
--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -703,12 +703,11 @@ TEST_F(CppEdsl, BroadcastNonOpLib) {
   I.bind_dims(B, N1, N2);
   auto O = TensorOutput(B, 7, N1, N2);
   O(b, j, i1, i2) = I(b, i1, i2);
-  // O.use_default(P);
   auto program = makeProgram("broadcast", {O});
   // clang-format off
-  // CHECK-LABEL: CppEdsl.UseDefault
+  // CHECK-LABEL: CppEdsl.BroadcastNonOpLib
   // CHECK: func @broadcast
-  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<1x7x10x10xf32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
+  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #{{.*}}, srcs = [#{{.*}}]} : tensor<f32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
   // CHECK: return %{{.*}} : tensor<1x7x10x10xf32>
   // clang-format on
   runProgram(program);

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -695,24 +695,6 @@ TEST_F(CppEdsl, UseDefault) {
   runProgram(program);
 }
 
-TEST_F(CppEdsl, BroadcastNonOpLib) {
-  auto P = Placeholder(DType::FLOAT32, {1, 7, 10, 10});
-  auto I = Placeholder(DType::FLOAT32, {1, 10, 10});
-  TensorDim B, N1, N2;
-  TensorIndex b, i1, i2, j;
-  I.bind_dims(B, N1, N2);
-  auto O = TensorOutput(B, 7, N1, N2);
-  O(b, j, i1, i2) = I(b, i1, i2);
-  auto program = makeProgram("broadcast", {O});
-  // clang-format off
-  // CHECK-LABEL: CppEdsl.BroadcastNonOpLib
-  // CHECK: func @broadcast
-  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #{{.*}}, srcs = [#{{.*}}]} : tensor<f32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
-  // CHECK: return %{{.*}} : tensor<1x7x10x10xf32>
-  // clang-format on
-  runProgram(program);
-}
-
 Tensor ArgMax(const Tensor& I) {
   TensorDim X0, X1, X2;
   TensorIndex x0, x1, x2;

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -695,6 +695,25 @@ TEST_F(CppEdsl, UseDefault) {
   runProgram(program);
 }
 
+TEST_F(CppEdsl, BroadcastNonOpLib) {
+  auto P = Placeholder(DType::FLOAT32, {1, 7, 10, 10});
+  auto I = Placeholder(DType::FLOAT32, {1, 10, 10});
+  TensorDim B, N1, N2;
+  TensorIndex b, i1, i2, j;
+  I.bind_dims(B, N1, N2);
+  auto O = TensorOutput(B, 7, N1, N2);
+  O(b, j, i1, i2) = I(b, i1, i2);
+  // O.use_default(P);
+  auto program = makeProgram("broadcast", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.UseDefault
+  // CHECK: func @broadcast
+  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<1x7x10x10xf32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
+  // CHECK: return %{{.*}} : tensor<1x7x10x10xf32>
+  // clang-format on
+  runProgram(program);
+}
+
 Tensor ArgMax(const Tensor& I) {
   TensorDim X0, X1, X2;
   TensorIndex x0, x1, x2;

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -488,11 +488,12 @@ Value broadcast(const Value& value) {
   // Define broadcast indices
   for (int i = 0; i < target_shape.size(); i++) {
     O_dims.emplace_back(TensorDim{target_shape[i]});
-    auto tidx = TensorIndex(llvm::formatv("x{0}", i));
+    auto tidx = TensorIndex();
+    // auto tidx = TensorIndex(llvm::formatv("x{0}", i));
     if (std::find(broadcast_axes.begin(), broadcast_axes.end(), i) != broadcast_axes.end()) {
       I_idxs.emplace_back(tidx);
     }
-    O_idxs.emplace_back(TensorIndex(tidx));
+    O_idxs.emplace_back(tidx);
   }
   auto O = TensorOutput(O_dims);
   O(O_idxs) = I(I_idxs);

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -487,7 +487,7 @@ Value broadcast(const Value& value) {
   std::vector<TensorIndex> O_idxs;
 
   // Define broadcast indices
-  for (int i = 0; i < target_shape.size(); i++) {
+  for (size_t i = 0; i < target_shape.size(); i++) {
     O_dims.emplace_back(TensorDim{target_shape[i]});
     auto tidx = TensorIndex(llvm::formatv("x{0}", i));
     if (input_shape[i] == 1) {

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -488,8 +488,7 @@ Value broadcast(const Value& value) {
   // Define broadcast indices
   for (int i = 0; i < target_shape.size(); i++) {
     O_dims.emplace_back(TensorDim{target_shape[i]});
-    auto tidx = TensorIndex();
-    // auto tidx = TensorIndex(llvm::formatv("x{0}", i));
+    auto tidx = TensorIndex(llvm::formatv("x{0}", i));
     if (std::find(broadcast_axes.begin(), broadcast_axes.end(), i) != broadcast_axes.end()) {
       I_idxs.emplace_back(tidx);
     }

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -475,6 +475,7 @@ Value broadcast(const Value& value) {
   }
 
   auto I = args[0].as_tensor();
+  auto input_shape = I.compute_shape().sizes();
   auto target_shape = args[1].as_int_tuple();
   auto broadcast_axes = args[2].as_int_tuple();
 
@@ -489,7 +490,9 @@ Value broadcast(const Value& value) {
   for (int i = 0; i < target_shape.size(); i++) {
     O_dims.emplace_back(TensorDim{target_shape[i]});
     auto tidx = TensorIndex(llvm::formatv("x{0}", i));
-    if (std::find(broadcast_axes.begin(), broadcast_axes.end(), i) != broadcast_axes.end()) {
+    if (input_shape[i] == 1) {
+      I_idxs.emplace_back(TensorIndex(0));
+    } else if (std::find(broadcast_axes.begin(), broadcast_axes.end(), i) != broadcast_axes.end()) {
       I_idxs.emplace_back(tidx);
     }
     O_idxs.emplace_back(tidx);

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -128,6 +128,12 @@ inline edsl::Tensor binary_crossentropy(const edsl::Tensor& I, const edsl::Tenso
   return details::op("binary_crossentropy", args).as_tensor();
 }
 
+inline edsl::Tensor broadcast(const edsl::Tensor& I, const std::vector<int>& result_shape,
+                              const std::vector<int>& bcast_axes) {
+  auto args = edsl::make_tuple(I, edsl::make_tuple(result_shape), edsl::make_tuple(bcast_axes));
+  return details::op("broadcast", args).as_tensor();
+}
+
 inline edsl::Tensor clip(const edsl::Tensor& I, const edsl::Tensor& min, const edsl::Tensor& max) {
   auto args = edsl::make_tuple(I, min, max);
   return details::op("clip", args).as_tensor();

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -29,7 +29,6 @@ namespace {
 class OpTest : public TestFixture {};
 
 Program makeProgram(const std::string& name, const std::vector<Tensor>& outputs) {
-  // TODO: remove empty target once all of these are passing.
   return ProgramBuilder(name, outputs).compile();
 }
 
@@ -169,26 +168,56 @@ TEST_F(OpTest, BroadcastNoOp) {
 }
 
 TEST_F(OpTest, BroadcastNumpy) {
-  auto A = Placeholder(DType::FLOAT32, {1, 10, 10});
-  std::vector<int> rshape = {1, 7, 10, 10};
+  auto A = Placeholder(DType::FLOAT32, {1, 3, 3});
+  std::vector<int> rshape = {1, 4, 3, 3};
   std::vector<int> bdims = {0, 2, 3};
   auto C = broadcast(A, rshape, bdims);
   auto program = makeProgram("broadcast_numpy", {C});
-  runProgram(program);
+
+  std::vector<float> A_input = {0, 1, 2,  //
+                                0, 1, 2,  //
+                                0, 1, 2};
+  std::vector<float> C_output = {0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2};
+}
+
+TEST_F(OpTest, BroadcastNumpy2) {
+  auto A = Placeholder(DType::FLOAT32, {3, 1});
+  std::vector<int> rshape = {3, 4};
+  std::vector<int> bdims = {0, 1};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_numpy_2", {C});
+
+  std::vector<float> A_input = {0, 1, 2};
+  std::vector<float> C_output = {0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2};
+  checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 
 TEST_F(OpTest, BroadcastNonNumpy) {
-  auto A = Placeholder(DType::UINT64, {3});
+  auto A = Placeholder(DType::FLOAT32, {3});
   std::vector<int> rshape = {3, 4};
   std::vector<int> bdims = {0};
   auto C = broadcast(A, rshape, bdims);
   auto program = makeProgram("broadcast_non_numpy", {C});
 
-  std::vector<uint64_t> A_input = {0, 1, 2};
-  std::vector<uint64_t> C_output = {0, 1, 2,  //
-                                    0, 1, 2,  //
-                                    0, 1, 2,  //
-                                    0, 1, 2};
+  std::vector<float> A_input = {0, 1, 2};
+  std::vector<float> C_output = {0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -167,6 +167,20 @@ TEST_F(OpTest, BroadcastNoOp) {
   checkProgram(program, {{A, A_input}}, {{C, A_input}});
 }
 
+TEST_F(OpTest, BroadcastNoOpLarge) {
+  auto A = Placeholder(DType::FLOAT32, {3, 4});
+  std::vector<int> rshape = {3, 4};
+  std::vector<int> bdims = {0, 1};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_nop_large", {C});
+
+  std::vector<float> A_input = {0, 1, 2,  //
+                                0, 1, 2,  //
+                                0, 1, 2,  //
+                                0, 1, 2};
+  checkProgram(program, {{A, A_input}}, {{C, A_input}});
+}
+
 TEST_F(OpTest, BroadcastNumpy) {
   auto A = Placeholder(DType::FLOAT32, {1, 3, 3});
   std::vector<int> rshape = {1, 4, 3, 3};
@@ -203,6 +217,34 @@ TEST_F(OpTest, BroadcastNumpy2) {
                                  0, 1, 2,  //
                                  0, 1, 2,  //
                                  0, 1, 2};
+  checkProgram(program, {{A, A_input}}, {{C, C_output}});
+}
+
+TEST_F(OpTest, BroadcastNumpy3) {
+  auto A = Placeholder(DType::FLOAT32, {3});
+  std::vector<int> rshape = {4, 3};
+  std::vector<int> bdims = {1};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_numpy_3", {C});
+
+  std::vector<float> A_input = {0, 1, 2};
+  std::vector<float> C_output = {0, 0, 0, 0,  //
+                                 1, 1, 1, 1,  //
+                                 2, 2, 2, 2};
+  checkProgram(program, {{A, A_input}}, {{C, C_output}});
+}
+
+TEST_F(OpTest, BroadcastNumpy3WeirdParam) {
+  auto A = Placeholder(DType::FLOAT32, {3});
+  std::vector<int> rshape = {4, 3};
+  std::vector<int> bdims = {0};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_numpy_3", {C});
+
+  std::vector<float> A_input = {0, 1, 2};
+  std::vector<float> C_output = {0, 0, 0, 0,  //
+                                 1, 1, 1, 1,  //
+                                 2, 2, 2, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -226,7 +226,10 @@ TEST_F(OpTest, BroadcastNumpy3) {
   auto program = makeProgram("broadcast_numpy_3", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2};
+  std::vector<float> C_output = {0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2,  //
+                                 0, 1, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 
@@ -238,7 +241,9 @@ TEST_F(OpTest, BroadcastNonNumpy) {
   auto program = makeProgram("broadcast_non_numpy", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2};
+  std::vector<float> C_output = {0, 0, 0, 0,  //
+                                 1, 1, 1, 1,  //
+                                 2, 2, 2, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -157,6 +157,41 @@ module {
 )#"));
 }
 
+TEST_F(OpTest, BroadcastNoOp) {
+  auto A = Placeholder(DType::FLOAT32, {3});
+  std::vector<int> rshape = {3};
+  std::vector<int> bdims = {0};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_nop", {C});
+
+  std::vector<std::uint64_t> A_input = {0, 1, 2};
+  checkProgram(program, {{A, A_input}}, {{C, A_input}});
+}
+
+TEST_F(OpTest, BroadcastNumpy) {
+  auto A = Placeholder(DType::FLOAT32, {1, 10, 10});
+  std::vector<int> rshape = {1, 7, 10, 10};
+  std::vector<int> bdims = {0, 2, 3};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_numpy", {C});
+  runProgram(program);
+}
+
+TEST_F(OpTest, BroadcastNonNumpy) {
+  auto A = Placeholder(DType::UINT64, {3});
+  std::vector<int> rshape = {3, 4};
+  std::vector<int> bdims = {0};
+  auto C = broadcast(A, rshape, bdims);
+  auto program = makeProgram("broadcast_non_numpy", {C});
+
+  std::vector<std::uint64_t> A_input = {0, 1, 2};
+  std::vector<std::uint64_t> C_output = {0, 1, 2,  //
+                                         0, 1, 2,  //
+                                         0, 1, 2,  //
+                                         0, 1, 2};
+  checkProgram(program, {{A, A_input}}, {{C, C_output}});
+}
+
 TEST(Op, Broadcast) {
   auto I = Placeholder(DType::FLOAT32, {1, 224, 224}, "I");
   std::vector<int> result_shape = {1, 224, 224, 3};

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -30,7 +30,7 @@ class OpTest : public TestFixture {};
 
 Program makeProgram(const std::string& name, const std::vector<Tensor>& outputs) {
   // TODO: remove empty target once all of these are passing.
-  return ProgramBuilder(name, outputs).target("").compile();
+  return ProgramBuilder(name, outputs).compile();
 }
 
 TEST(Op, Abs) {
@@ -164,7 +164,7 @@ TEST_F(OpTest, BroadcastNoOp) {
   auto C = broadcast(A, rshape, bdims);
   auto program = makeProgram("broadcast_nop", {C});
 
-  std::vector<std::uint64_t> A_input = {0, 1, 2};
+  std::vector<float> A_input = {0, 1, 2};
   checkProgram(program, {{A, A_input}}, {{C, A_input}});
 }
 
@@ -184,11 +184,11 @@ TEST_F(OpTest, BroadcastNonNumpy) {
   auto C = broadcast(A, rshape, bdims);
   auto program = makeProgram("broadcast_non_numpy", {C});
 
-  std::vector<std::uint64_t> A_input = {0, 1, 2};
-  std::vector<std::uint64_t> C_output = {0, 1, 2,  //
-                                         0, 1, 2,  //
-                                         0, 1, 2,  //
-                                         0, 1, 2};
+  std::vector<uint64_t> A_input = {0, 1, 2};
+  std::vector<uint64_t> C_output = {0, 1, 2,  //
+                                    0, 1, 2,  //
+                                    0, 1, 2,  //
+                                    0, 1, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -212,7 +212,9 @@ TEST_F(OpTest, BroadcastNumpy2) {
   auto program = makeProgram("broadcast_numpy_2", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2};
+  std::vector<float> C_output = {0, 0, 0, 0,  //
+                                 1, 1, 1, 1,  //
+                                 2, 2, 2, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -213,10 +213,7 @@ TEST_F(OpTest, BroadcastNumpy2) {
   auto program = makeProgram("broadcast_numpy_2", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 1, 2,  //
-                                 0, 1, 2,  //
-                                 0, 1, 2,  //
-                                 0, 1, 2};
+  std::vector<float> C_output = {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 
@@ -228,23 +225,7 @@ TEST_F(OpTest, BroadcastNumpy3) {
   auto program = makeProgram("broadcast_numpy_3", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 0, 0, 0,  //
-                                 1, 1, 1, 1,  //
-                                 2, 2, 2, 2};
-  checkProgram(program, {{A, A_input}}, {{C, C_output}});
-}
-
-TEST_F(OpTest, BroadcastNumpy3WeirdParam) {
-  auto A = Placeholder(DType::FLOAT32, {3});
-  std::vector<int> rshape = {4, 3};
-  std::vector<int> bdims = {0};
-  auto C = broadcast(A, rshape, bdims);
-  auto program = makeProgram("broadcast_numpy_3", {C});
-
-  std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 0, 0, 0,  //
-                                 1, 1, 1, 1,  //
-                                 2, 2, 2, 2};
+  std::vector<float> C_output = {0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 
@@ -256,10 +237,7 @@ TEST_F(OpTest, BroadcastNonNumpy) {
   auto program = makeProgram("broadcast_non_numpy", {C});
 
   std::vector<float> A_input = {0, 1, 2};
-  std::vector<float> C_output = {0, 1, 2,  //
-                                 0, 1, 2,  //
-                                 0, 1, 2,  //
-                                 0, 1, 2};
+  std::vector<float> C_output = {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2};
   checkProgram(program, {{A, A_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -174,10 +174,9 @@ TEST_F(OpTest, BroadcastNoOpLarge) {
   auto C = broadcast(A, rshape, bdims);
   auto program = makeProgram("broadcast_nop_large", {C});
 
-  std::vector<float> A_input = {0, 1, 2,  //
-                                0, 1, 2,  //
-                                0, 1, 2,  //
-                                0, 1, 2};
+  std::vector<float> A_input = {0, 1, 2, 3,  //
+                                0, 1, 2, 3,  //
+                                0, 1, 2, 3};
   checkProgram(program, {{A, A_input}}, {{C, A_input}});
 }
 

--- a/plaidml/testenv.h
+++ b/plaidml/testenv.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "plaidml/exec/exec.h"
+#include "pmlc/util/logging.h"
 
 namespace plaidml::edsl {
 
@@ -35,6 +36,8 @@ class TestFixture : public ::testing::Test {
     ASSERT_THAT(view.size(), expected.size() * sizeof(expected[0]));
     auto data = reinterpret_cast<T*>(view.data());
     std::vector<T> actual(data, data + expected.size());
+    IVLOG(3, "Expected: " << expected);
+    IVLOG(3, "Actual  : " << actual);
     for (size_t i = 0; i < actual.size(); i++) {
       compareElements(actual[i], expected[i]);
     }


### PR DESCRIPTION
I've been working with @tzerrell regarding some weirdness I've been seeing in my implementation of the `broadcast` op.

Essentially, I wrote a `broadcast` op, the tile code looks fine, but I run into the following errors when trying to test the code with `runProgram` or `checkProgram`.

```
error: 'func' op unsupported module-level operation
unknown file: Failure
C++ exception with description "could not convert to LLVM IR" thrown in the test body.
```

To try and debug, I created a test `CppEdsl.BroadcastNonOpLib` in `edsl_test.cc` that does a broadcast using _just_ EDSL code, and replicated the same code using the `broadcast` op in `op_test.cc`.

Program generated from EDSL code:
```
#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>


module {
  func @broadcast(%arg0: tensor<1x10x10xf32>) -> tensor<1x7x10x10xf32> {
    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
    %0 = tile.contract assign, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : tensor<f32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
    return %0 : tensor<1x7x10x10xf32>
  }
}
```

Program generated from the op lib:
```
#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>


module {
  func @broadcast_numpy(%arg0: tensor<1x10x10xf32>) -> tensor<1x7x10x10xf32> {
    %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
    %0 = tile.contract assign, none, %cst, %arg0 {sink = #map0, srcs = [#map1]} : tensor<f32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
    return %0 : tensor<1x7x10x10xf32>
  }
}
```

Why would basically the same tile code pass in one case and fail in the other case?