### PR TITLE
Fix OpenVINO plugin pool failures

### DIFF
--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/avg_pool.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/avg_pool.cpp
@@ -30,8 +30,8 @@ static OpRegistration reg("avgpool", [](const Context& ctx) {
   auto pool_type = plaidml::op::PoolMode::AVG;
   auto input_layout = plaidml::op::TensorLayout::NCX;
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
-  bool include_padding_in_avg = false;
-  bool use_ceil_for_output_shape = false;
+  auto include_padding_in_avg = to_plaidml(layer->get_exclude_pad();
+  auto use_ceil_for_output_shape = to_plaidml(layer->get_rounding_type());
   std::vector<int> padding;
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
     for (auto pad : layer->get_pads_begin()) {

--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/avg_pool.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/avg_pool.cpp
@@ -30,8 +30,8 @@ static OpRegistration reg("avgpool", [](const Context& ctx) {
   auto pool_type = plaidml::op::PoolMode::AVG;
   auto input_layout = plaidml::op::TensorLayout::NCX;
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
-  auto include_padding_in_avg = to_plaidml(layer->get_exclude_pad();
-  auto use_ceil_for_output_shape = to_plaidml(layer->get_rounding_type());
+  auto include_padding_in_avg = !layer->get_exclude_pad();
+  auto use_ceil_for_output_shape = layer->get_rounding_type() == ngraph::op::RoundingType::CEIL;
   std::vector<int> padding;
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
     for (auto pad : layer->get_pads_begin()) {

--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/max_pool.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/max_pool.cpp
@@ -16,7 +16,7 @@ using namespace InferenceEngine;  // NOLINT[build/namespaces]
 namespace PlaidMLPlugin {
 
 static OpRegistration reg("maxpool", [](const Context& ctx) {
-  auto* layer = dynamic_cast<ngraph::opset1::AvgPool*>(ctx.layer);
+  auto* layer = dynamic_cast<ngraph::opset1::MaxPool*>(ctx.layer);
   IE_ASSERT(ctx.operands.size() == 1);
   auto I = ctx.operands.at(0);
   std::vector<int> strides;
@@ -31,7 +31,7 @@ static OpRegistration reg("maxpool", [](const Context& ctx) {
   auto input_layout = plaidml::op::TensorLayout::NCX;
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
   bool include_padding_in_avg = false;
-  bool use_ceil_for_output_shape = false;
+  auto use_ceil_for_output_shape = to_plaidml(layer->get_rounding_type());
   std::vector<int> padding;
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
     for (auto pad : layer->get_pads_begin()) {

--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/max_pool.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/max_pool.cpp
@@ -31,7 +31,7 @@ static OpRegistration reg("maxpool", [](const Context& ctx) {
   auto input_layout = plaidml::op::TensorLayout::NCX;
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
   bool include_padding_in_avg = false;
-  auto use_ceil_for_output_shape = to_plaidml(layer->get_rounding_type());
+  auto use_ceil_for_output_shape = layer->get_rounding_type() == ngraph::op::RoundingType::CEIL;
   std::vector<int> padding;
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
     for (auto pad : layer->get_pads_begin()) {

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -13,14 +13,8 @@ using LayerTestsDefinitions::poolSpecificParams;
 
 namespace {
 // Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-    InferenceEngine::Precision::FP32,
-    //         InferenceEngine::Precision::FP16, // "[NOT_IMPLEMENTED] Input image format FP16 is not supported yet...
-    InferenceEngine::Precision::U8,
-    //         InferenceEngine::Precision::I8 // Too much cases
-};
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP16};
+const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
 
 const std::vector<std::vector<size_t>> kernels = {{3, 3}, {3, 5}};
 const std::vector<std::vector<size_t>> strides = {{1, 1}, {1, 2}};
@@ -40,7 +34,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params =
                        ::testing::Values(ngraph::op::PadType::EXPLICIT),       //
                        ::testing::Values(false));  // placeholder value - exclude pad not applicable for max pooling
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_FloorRounding, PoolingLayerTest,
                         ::testing::Combine(maxPool_ExplicitPad_FloorRounding_Params,                //
                                            ::testing::ValuesIn(netPrecisions),                      //
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //


### PR DESCRIPTION
A collaboration with @cnamrata15 to fix pooling test failures. There are still 28 failing pooling tests, but they are all failing on the nGraph interpreter reference implementation side due to known errors (commented on in the OV code we got these test cases from).