### PR TITLE
Create OpenVINO plugin smoke tests

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -11,8 +11,6 @@ cc_test(
             "cum_sum.cpp",
             "extract_image_patches.cpp",
             "fake_quantize.cpp",
-            "mvn.cpp",
-            "power.cpp",
             "space_to_batch.cpp",
         ],
     ),
@@ -24,6 +22,57 @@ cc_test(
     linkopts = PLAIDML_LINKOPTS,
     tags = [
         "manual",
+        "skip_macos",
+        "skip_windows",
+    ],
+    deps = [
+        "//pmlc/util:logging",
+        "@gflags",
+        "@gmock//:gtest_main",
+        "@openvino//:helpers",
+        "@openvino//:inference_engine",
+        "@openvino//:common_test_utils",
+        "@openvino//:shared_plugin_tests",
+    ],
+)
+
+# Tests suitable for CI, skips flakey, broken, and long tests
+cc_test(
+    name = "smoke",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = [
+            "convert_like.cpp",                     # Known errors
+            "convolution.cpp",                      # Long
+            "convolution_backprop_data.cpp",        # Long
+            "cum_sum.cpp",                          # Doesn't compile
+            "equal.cpp",                            # Known errors
+            "extract_image_patches.cpp",            # Doesn't compile
+            "fake_quantize.cpp",                    # Doesn't compile
+            "group_convolution_backprop_data.cpp",  # Long
+            "less.cpp",                             # Known errors
+            "less_equal.cpp",                       # Known errors
+            "lrn.cpp",                              # Known errors
+            "not_equal.cpp",                        # Known errors
+            "reduce_logical_and.cpp",               # Known errors
+            "reduce_logical_or.cpp",                # Known errors
+            "mvn.cpp",                              # Known errors
+            "pooling.cpp",                          # Long, known errors
+            "power.cpp",                            # Known errors
+            "select.cpp",                           # Known errors
+            "sin.cpp",                              # Known errors
+            "split.cpp",                            # Known errors
+            "space_to_batch.cpp",                   # Doesn't compile
+            "tile.cpp",                             # Known errors
+        ],
+    ),
+    copts = ["-Wno-deprecated-declarations"],
+    data = [
+        "//plaidml/bridge/openvino:libplaidml-plugin.so",
+        "//plaidml/bridge/openvino:plugins",
+    ],
+    linkopts = PLAIDML_LINKOPTS,
+    tags = [
         "skip_macos",
         "skip_windows",
     ],

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -54,7 +54,10 @@ cc_test(
             "group_convolution_backprop_data.cpp",  # Long
             "less.cpp",                             # Known errors
             "less_equal.cpp",                       # Known errors
+            "logical_and.cpp",                      # Known errors
             "logical_not.cpp",                      # Known errors
+            "logical_or.cpp",                       # Known errors
+            "logical_xor.cpp",                      # Known errors
             "lrn.cpp",                              # Known errors
             "not_equal.cpp",                        # Known errors
             "reduce_logical_and.cpp",               # Known errors

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -54,6 +54,7 @@ cc_test(
             "group_convolution_backprop_data.cpp",  # Long
             "less.cpp",                             # Known errors
             "less_equal.cpp",                       # Known errors
+            "logical_not.cpp",                      # Known errors
             "lrn.cpp",                              # Known errors
             "not_equal.cpp",                        # Known errors
             "reduce_logical_and.cpp",               # Known errors

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -49,6 +49,8 @@ cc_test(
             "equal.cpp",                            # Known errors
             "extract_image_patches.cpp",            # Doesn't compile
             "fake_quantize.cpp",                    # Doesn't compile
+            "greater.cpp",                          # Known errors
+            "greater_equal.cpp",                    # Known errors
             "group_convolution_backprop_data.cpp",  # Long
             "less.cpp",                             # Known errors
             "less_equal.cpp",                       # Known errors

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
@@ -1,0 +1,246 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/convolution.hpp"
+#include "single_layer_tests/convolution_backprop_data.hpp"
+#include "single_layer_tests/group_convolution_backprop_data.hpp"
+
+using LayerTestsDefinitions::ConvolutionBackpropDataLayerTest;
+using LayerTestsDefinitions::ConvolutionLayerTest;
+using LayerTestsDefinitions::GroupConvBackpropDataLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+/* ============= 2D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels = {{3, 5}};
+const std::vector<std::vector<size_t>> strides = {{1, 3}};
+const std::vector<std::vector<ptrdiff_t>> padBegins = {{0, 3}};
+const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations = {{3, 1}};
+const std::vector<size_t> numOutChannels = {5};
+
+const auto conv2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels),                     //
+                                                             ::testing::ValuesIn(strides),                     //
+                                                             ::testing::ValuesIn(padBegins),                   //
+                                                             ::testing::ValuesIn(padEnds),                     //
+                                                             ::testing::ValuesIn(dilations),                   //
+                                                             ::testing::ValuesIn(numOutChannels),              //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels),                       //
+                                                          ::testing::ValuesIn(strides),                       //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::ValuesIn(dilations),                     //
+                                                          ::testing::ValuesIn(numOutChannels),                //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)       //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_ExplicitPadding, ConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_ExplicitPadding,                            //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_AutoPadValid, ConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_AutoPadValid,  //
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ConvolutionLayerTest::getTestCaseName);
+/* ============= 3D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels3d = {{3, 5, 3}};
+const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 2, 0}};
+
+const std::vector<std::vector<size_t>> strides3d = {{1, 2, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 2, 1}};
+
+const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
+                                                             ::testing::ValuesIn(strides3d),                   //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(dilations3d),                 //
+                                                             ::testing::Values(5),                             //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
+                                                          ::testing::ValuesIn(strides3d),                        //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::ValuesIn(dilations3d),                      //
+                                                          ::testing::Values(5),                                  //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_ExplicitPadding, ConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_ExplicitPadding,                                //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_AutoPadValid, ConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_AutoPadValid,                                   //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        ConvolutionLayerTest::getTestCaseName);
+
+/* ============= 2D ConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t>> inputShapes2D = {{1, 3, 30, 30}};
+const std::vector<std::vector<size_t>> kernels2D = {{3, 5}};
+const std::vector<std::vector<size_t>> strides2D = {{1, 3}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{1, 1}};
+const std::vector<std::vector<size_t>> dilations2D = {{1, 2}};
+
+const auto convbprop2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels2D),       //
+                                                                  ::testing::ValuesIn(strides2D),       //
+                                                                  ::testing::ValuesIn(padBegins2D),     //
+                                                                  ::testing::ValuesIn(padEnds2D),       //
+                                                                  ::testing::ValuesIn(dilations2D),     //
+                                                                  ::testing::ValuesIn(numOutChannels),  //
+                                                                  ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto convbprop2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                                                               ::testing::ValuesIn(strides2D),                     //
+                                                               ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                               ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                               ::testing::ValuesIn(dilations2D),                   //
+                                                               ::testing::ValuesIn(numOutChannels),                //
+                                                               ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop2DParams_ExplicitPadding,   //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop2DParams_AutoPadValid,      //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D ConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t>> inputShapes3D = {{1, 16, 5, 5, 5}};
+const std::vector<std::vector<size_t>> kernels3D = {{3, 3, 3}};
+const std::vector<std::vector<size_t>> strides3D = {{1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3D = {{2, 2, 2}};
+
+const auto convbprop3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3D),       //
+                                                                  ::testing::ValuesIn(strides3D),       //
+                                                                  ::testing::ValuesIn(padBegins3D),     //
+                                                                  ::testing::ValuesIn(padEnds3D),       //
+                                                                  ::testing::ValuesIn(dilations3D),     //
+                                                                  ::testing::ValuesIn(numOutChannels),  //
+                                                                  ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto convbrop3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3D),                        //
+                                                              ::testing::ValuesIn(strides3D),                        //
+                                                              ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                              ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                              ::testing::ValuesIn(dilations3D),                      //
+                                                              ::testing::ValuesIn(numOutChannels),                   //
+                                                              ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop3DParams_ExplicitPadding,   //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbrop3DParams_AutoPadValid,       //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+const std::vector<size_t> groupNumOutChannels = {16};
+const std::vector<size_t> numGroups = {8};
+
+/* ============= 2D GroupConvolution ============= */
+const std::vector<std::vector<size_t>> groupInputShapes2D = {{1, 32, 10, 10}};
+
+const auto groupConvBackpropData2DParams_ExplicitPadding =
+    ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                       ::testing::ValuesIn(strides2D),                     //
+                       ::testing::ValuesIn(padBegins2D),                   //
+                       ::testing::ValuesIn(padEnds2D),                     //
+                       ::testing::ValuesIn(dilations2D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT));  //
+const auto groupConvBackpropData2DParams_AutoPadValid =
+    ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                       ::testing::ValuesIn(strides2D),                     //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                       ::testing::ValuesIn(dilations2D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::VALID));     //
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData2DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(groupInputShapes2D),              //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_AutoPadValid, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData2DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(groupInputShapes2D),              //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D GroupConvolution ============= */
+
+const auto groupConvBackpropData3DParams_ExplicitPadding =
+    ::testing::Combine(::testing::ValuesIn(kernels3D),                     //
+                       ::testing::ValuesIn(strides3D),                     //
+                       ::testing::ValuesIn(padBegins3D),                   //
+                       ::testing::ValuesIn(padEnds3D),                     //
+                       ::testing::ValuesIn(dilations3D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT));  //
+const auto groupConvBackpropData3DParams_AutoPadValid =
+    ::testing::Combine(::testing::ValuesIn(kernels3D),                        //
+                       ::testing::ValuesIn(strides3D),                        //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                       ::testing::ValuesIn(dilations3D),                      //
+                       ::testing::ValuesIn(groupNumOutChannels),              //
+                       ::testing::ValuesIn(numGroups),                        //
+                       ::testing::Values(ngraph::op::PadType::VALID));        //
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData3DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(inputShapes3D),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_AutoPadValid, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData3DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(inputShapes3D),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -27,8 +27,7 @@ using EltwiseTestNamespace::ParameterInputIdx;
 std::vector<EltwiseOpType> operations = {EltwiseOpType::ADD, EltwiseOpType::SUBSTRACT, EltwiseOpType::MULTIPLY};
 std::vector<ParameterInputIdx> primary_input_idx = {0, 1};
 std::vector<InputLayerType> secondary_input_types = {InputLayerType::CONSTANT, InputLayerType::PARAMETER};
-std::vector<InferenceEngine::Precision> net_precisions = {InferenceEngine::Precision::FP32,
-                                                          InferenceEngine::Precision::FP16};
+std::vector<InferenceEngine::Precision> net_precisions = {InferenceEngine::Precision::FP32};
 std::vector<InferenceEngine::SizeVector> flat_shapes = {{1, 200}, {1, 2000}, {1, 20000}};
 std::vector<InferenceEngine::SizeVector> non_flat_shapes = {{2, 200}, {10, 200}, {1, 10, 100}, {4, 4, 16}};
 std::map<std::string, std::string> additional_config = {};

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Simplified pooling tests, suitable for CI. The main pooling tests are long and include errors in the reference
+// implementation
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/pooling.hpp"
+
+using LayerTestsDefinitions::PoolingLayerTest;
+using LayerTestsDefinitions::poolSpecificParams;
+
+namespace {
+// Common params
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
+
+const std::vector<std::vector<size_t>> kernels = {{3, 5}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}};
+const std::vector<std::vector<size_t>> padBegins = {{0, 2}};
+const std::vector<std::vector<size_t>> padEnds = {{0, 2}};
+const std::vector<ngraph::op::RoundingType> roundingTypes = {ngraph::op::RoundingType::CEIL,
+                                                             ngraph::op::RoundingType::FLOOR};
+////* ========== Max Polling ========== */
+const auto MaxPoolSmokeParams =
+    ::testing::Combine(::testing::Values(ngraph::helpers::PoolingTypes::MAX),  //
+                       ::testing::ValuesIn(kernels),                           //
+                       ::testing::ValuesIn(strides),                           //
+                       ::testing::ValuesIn(padBegins),                         //
+                       ::testing::ValuesIn(padEnds),                           //
+                       ::testing::ValuesIn(roundingTypes),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT),       //
+                       ::testing::Values(false));  // placeholder value - exclude pad not applicable for max pooling
+
+INSTANTIATE_TEST_CASE_P(MaxPool_Smoke, PoolingLayerTest,
+                        ::testing::Combine(MaxPoolSmokeParams,                                      //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        PoolingLayerTest::getTestCaseName);
+
+////* ========== Avg Pooling ========== */
+
+/* +========== Explicit Pad Floor Rounding ========== */
+const auto avgPoolSmokeParams =
+    ::testing::Combine(::testing::Values(ngraph::helpers::PoolingTypes::AVG),                    //
+                       ::testing::ValuesIn(kernels),                                             //
+                       ::testing::ValuesIn(strides),                                             //
+                       ::testing::ValuesIn(padBegins),                                           //
+                       ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}})),  //
+                       ::testing::ValuesIn(roundingTypes),                                       //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT),                         //
+                       ::testing::Values(true, false));                                          //
+
+INSTANTIATE_TEST_CASE_P(AvgPool_Smoke, PoolingLayerTest,
+                        ::testing::Combine(avgPoolSmokeParams,                                      //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        PoolingLayerTest::getTestCaseName);
+
+////* ========== Avg and Max Polling Cases ========== */
+/*    ========== Valid Pad Rounding Not Applicable ========== */
+const auto allPools_ValidPad_Params = ::testing::Combine(
+    ::testing::Values(ngraph::helpers::PoolingTypes::MAX, ngraph::helpers::PoolingTypes::AVG),  //
+    ::testing::ValuesIn(kernels),                                                               //
+    ::testing::ValuesIn(strides),                                                               //
+    ::testing::Values(std::vector<size_t>({0, 0})),                                             //
+    ::testing::Values(std::vector<size_t>({0, 0})),                                             //
+    ::testing::Values(
+        ngraph::op::RoundingType::FLOOR),  // placeholder value - Rounding Type not applicable for Valid pad type
+    ::testing::Values(ngraph::op::PadType::VALID),  //
+    ::testing::Values(false));                      // placeholder value - exclude pad not applicable for max pooling
+
+INSTANTIATE_TEST_CASE_P(BothPool_Smoke, PoolingLayerTest,
+                        ::testing::Combine(allPools_ValidPad_Params,                                //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        PoolingLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -10,8 +10,7 @@
 using LayerTestsDefinitions::ReshapeLayerTest;
 
 namespace {
-const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
-                                                               InferenceEngine::Precision::FP16};
+const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
 
 INSTANTIATE_TEST_CASE_P(ReshapeCheckDynBatch, ReshapeLayerTest,
                         ::testing::Combine(::testing::Values(true),                                   //


### PR DESCRIPTION
Adds smoke tests covering all OpenVINO plugin ops without known errors in the op and/or its tests. These tests should be suitable for CI -- they ran in 10 seconds on my linux setup -- but I'm adding Matt as a reviewer so he can complain if I'm wrong about that.

~Also fix the bug that inspired these tests: MatMul had gotten out of sync with our OpenVINO fork, and we had untested and unnoticed compilation errors. CI should now yell at us if we overlook that again. This is in a separate commit for ease of review.~ This is instead addressed in https://github.com/plaidml/plaidml/pull/1191