### PR TITLE
Fix for #1122

### DIFF
--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -29,8 +29,7 @@ namespace {
 class OpTest : public TestFixture {};
 
 Program makeProgram(const std::string& name, const std::vector<Tensor>& outputs) {
-  // TODO: remove empty target once all of these are passing.
-  return ProgramBuilder(name, outputs).target("").compile();
+  return ProgramBuilder(name, outputs).compile();
 }
 
 TEST(Op, Abs) {

--- a/pmlc/dialect/eltwise/ir/util.cc
+++ b/pmlc/dialect/eltwise/ir/util.cc
@@ -171,6 +171,16 @@ Type promoteTypes(Type lhs, Type rhs) {
   return typeScore(lhs) > typeScore(rhs) ? lhs : rhs;
 }
 
+Type inferElementType(ArrayRef<Type> types) {
+  Type ret;
+  for (auto type : types) {
+    auto rankedTensorType = getRankedTensorType(type);
+    auto dtype = rankedTensorType.getElementType();
+    ret = promoteTypes(ret, dtype);
+  }
+  return ret;
+}
+
 RankedTensorType getRankedTensorType(Type type) {
   if (auto rankedType = type.dyn_cast<RankedTensorType>()) {
     return rankedType;

--- a/pmlc/dialect/eltwise/ir/util.h
+++ b/pmlc/dialect/eltwise/ir/util.h
@@ -10,6 +10,7 @@
 namespace pmlc::dialect::eltwise {
 
 mlir::Type promoteTypes(mlir::Type lhs, mlir::Type rhs);
+mlir::Type inferElementType(mlir::ArrayRef<mlir::Type> types);
 
 llvm::SmallVector<int64_t, 4>
 ComputeShape(llvm::ArrayRef<mlir::Value> operands);

--- a/pmlc/dialect/tile/BUILD
+++ b/pmlc/dialect/tile/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2019 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "tile",

--- a/pmlc/dialect/tile/ir/ops.h
+++ b/pmlc/dialect/tile/ir/ops.h
@@ -74,4 +74,7 @@ namespace SideEffects = mlir::SideEffects;
 
 #include "pmlc/dialect/tile/ir/dialect.h.inc"
 
+Type inferElementType(MLIRContext *context, CombinationKind combo,
+                      ValueRange srcs);
+
 } // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/tests/build-cion.mlir
+++ b/pmlc/dialect/tile/tests/build-cion.mlir
@@ -1,5 +1,8 @@
-// RUN: pmlc-opt -canonicalize -cse -split-input-file %s | FileCheck %s
+// RUN: pmlc-opt -tile-make-program -canonicalize -cse -split-input-file %s | FileCheck %s
 
+// CHECK: #[[MAP0:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK: #[[MAP1:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[MAP2:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 func @dot(%arg0: tensor<1x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<?x?xf32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f32} : () -> tensor<f32>
   %0 = tile.idx 0
@@ -16,17 +19,11 @@ func @dot(%arg0: tensor<1x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<?x?xf32> {
   return %10 : tensor<?x?xf32>
 }
 
-// CHECK: #[[MAP0:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK: #[[MAP1:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK: #[[MAP2:map[0-9]+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-
-// CHECK: func @dot(%arg0: tensor<1x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<1x3xf32> {
-// CHECK:   %[[CST:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f32} : () -> tensor<f32>
-// CHECK:   %[[CION:.*]] = tile.contract add, mul, %[[CST]], %arg0, %arg1
-// CHECK-SAME: {sink = #[[MAP0]], srcs = [#[[MAP1]], #[[MAP2]]]}
+// CHECK: func @dot(%{{.*}}: tensor<1x2xf32>, %{{.*}}: tensor<2x3xf32>) -> tensor<1x3xf32>
+// CHECK: %[[CST:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f32} : () -> tensor<f32>
+// CHECK: %[[CION:.*]] = tile.contract add, mul, %[[CST]], %{{.*}}, %{{.*}} {sink = #[[MAP0]], srcs = [#[[MAP1]], #[[MAP2]]]}
 // CHECK-SAME: tensor<f32>, tensor<1x2xf32>, tensor<2x3xf32> -> tensor<1x3xf32>
-// CHECK:   return %[[CION]] : tensor<1x3xf32>
-// CHECK: }
+// CHECK: return %[[CION]] : tensor<1x3xf32>
 
 // -----
 
@@ -46,7 +43,7 @@ func @dot_partial_size(%arg0: tensor<?x2xf32>, %arg1: tensor<2x3xf32>) -> tensor
   return %10 : tensor<?x?xf32>
 }
 
-// CHECK: func @dot_partial_size(%arg0: tensor<?x2xf32>, %arg1: tensor<2x3xf32>) -> tensor<?x3xf32> {
+// CHECK: func @dot_partial_size(%{{.*}}: tensor<?x2xf32>, %{{.*}}: tensor<2x3xf32>) -> tensor<?x3xf32> {
 // CHECK:   %{{.*}} = tile.sym_contract add, mul, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : tensor<f32> -> tensor<?x3xf32>
 
 // -----
@@ -67,10 +64,11 @@ func @max_axis_partial_size(%arg0: tensor<?x3x4xf32>) -> tensor<?x?xf32> {
   return %10 : tensor<?x?xf32>
 }
 
-// CHECK: func @max_axis_partial_size(%arg0: tensor<?x3x4xf32>) -> tensor<?x3xf32> {
+// CHECK: func @max_axis_partial_size(%{{.*}}: tensor<?x3x4xf32>) -> tensor<?x3xf32> {
 // CHECK:   %{{.*}} = tile.sym_contract max, none, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : tensor<f32> -> tensor<?x3xf32>
 
 // -----
+
 func @cumsum(%arg0: tensor<10xf32>) -> tensor<?xf32> {
   %c0 = "eltwise.sconst"() {value = 0.0 : f32} : () -> f32
   %0 = tile.idx 0
@@ -96,3 +94,23 @@ func @cumsum(%arg0: tensor<10xf32>) -> tensor<?xf32> {
 // CHECK-SAME: f32, tensor<10xf32> -> tensor<10xf32>
 // CHECK:   return %[[CION]] : tensor<10xf32>
 // CHECK: }
+
+// -----
+
+// CHECK-LABEL: func @infer_cion_result
+// CHECK-SAME: tensor<3xf16>) -> tensor<3xf16>
+func @infer_cion_result(%arg0: tensor<3xf16>) -> tensor<3xf32> {
+  %0 = tile.idx 0
+  %zero = "eltwise.sconst"() {value = 0.0 : f64} : () -> tensor<f16>
+  %two = "eltwise.sconst"() {value = 2.0 : f64} : () -> tensor<f16>
+  %1 = "eltwise.mul"(%arg0, %two) : (tensor<3xf16>, tensor<f16>) -> tensor<3xf32>
+  %2 = tile.tmap %1[%0] : tensor<3xf32>
+  %3 = tile.map %0
+  %c3 = tile.constant 3
+  %4 = tile.map %c3
+  %5 = tile.cons ()
+  %6 = tile.sym_contract assign, none, %zero, %5, %4, %3, %2 : tensor<f16> -> tensor<3xf32>
+  // CHECK: tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #{{.*}}, srcs = [#{{.*}}]} : tensor<f16>, tensor<3xf16> -> tensor<3xf16>
+  return %6 : tensor<3xf32>
+  // CHECK: return %{{.*}} : tensor<3xf16>
+}

--- a/pmlc/dialect/tile/transforms/BUILD
+++ b/pmlc/dialect/tile/transforms/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 gentbl(
     name = "gen-pass",
@@ -24,6 +24,7 @@ plaidml_cc_library(
     srcs = [
         "constant_types.cc",
         "contraction.cc",
+        "make_program.cc",
         "padding.cc",
         "pass_detail.h",
     ],

--- a/pmlc/dialect/tile/transforms/make_program.cc
+++ b/pmlc/dialect/tile/transforms/make_program.cc
@@ -1,0 +1,64 @@
+// Copyright 2020 Intel Corporation
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/FoldUtils.h"
+
+#include "pmlc/dialect/tile/transforms/pass_detail.h"
+
+using namespace mlir; // NOLINT
+
+namespace pmlc::dialect::tile {
+
+namespace {
+
+class MakeProgramDriver : public PatternRewriter {
+public:
+  MakeProgramDriver(MLIRContext *ctx, const OwningRewritePatternList &patterns)
+      : PatternRewriter(ctx), matcher(patterns), folder(ctx) {}
+
+  void run(FuncOp funcOp) {
+    funcOp.walk([&](Operation *op) {
+      // Try to fold this op.
+      if (succeeded(folder.tryToFold(op))) {
+        return;
+      }
+
+      // Make sure that any new operations are inserted at this point.
+      setInsertionPoint(op);
+
+      // Try to match one of the patterns.
+      matcher.matchAndRewrite(op, *this);
+    });
+  }
+
+private:
+  RewritePatternMatcher matcher;
+  OperationFolder folder;
+};
+
+struct MakeProgramPass
+    : public mlir::PassWrapper<MakeProgramPass, mlir::FunctionPass> {
+  void runOnFunction() final {
+    OwningRewritePatternList patterns;
+    auto context = &getContext();
+    for (auto op : context->getRegisteredOperations()) {
+      op->getCanonicalizationPatterns(patterns, context);
+    }
+
+    MakeProgramDriver driver(context, patterns);
+    driver.run(getFunction());
+  }
+
+  static std::unique_ptr<mlir::Pass> create() {
+    return std::make_unique<MakeProgramPass>();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createMakeProgramPass() {
+  return std::make_unique<MakeProgramPass>();
+}
+
+} // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/transforms/passes.h
+++ b/pmlc/dialect/tile/transforms/passes.h
@@ -21,6 +21,8 @@ std::unique_ptr<mlir::Pass> createConstantTypesPass();
 std::unique_ptr<mlir::Pass> createConstantTypesPass(mlir::Type concreteFloat,
                                                     mlir::Type concreteInt);
 
+std::unique_ptr<mlir::Pass> createMakeProgramPass();
+
 std::unique_ptr<mlir::Pass> createPadPass();
 
 } // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/transforms/passes.td
+++ b/pmlc/dialect/tile/transforms/passes.td
@@ -21,6 +21,11 @@ def ConstantTypes : FunctionPass<"tile-constant-types"> {
   ];
 }
 
+def MakeProgram : FunctionPass<"tile-make-program"> {
+  let summary = "Forward-only canonicalization pass";
+  let constructor = "pmlc::dialect::tile::createMakeProgramPass()";
+}
+
 def Pad : FunctionPass<"tile-pad"> {
   let summary = "Pad outputs to remove constraints on inputs";
   let constructor = "pmlc::dialect::tile::createPadPass()";


### PR DESCRIPTION
With the current implementation of floatx/intx, it's possible for the initial element type inference of a contraction to compute a higher-precision type. Later, once the constant types are materialized, we need to re-infer the element type as a symbolic contraction is being converted to a regular one.