### PR TITLE
Updating oplib testing to lit

### DIFF
--- a/plaidml/op/BUILD
+++ b/plaidml/op/BUILD
@@ -3,6 +3,7 @@
 load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//pmlc:lit.bzl", "lit_test")
 
 SDK_HDRS = [
     "ffi.h",
@@ -63,8 +64,15 @@ py_library(
 plaidml_cc_test(
     name = "cc_test",
     srcs = ["op_test.cc"],
+    tags = ["manual"],  # the `edsl_test.cc.test` rule will run this test via lit
     deps = [
-        ":op",
         "//plaidml:testenv",
+        "//plaidml/edsl",
+        "//plaidml/exec",
     ],
+)
+
+lit_test(
+    name = "op_test.cc",
+    data = [":cc_test"],
 )

--- a/plaidml/op/CPPLINT.cfg
+++ b/plaidml/op/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace/line_length

--- a/pmlc/lit.site.cfg.py
+++ b/pmlc/lit.site.cfg.py
@@ -29,6 +29,7 @@ mlir_pmlc_tools_dirs = [
     'pmlc/tools/pmlc-vulkan-runner',
     'pmlc/rt/vulkan/tests',
     'plaidml/edsl/tests',
+    'plaidml/op',
 ]
 config.mlir_pmlc_tools_dirs = [
     os.path.join(os.environ['TEST_SRCDIR'], os.environ['TEST_WORKSPACE'], s)


### PR DESCRIPTION
Modified necessary files to run lit testing on oplib, including a cpplint config file to ignore line length limits.

Implemented lit tests for Relu, Abs, and All