### PR TITLE
Add OpenVINO plugin ConvolutionBackpropData op

### DIFF
--- a/networks/oplib/resnet50.cc
+++ b/networks/oplib/resnet50.cc
@@ -33,7 +33,7 @@ edsl::Tensor block(             //
   // as their existence depends on use_shortcut_conv
   auto conv_2a = op::convolution(I, W[0])
                      .name(base_name.str() + "_branch2a")
-                     .strides(strides)
+                     .strides<int>(strides)
                      .dilations({1, 1})
                      .data_dilations({1, 1})
                      .autopad_mode(op::AutoPadMode::VALID)
@@ -60,7 +60,7 @@ edsl::Tensor block(             //
   if (use_shortcut_conv) {
     auto conv_1 = op::convolution(I, W[3])
                       .name(base_name.str() + "_branch1")
-                      .strides(strides)
+                      .strides<int>(strides)
                       .dilations({1, 1})
                       .data_dilations({1, 1})
                       .autopad_mode(op::AutoPadMode::VALID)

--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/convolution_backprop_data.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/convolution_backprop_data.cpp
@@ -21,19 +21,11 @@ static OpRegistration reg("convolutionbackpropdata", [](const Context& ctx) {
   IE_ASSERT(ctx.operands.size() <= 3);
   auto I = ctx.operands.at(0);
   auto F = ctx.operands.at(1);
-  std::vector<int> strides;
-  for (auto stride : layer->get_strides()) {
-    strides.push_back(stride);
-  }
-  std::vector<int> dilations;
-  for (auto dilation : layer->get_dilations()) {
-    dilations.push_back(dilation);
-  }
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
   auto result = op::convolution(I, F)
                     .deriv_mode(plaidml::op::ConvDerivMode::DATA)
-                    .strides(strides)
-                    .dilations(dilations)
+                    .strides(layer->get_strides())
+                    .dilations(layer->get_dilations())
                     .autopad_mode(autopad_mode)
                     .input_layout(plaidml::op::TensorLayout::NCX)
                     .filter_layout(plaidml::op::TensorLayout::KCX);

--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/convolution_backprop_data.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/convolution_backprop_data.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset1.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("convolutionbackpropdata", [](const Context& ctx) {
+  auto* layer = dynamic_cast<ngraph::opset1::ConvolutionBackpropData*>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() >= 2);
+  IE_ASSERT(ctx.operands.size() <= 3);
+  auto I = ctx.operands.at(0);
+  auto F = ctx.operands.at(1);
+  std::vector<int> strides;
+  for (auto stride : layer->get_strides()) {
+    strides.push_back(stride);
+  }
+  std::vector<int> dilations;
+  for (auto dilation : layer->get_dilations()) {
+    dilations.push_back(dilation);
+  }
+  auto autopad_mode = to_plaidml(layer->get_auto_pad());
+  auto result = op::convolution(I, F)
+                    .deriv_mode(plaidml::op::ConvDerivMode::DATA)
+                    .strides(strides)
+                    .dilations(dilations)
+                    .autopad_mode(autopad_mode)
+                    .input_layout(plaidml::op::TensorLayout::NCX)
+                    .filter_layout(plaidml::op::TensorLayout::KCX);
+  if (ctx.operands.size() == 3) {
+    auto result_shape = layer->get_output_shape();
+    if (!result_shape.is_static()) {
+      THROW_IE_EXCEPTION << "Dynamic conv backprop output_shape not supported";
+    }
+    result.result_shape(result_shape.to_shape());
+  } else {
+    result.infer_result_shape(true);
+  }
+  if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
+    std::vector<int> padding;
+    for (auto pad : layer->get_pads_begin()) {
+      padding.push_back(pad);
+    }
+    for (auto pad : layer->get_pads_end()) {
+      padding.push_back(pad);
+    }
+    result.manual_padding(padding);
+  }
+  return edsl::make_tuple(result);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -8,7 +8,6 @@ cc_test(
     srcs = glob(
         ["*.cpp"],
         exclude = [
-            "convolution_backprop_data.cpp",
             "cum_sum.cpp",
             "extract_image_patches.cpp",
             "fake_quantize.cpp",

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -4,108 +4,104 @@
 
 #include <vector>
 
-#include "single_layer_tests/convolution_backprop_data.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/convolution_backprop_data.hpp"
 
-using namespace LayerTestsDefinitions;
+using LayerTestsDefinitions::ConvolutionBackpropDataLayerTest;
 
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::FP16  // Not working yet
 };
 
 const std::vector<size_t> numOutChannels = {1, 5, 16};
 
 /* ============= 2D ConvolutionBackpropData ============= */
-const std::vector<std::vector<size_t >> inputShapes2D = {{1, 3, 30, 30},
-                                                         {1, 16, 10, 10},
-                                                         {1, 32, 10, 10}};
-const std::vector<std::vector<size_t >> kernels2D = {{1, 1}, {3, 3}, {3, 5}};
-const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {1, 3}};
+const std::vector<std::vector<size_t>> inputShapes2D = {{1, 3, 30, 30},    //
+                                                        {1, 16, 10, 10},   //
+                                                        {1, 32, 10, 10}};  //
+const std::vector<std::vector<size_t>> kernels2D = {{1, 1},                //
+                                                    {3, 3},                //
+                                                    {3, 5}};
+const std::vector<std::vector<size_t>> strides2D = {{1, 1},  //
+                                                    {1, 3}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0}, {1, 1}};
-const std::vector<std::vector<size_t >> dilations2D = {{1, 1}, {2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0},  //
+                                                       {1, 1}};
+const std::vector<std::vector<size_t>> dilations2D = {{1, 1},  //
+                                                      {2, 2}};
 
-const auto conv2DParams_ExplicitPadding = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(strides2D),
-        ::testing::ValuesIn(padBegins2D),
-        ::testing::ValuesIn(padEnds2D),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-const auto conv2DParams_AutoPadValid = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(strides2D),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID)
-);
+const auto conv2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels2D),       //
+                                                             ::testing::ValuesIn(strides2D),       //
+                                                             ::testing::ValuesIn(padBegins2D),     //
+                                                             ::testing::ValuesIn(padEnds2D),       //
+                                                             ::testing::ValuesIn(dilations2D),     //
+                                                             ::testing::ValuesIn(numOutChannels),  //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                                                          ::testing::ValuesIn(strides2D),                     //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::ValuesIn(dilations2D),                   //
+                                                          ::testing::ValuesIn(numOutChannels),                //
+                                                          ::testing::Values(ngraph::op::PadType::VALID));
 
 INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv2DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ::testing::Combine(conv2DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv2DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ::testing::Combine(conv2DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 /* ============= 3D ConvolutionBackpropData ============= */
-const std::vector<std::vector<size_t >> inputShapes3D = {{1, 3, 10, 10, 10},
-                                                         {1, 16, 5, 5, 5},
-                                                         {1, 32, 5, 5, 5}};
-const std::vector<std::vector<size_t >> kernels3D = {{1, 1, 1}, {3, 3, 3}};
-const std::vector<std::vector<size_t >> strides3D = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> inputShapes3D = {{1, 3, 10, 10, 10},
+                                                        {1, 16, 5, 5, 5},   //
+                                                        {1, 32, 5, 5, 5}};  //
+const std::vector<std::vector<size_t>> kernels3D = {{1, 1, 1},              //
+                                                    {3, 3, 3}};
+const std::vector<std::vector<size_t>> strides3D = {{1, 1, 1}};
 const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0}, {1, 1, 1}};
-const std::vector<std::vector<size_t >> dilations3D = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0},  //
+                                                       {1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3D = {{1, 1, 1},  //
+                                                      {2, 2, 2}};
 
-const auto conv3DParams_ExplicitPadding = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(strides3D),
-        ::testing::ValuesIn(padBegins3D),
-        ::testing::ValuesIn(padEnds3D),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-const auto conv3DParams_AutoPadValid = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(strides3D),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID)
-);
+const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3D),       //
+                                                             ::testing::ValuesIn(strides3D),       //
+                                                             ::testing::ValuesIn(padBegins3D),     //
+                                                             ::testing::ValuesIn(padEnds3D),       //
+                                                             ::testing::ValuesIn(dilations3D),     //
+                                                             ::testing::ValuesIn(numOutChannels),  //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3D),                        //
+                                                          ::testing::ValuesIn(strides3D),                        //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::ValuesIn(dilations3D),                      //
+                                                          ::testing::ValuesIn(numOutChannels),                   //
+                                                          ::testing::Values(ngraph::op::PadType::VALID));
 
 INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv3DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ::testing::Combine(conv3DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv3DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ::testing::Combine(conv3DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -1502,6 +1502,10 @@ class Value {
     return ret;
   }
 
+  std::vector<int64_t> as_int_tuple_or_empty() const {  //
+    return is_none() ? std::vector<int64_t>{} : as_int_tuple();
+  }
+
   plaidml_value* as_ptr() const { return ptr_.get(); }
 
  private:

--- a/plaidml/op/__init__.py
+++ b/plaidml/op/__init__.py
@@ -124,6 +124,7 @@ def convolution(
         autogroup_mode,
         deriv_mode,
         result_shape,
+        infer_result_shape=False,
 ):
     return op("convolution", [
         inputs,
@@ -143,6 +144,7 @@ def convolution(
         autogroup_mode,
         deriv_mode,
         result_shape,
+        infer_result_shape,
     ]).as_tensor()
 
 

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -325,6 +325,42 @@ std::pair<TensorDim, TensorDim> compute_padding_and_output_size(  //
   throw std::runtime_error(llvm::formatv("Unexpected autopadding mode: {0}", to_string(autopad_mode)));
 }
 
+std::pair<TensorDim, TensorDim> compute_padding_and_input_size(  //
+    const TensorDim& output_size,                                //
+    const TensorDim& filter_size,                                //
+    int64_t stride,                                              //
+    AutoPadMode autopad_mode,                                    //
+    int64_t pad_lo,                                              //
+    int64_t pad_hi,                                              //
+    int64_t dilation,                                            //
+    int64_t data_dilation) {
+  // Note that this computes the smallest input_size that would produce the given output_size
+
+  if (data_dilation != 1) {
+    throw std::runtime_error("Cannot infer input data size for transposed convolution with data dilation");
+  }
+
+  auto O_eff = output_size;
+  auto F_eff = (dilation * (filter_size - 1)) + 1;  // Effective Filter Size
+  if (autopad_mode == AutoPadMode::NONE) {
+    TensorDim pad_before(pad_lo);
+    TensorDim input_size(O_eff * stride - pad_lo - pad_hi + F_eff - stride);
+    return std::pair<TensorDim, TensorDim>(pad_before, input_size);
+  }
+  if (autopad_mode == AutoPadMode::VALID) {
+    TensorDim pad_before(0);
+    TensorDim input_size(O_eff * stride + F_eff - stride);
+    return std::pair<TensorDim, TensorDim>(pad_before, input_size);
+  }
+  if (autopad_mode == AutoPadMode::SAME_LOWER || autopad_mode == AutoPadMode::SAME_UPPER) {
+    TensorDim input_size(O_eff * stride - stride + 1);
+    int64_t lower_term = (autopad_mode == AutoPadMode::SAME_LOWER) ? 1 : 0;
+    TensorDim pad_before((max(0, (O_eff - 1) * stride + F_eff - input_size) + lower_term) / 2);
+    return std::pair<TensorDim, TensorDim>(pad_before, output_size);
+  }
+  throw std::runtime_error(llvm::formatv("Unexpected autopadding mode: {0}", to_string(autopad_mode)));
+}
+
 std::vector<int64_t>* extend_manual_padding(std::vector<int64_t>* pads, size_t rank) {
   // TODO: Perhaps we should throw for sizes != 0, rank, 2*rank?
   if (pads->size() > 2 * rank) {
@@ -714,11 +750,14 @@ void validate_conv_group_layout(TensorLayout filter_layout, GroupLayout group_la
 }
 
 void validate_conv_result_shape(size_t spatial_rank, const std::vector<int64_t>& result_shape, ConvDerivMode deriv_mode,
-                                std::stringstream& args_log) {
+                                bool infer_result_shape, std::stringstream& args_log) {
   if (result_shape.empty()) {
-    if (deriv_mode != ConvDerivMode::NONE) {
+    if (deriv_mode != ConvDerivMode::NONE && !infer_result_shape) {
       IVLOG(1, "Bad convolution, arguments:\n" << args_log.str());
-      throw std::runtime_error("Transposed/gradient convolutions require specifying the result_shape");
+      throw std::runtime_error(
+          "Transposed/gradient convolutions require specifying the result_shape. This can be bypassed by setting "
+          "infer_result_shape = true, but be warned that infered result shapes do not necessarily match the input "
+          "shape used in the forward convolution, as multiple input shapes produce the same output shape.");
     }
   } else {
     if (result_shape.size() != spatial_rank) {
@@ -816,22 +855,24 @@ Value convolution(const Value& value) {
   // 14. Autogrouping (? Unclear if we really need this)
   // 15. Deriv Mode (DATA is equivalent to transposed conv)
   // 16. Result Shape (a.k.a. output shape, used for transposed/derivative convs)
+  // 17. Infer Result Shape (is it legal to omit result shape for transposed convs)
 
   // Read Arguments
   auto args = value.as_tuple();
-  if (args.size() != 17) {
-    throw std::runtime_error("Convolution op expects 17 arguments");
+  if (args.size() != 18) {
+    throw std::runtime_error("Convolution op expects 18 arguments");
   }
   auto I_or_O = args[0].as_tensor();  // O if deriv_mode is DATA, else I
   auto F_or_O = args[1].as_tensor();  // O if deriv_mode is FILTER, else F
-  auto strides = args[2].as_int_tuple();
-  auto dilations = args[3].as_int_tuple();
-  auto data_dilations = args[4].as_int_tuple();
+  auto strides = args[2].is_none() ? std::vector<int64_t>{} : args[2].as_int_tuple();
+  auto dilations = args[3].is_none() ? std::vector<int64_t>{} : args[3].as_int_tuple();
+  auto data_dilations = args[4].is_none() ? std::vector<int64_t>{} : args[4].as_int_tuple();
   // TODO: Perhaps could upgrade use of filter_shape?
-  auto filter_shape = args[5].as_int_tuple();  // This is the shape of the _spatial_ filter dims _only_
-  auto groups = args[6].as_int();              // will be 1 for non-grouped convolutions
+  // This is the shape of the _spatial_ filter dims _only_
+  auto filter_shape = args[5].is_none() ? std::vector<int64_t>{} : args[5].as_int_tuple();
+  auto groups = args[6].as_int();  // will be 1 for non-grouped convolutions
   auto autopad_mode = validate<AutoPadMode>(args[7].as_int());
-  auto manual_padding = args[8].as_int_tuple();
+  auto manual_padding = args[8].is_none() ? std::vector<int64_t>{} : args[8].as_int_tuple();
   auto input_layout = validate<TensorLayout>(args[9].as_int());
   auto filter_layout = validate<TensorLayout>(args[10].as_int());
   auto group_layout = validate<GroupLayout>(args[11].as_int());
@@ -839,7 +880,8 @@ Value convolution(const Value& value) {
   auto name = args[13].as_str();
   auto autogroup_mode = validate<AutoGroupMode>(args[14].as_int());
   auto deriv_mode = validate<ConvDerivMode>(args[15].as_int());
-  auto result_shape = args[16].as_int_tuple();
+  auto result_shape = args[16].is_none() ? std::vector<int64_t>{} : args[16].as_int_tuple();
+  auto infer_result_shape = args[17].as_bool();
 
   // Construct a string to log the arguments if something throws
   std::stringstream args_log;
@@ -900,7 +942,7 @@ Value convolution(const Value& value) {
   validate_conv_filter_rank(spatial_rank, F, filter_layout, deriv_mode, args_log);
   validate_conv_filter_shape_rank(spatial_rank, filter_shape, args_log);
   validate_conv_group_layout(filter_layout, group_layout, args_log);
-  validate_conv_result_shape(spatial_rank, result_shape, deriv_mode, args_log);
+  validate_conv_result_shape(spatial_rank, result_shape, deriv_mode, infer_result_shape, args_log);
   extend_manual_padding(&manual_padding, spatial_rank);
   if (name.empty()) {
     name = "conv";
@@ -916,16 +958,16 @@ Value convolution(const Value& value) {
   TensorIndex co("co");
   TensorIndex g("g");
   // The spatial dimensions of I
-  std::vector<TensorDim> X(spatial_rank);
+  std::vector<TensorDim> I_spatial_dims(spatial_rank);
   // The spatial indexes of I
   std::vector<TensorIndex> x;
   for (size_t i = 0; i < spatial_rank; ++i) {
     x.emplace_back(TensorIndex(llvm::formatv("x{0}", i)));
   }
   // The spatial dimensions of O; nearly unused
-  std::vector<TensorDim> Y(spatial_rank);
+  std::vector<TensorDim> O_spatial_dims(spatial_rank);
   // The spatial dimensions of F
-  std::vector<TensorDim> K(spatial_rank);
+  std::vector<TensorDim> F_spatial_dims(spatial_rank);
   // The spatial indexs of F
   std::vector<TensorIndex> k;
   for (size_t i = 0; i < spatial_rank; ++i) {
@@ -1006,13 +1048,13 @@ Value convolution(const Value& value) {
         I_dims.push_back(N);
         I_dims.push_back(CI);
         for (size_t i = 0; i < spatial_rank; ++i) {
-          I_dims.push_back(X[i]);
+          I_dims.push_back(I_spatial_dims[i]);
         }
         break;
       case TensorLayout::NXC:
         I_dims.push_back(N);
         for (size_t i = 0; i < spatial_rank; ++i) {
-          I_dims.push_back(X[i]);
+          I_dims.push_back(I_spatial_dims[i]);
         }
         I_dims.push_back(CI);
         break;
@@ -1036,7 +1078,7 @@ Value convolution(const Value& value) {
         F_dims.push_back(F_CI);
         F_explicit_dims.push_back(F_CI);
         for (size_t i = 0; i < spatial_rank; ++i) {
-          F_dims.push_back(K[i]);
+          F_dims.push_back(F_spatial_dims[i]);
           if (filter_shape.size()) {
             F_explicit_dims.push_back(TensorDim(filter_shape[i]));
           }
@@ -1045,7 +1087,7 @@ Value convolution(const Value& value) {
       case TensorLayout::XCK:
       case TensorLayout::XGCK:
         for (size_t i = 0; i < spatial_rank; ++i) {
-          F_dims.push_back(K[i]);
+          F_dims.push_back(F_spatial_dims[i]);
           if (filter_shape.size()) {
             F_explicit_dims.push_back(TensorDim(filter_shape[i]));
           }
@@ -1078,13 +1120,13 @@ Value convolution(const Value& value) {
         O_dims.push_back(N);
         O_dims.push_back(CO);
         for (size_t i = 0; i < spatial_rank; ++i) {
-          O_dims.push_back(Y[i]);
+          O_dims.push_back(O_spatial_dims[i]);
         }
         break;
       case TensorLayout::NXC:
         O_dims.push_back(N);
         for (size_t i = 0; i < spatial_rank; ++i) {
-          O_dims.push_back(Y[i]);
+          O_dims.push_back(O_spatial_dims[i]);
         }
         O_dims.push_back(CO);
         break;
@@ -1115,18 +1157,58 @@ Value convolution(const Value& value) {
   }
 
   // Determine the padding and the shape of the result tensor
+  // Note that this is a different shape computed in a different way depending on the DerivMode. In most cases with DATA
+  // and FILTER, `result_shape` will be set, in which case we use the NONE mode logic for the fully determined padding
+  // amounts it enables. If we need to we can infer result_shape for these cases (currently only implemented for DATA),
+  // but we have to make the assumption that the size is the minimal possible, so we avoid this path where possible.
   std::vector<TensorDim> pad_before;
-  std::vector<TensorDim> O_spatial_dims;
+  // Replace the unset defaults
+  switch (deriv_mode) {
+    case ConvDerivMode::NONE:
+      O_spatial_dims.clear();
+      break;
+    case ConvDerivMode::DATA:
+      I_spatial_dims.clear();
+      break;
+    default:
+      break;
+  }
   for (size_t i = 0; i < spatial_rank; ++i) {
     TensorDim local_pad_before;
     TensorDim local_output_size;
-    TensorDim local_input_size = (deriv_mode == ConvDerivMode::DATA) ? TensorDim(result_shape[i]) : X[i];
-    TensorDim local_filter_size = (deriv_mode == ConvDerivMode::FILTER) ? TensorDim(result_shape[i]) : K[i];
-    std::tie(local_pad_before, local_output_size) = compute_padding_and_output_size(
-        local_input_size, local_filter_size, strides[i], autopad_mode, manual_padding[i],
-        manual_padding[i + spatial_rank], dilations[i], data_dilations[i], false);
-    pad_before.emplace_back(local_pad_before);
-    O_spatial_dims.emplace_back(local_output_size);
+    TensorDim local_input_size;
+    TensorDim local_filter_size;
+    if (deriv_mode == ConvDerivMode::DATA && result_shape.empty()) {
+      TensorDim local_output_size = O_spatial_dims[i];
+      TensorDim local_filter_size = F_spatial_dims[i];
+      std::tie(local_pad_before, local_input_size) = compute_padding_and_input_size(
+          local_output_size, local_filter_size, strides[i], autopad_mode, manual_padding[i],
+          manual_padding[i + spatial_rank], dilations[i], data_dilations[i]);
+      pad_before.push_back(local_pad_before);
+      I_spatial_dims.push_back(local_input_size);
+    } else {
+      if (deriv_mode == ConvDerivMode::FILTER && result_shape.empty()) {
+        IVLOG(1, "Bad convolution, arguments:\n" << args_log.str());
+        throw std::runtime_error(
+            "Result shape inference not yet supported for filter transposed/derivative convolutions");
+      }
+      local_input_size = (deriv_mode == ConvDerivMode::DATA) ? TensorDim(result_shape[i]) : I_spatial_dims[i];
+      local_filter_size = (deriv_mode == ConvDerivMode::FILTER) ? TensorDim(result_shape[i]) : F_spatial_dims[i];
+      std::tie(local_pad_before, local_output_size) = compute_padding_and_output_size(
+          local_input_size, local_filter_size, strides[i], autopad_mode, manual_padding[i],
+          manual_padding[i + spatial_rank], dilations[i], data_dilations[i], false);
+      pad_before.push_back(local_pad_before);
+      switch (deriv_mode) {
+        case ConvDerivMode::NONE:
+          O_spatial_dims.push_back(local_output_size);
+          break;
+        case ConvDerivMode::DATA:
+          I_spatial_dims.push_back(TensorDim(result_shape[i]));
+          break;
+        default:
+          break;
+      }
+    }
   }
 
   // Now set up the dimensions of the result to be returned
@@ -1162,13 +1244,13 @@ Value convolution(const Value& value) {
           I_dims.push_back(N);
           I_dims.push_back(CI);
           for (size_t i = 0; i < spatial_rank; ++i) {
-            I_dims.push_back(TensorDim(result_shape[i]));
+            I_dims.push_back(I_spatial_dims[i]);
           }
           break;
         case TensorLayout::NXC:
           I_dims.push_back(N);
           for (size_t i = 0; i < spatial_rank; ++i) {
-            I_dims.push_back(TensorDim(result_shape[i]));
+            I_dims.push_back(I_spatial_dims[i]);
           }
           I_dims.push_back(CI);
           break;

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -864,15 +864,15 @@ Value convolution(const Value& value) {
   }
   auto I_or_O = args[0].as_tensor();  // O if deriv_mode is DATA, else I
   auto F_or_O = args[1].as_tensor();  // O if deriv_mode is FILTER, else F
-  auto strides = args[2].is_none() ? std::vector<int64_t>{} : args[2].as_int_tuple();
-  auto dilations = args[3].is_none() ? std::vector<int64_t>{} : args[3].as_int_tuple();
-  auto data_dilations = args[4].is_none() ? std::vector<int64_t>{} : args[4].as_int_tuple();
+  auto strides = args[2].as_int_tuple_or_empty();
+  auto dilations = args[3].as_int_tuple_or_empty();
+  auto data_dilations = args[4].as_int_tuple_or_empty();
   // TODO: Perhaps could upgrade use of filter_shape?
   // This is the shape of the _spatial_ filter dims _only_
-  auto filter_shape = args[5].is_none() ? std::vector<int64_t>{} : args[5].as_int_tuple();
+  auto filter_shape = args[5].as_int_tuple_or_empty();
   auto groups = args[6].as_int();  // will be 1 for non-grouped convolutions
   auto autopad_mode = validate<AutoPadMode>(args[7].as_int());
-  auto manual_padding = args[8].is_none() ? std::vector<int64_t>{} : args[8].as_int_tuple();
+  auto manual_padding = args[8].as_int_tuple_or_empty();
   auto input_layout = validate<TensorLayout>(args[9].as_int());
   auto filter_layout = validate<TensorLayout>(args[10].as_int());
   auto group_layout = validate<GroupLayout>(args[11].as_int());
@@ -880,7 +880,7 @@ Value convolution(const Value& value) {
   auto name = args[13].as_str();
   auto autogroup_mode = validate<AutoGroupMode>(args[14].as_int());
   auto deriv_mode = validate<ConvDerivMode>(args[15].as_int());
-  auto result_shape = args[16].is_none() ? std::vector<int64_t>{} : args[16].as_int_tuple();
+  auto result_shape = args[16].as_int_tuple_or_empty();
   auto infer_result_shape = args[17].as_bool();
 
   // Construct a string to log the arguments if something throws

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -166,8 +166,20 @@ class convolution {
   }
 
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& strides(const std::initializer_list<T>& strides) {
+    strides_ = edsl::make_tuple(std::vector<T>(strides));
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
   convolution& dilations(const std::vector<T>& dilations) {
     dilations_ = edsl::make_tuple(dilations);
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& dilations(const std::initializer_list<T>& dilations) {
+    dilations_ = edsl::make_tuple(std::vector<T>(dilations));
     return *this;
   }
 
@@ -178,8 +190,20 @@ class convolution {
   }
 
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& data_dilations(const std::initializer_list<T>& data_dilations) {
+    data_dilations_ = edsl::make_tuple(std::vector<T>(data_dilations));
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
   convolution& filter_shape(const std::vector<T>& filter_shape) {
     filter_shape_ = edsl::make_tuple(filter_shape);
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& filter_shape(const std::initializer_list<T>& filter_shape) {
+    filter_shape_ = edsl::make_tuple(std::vector<T>(filter_shape));
     return *this;
   }
 
@@ -191,6 +215,12 @@ class convolution {
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
   convolution& manual_padding(const std::vector<T>& manual_padding) {
     manual_padding_ = edsl::make_tuple(manual_padding);
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& manual_padding(const std::initializer_list<T>& manual_padding) {
+    manual_padding_ = edsl::make_tuple(std::vector<T>(manual_padding));
     return *this;
   }
 
@@ -237,6 +267,12 @@ class convolution {
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
   convolution& result_shape(const std::vector<T>& result_shape) {
     result_shape_ = edsl::make_tuple(result_shape);
+    return *this;
+  }
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& result_shape(const std::initializer_list<T>& result_shape) {
+    result_shape_ = edsl::make_tuple(std::vector<T>(result_shape));
     return *this;
   }
 

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -156,25 +156,30 @@ class convolution {
         group_layout_(GroupLayout::NONE),
         winograd_allowed_(false),
         autogroup_mode_(AutoGroupMode::UNGROUPED),
-        deriv_mode_(ConvDerivMode::NONE) {}
+        deriv_mode_(ConvDerivMode::NONE),
+        infer_result_shape_(false) {}
 
-  convolution& strides(const std::vector<int>& strides) {
-    strides_ = strides;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& strides(const std::vector<T>& strides) {
+    strides_ = edsl::make_tuple(strides);
     return *this;
   }
 
-  convolution& dilations(const std::vector<int>& dilations) {
-    dilations_ = dilations;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& dilations(const std::vector<T>& dilations) {
+    dilations_ = edsl::make_tuple(dilations);
     return *this;
   }
 
-  convolution& data_dilations(const std::vector<int>& data_dilations) {
-    data_dilations_ = data_dilations;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& data_dilations(const std::vector<T>& data_dilations) {
+    data_dilations_ = edsl::make_tuple(data_dilations);
     return *this;
   }
 
-  convolution& filter_shape(const std::vector<int>& filter_shape) {
-    filter_shape_ = filter_shape;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& filter_shape(const std::vector<T>& filter_shape) {
+    filter_shape_ = edsl::make_tuple(filter_shape);
     return *this;
   }
 
@@ -183,8 +188,9 @@ class convolution {
     return *this;
   }
 
-  convolution& manual_padding(const std::vector<int>& manual_padding) {
-    manual_padding_ = manual_padding;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& manual_padding(const std::vector<T>& manual_padding) {
+    manual_padding_ = edsl::make_tuple(manual_padding);
     return *this;
   }
 
@@ -228,8 +234,14 @@ class convolution {
     return *this;
   }
 
-  convolution& result_shape(const std::vector<int>& result_shape) {
-    result_shape_ = result_shape;
+  template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  convolution& result_shape(const std::vector<T>& result_shape) {
+    result_shape_ = edsl::make_tuple(result_shape);
+    return *this;
+  }
+
+  convolution& infer_result_shape(bool infer_result_shape) {
+    infer_result_shape_ = infer_result_shape;
     return *this;
   }
 
@@ -237,13 +249,13 @@ class convolution {
     auto args = edsl::make_tuple(           //
         I_,                                 //
         F_,                                 //
-        edsl::make_tuple(strides_),         //
-        edsl::make_tuple(dilations_),       //
-        edsl::make_tuple(data_dilations_),  //
-        edsl::make_tuple(filter_shape_),    //
+        strides_,                           //
+        dilations_,                         //
+        data_dilations_,                    //
+        filter_shape_,                      //
         groups_,                            //
         static_cast<int>(autopad_mode_),    //
-        edsl::make_tuple(manual_padding_),  //
+        manual_padding_,                    //
         static_cast<int>(input_layout_),    //
         static_cast<int>(filter_layout_),   //
         static_cast<int>(group_layout_),    //
@@ -251,28 +263,30 @@ class convolution {
         name_,                              //
         static_cast<int>(autogroup_mode_),  //
         static_cast<int>(deriv_mode_),      //
-        edsl::make_tuple(result_shape_));
+        result_shape_,                      //
+        infer_result_shape_);
     return details::op("convolution", args).as_tensor();
   }
 
  private:
   edsl::Tensor I_;
   edsl::Tensor F_;
-  std::vector<int> strides_;         // Default: empty (builds vector of 1s in oplib)
-  std::vector<int> dilations_;       // Default: empty (builds vector of 1s in oplib)
-  std::vector<int> data_dilations_;  // Default: empty (builds vector of 1s in oplib)
-  std::vector<int> filter_shape_;    // Default: empty (i.e. no filter dim check)
-  int groups_;                       // Default: 1
-  std::vector<int> manual_padding_;  // Default: empty (i.e. no manual padding)
-  AutoPadMode autopad_mode_;         // Default: AutoPadMode::SAME_UPPER
-  TensorLayout input_layout_;        // Default: TensorLayout::NXC
-  TensorLayout filter_layout_;       // Default: TensorLayout::XCK
-  GroupLayout group_layout_;         // Default: GroupLayout::NONE
-  bool winograd_allowed_;            // Default: false
-  std::string name_;                 // Default: empty (oplib currently renames "" to "conv")
-  AutoGroupMode autogroup_mode_;     // Default: AutoGroupMode::UNGROUPED
-  ConvDerivMode deriv_mode_;         // Default: ConvDerivMode::NONE
-  std::vector<int> result_shape_;    // Default: empty (i.e. unspecified)
+  edsl::Value strides_;           // Default: empty (builds vector of 1s in oplib)
+  edsl::Value dilations_;         // Default: empty (builds vector of 1s in oplib)
+  edsl::Value data_dilations_;    // Default: empty (builds vector of 1s in oplib)
+  edsl::Value filter_shape_;      // Default: empty (i.e. no filter dim check)
+  int groups_;                    // Default: 1
+  edsl::Value manual_padding_;    // Default: empty (i.e. no manual padding)
+  AutoPadMode autopad_mode_;      // Default: AutoPadMode::SAME_UPPER
+  TensorLayout input_layout_;     // Default: TensorLayout::NXC
+  TensorLayout filter_layout_;    // Default: TensorLayout::XCK
+  GroupLayout group_layout_;      // Default: GroupLayout::NONE
+  bool winograd_allowed_;         // Default: false
+  std::string name_;              // Default: empty (oplib currently renames "" to "conv")
+  AutoGroupMode autogroup_mode_;  // Default: AutoGroupMode::UNGROUPED
+  ConvDerivMode deriv_mode_;      // Default: ConvDerivMode::NONE
+  edsl::Value result_shape_;      // Default: empty (i.e. unspecified)
+  bool infer_result_shape_;       // Default: false
 };
 
 inline edsl::Tensor cumprod(const edsl::Tensor& I, int axis) {


### PR DESCRIPTION
Adds the ConvolutionBackpropData op to the PlaidML OpenVINO plugin. Includes several parts:

1. Actually adding the op
2. Reformatting the tests to make the linter happy
3. Extending the oplib convolution to allow it to infer the result size for ConvDerivMode::DATA. Add a new parameter to the oplib conv to enable this (IMO we don't want it on by default; it's forced to make assumptions about the possible size as multiple input data sizes correspond to the same output size and I don't think we should make such assumptions without an explicit request)
4. Add some fancy template metaprogramming code to the Convolution Fluent API to allow multiple integer vector types to be used as inputs.
5. Advances the OpenVINO reference

Sorry that these are bundled in one PR, ~but no part of this is tested without the other parts~ turns out some of the edsl cc_tests do test the fluent API changes, I could split that off if it's important but I'd prefer not to.