### PR TITLE
Add setMemRef for affine.reduce

### DIFF
--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -53,6 +53,8 @@ def AffineReduceOp : PXA_OpWithPP<"reduce", []> {
 
   let extraClassDeclaration = [{
     Value getMemRef() { return mem(); }
+    unsigned getMemRefOperandIndex() { return 2; }
+    void setMemRef(Value value) { setOperand(getMemRefOperandIndex(), value); }
     MemRefType getMemRefType() { return mem().getType().cast<MemRefType>(); }
     AffineMap getAffineMap() { return map(); }
     operand_range getMapOperands() { return idxs(); }


### PR DESCRIPTION
Both affine.load and affine.store have setMemRef. We need setMemRef for affine.reduce for some passes, too.