### PR TITLE
Enable OpenVINO test for newly legalizable ops

### DIFF
--- a/plaidml/bridge/openvino/src/plaidml_plugin/ops/floor_mod.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/ops/floor_mod.cpp
@@ -17,7 +17,7 @@ namespace PlaidMLPlugin {
 static OpRegistration reg("floormod", [](const Context& ctx) {
   IE_ASSERT(ctx.operands.size() == 2);
   auto N = ctx.operands.at(0);
-  auto D = ctx.operands.at(0);
+  auto D = ctx.operands.at(1);
   return edsl::make_tuple(N - D * edsl::floor(N / D));
 });
 

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -46,10 +46,7 @@ cc_test(
             "convolution_backprop_data.cpp",        # Long
             "cum_sum.cpp",                          # Doesn't compile
             "equal.cpp",                            # Known errors
-            "erf.cpp",                              # Known errors
             "extract_image_patches.cpp",            # Doesn't compile
-            "fake_quantize.cpp",                    # Known errors
-            "floor.cpp",                            # Known errors
             "floor_mod.cpp",                        # Known errors
             "greater.cpp",                          # Known errors
             "greater_equal.cpp",                    # Known errors
@@ -66,7 +63,6 @@ cc_test(
             "reduce_logical_or.cpp",                # Known errors
             "mvn.cpp",                              # Known errors
             "pooling.cpp",                          # Long, known errors
-            "power.cpp",                            # Known errors
             "select.cpp",                           # Known errors
             "sin.cpp",                              # Known errors
             "split.cpp",                            # Known errors

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -47,6 +47,7 @@ cc_test(
             "cum_sum.cpp",                          # Doesn't compile
             "equal.cpp",                            # Known errors
             "extract_image_patches.cpp",            # Doesn't compile
+            "fake_quantize.cpp",                    # Known errors (intermittent)
             "floor_mod.cpp",                        # Known errors
             "greater.cpp",                          # Known errors
             "greater_equal.cpp",                    # Known errors

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -7,12 +7,11 @@
 #include "common_test_utils/test_constants.hpp"
 #include "single_layer_tests/fake_quantize.hpp"
 
-using namespace LayerTestsDefinitions;  // TODO: Lint once enabled
+using LayerTestsDefinitions::FakeQuantizeLayerTest;
 
 namespace {
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
-                                                               InferenceEngine::Precision::FP16};
+const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
 
 const std::vector<std::vector<size_t>> inputShapes = {{1, 1, 1, 1}, {3, 10, 5, 6}};
 const std::vector<std::vector<size_t>> constShapes = {{1}};

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/floor_mod.cpp
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/floor_mod.cpp
@@ -11,7 +11,7 @@ using LayerTestsDefinitions::FloorModLayerTest;
 namespace {
 
 const std::vector<std::vector<std::size_t>> inputShapes = {
-    {std::vector<std::size_t>({1, 30}), std::vector<std::size_t>({1, 30})}};
+    {std::vector<std::size_t>({10, 30}), std::vector<std::size_t>({1, 30})}};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,


### PR DESCRIPTION
Includes minor fixes discovered on enabling the tests.

Note that FloorMod isn't re-enabled due to a reference implementation error. But, as best as I can tell without a reference implementation, FloorMod is working.