### PR TITLE
Fix for strided convolutions in XSMM.  

### DIFF
--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -196,6 +196,15 @@ TEST_F(OpTest, Convolution) {
   runProgram(program);
 }
 
+TEST_F(OpTest, Convolution_Padding3) {
+  auto I = Placeholder(DType::FLOAT32, {1, 224, 224, 3}, "I");
+  auto K = Placeholder(DType::FLOAT32, {7, 7, 3, 64}, "K");
+  auto O = op::convolution(I, K).strides({2, 2}).autopad_mode(AutoPadMode::EXPLICIT).manual_padding({3, 3});
+  auto program = makeProgram("convolution", {O});
+  IVLOG(1, program);
+  runProgram(program);
+}
+
 TEST_F(OpTest, CumProd) {
   auto I = Placeholder(DType::FLOAT32, {7, 7, 3, 64}, "I");
   auto program = makeProgram("cumprod", {op::cumprod(I, 2)});


### PR DESCRIPTION
Note: These convolutions should have a valid XSSM lowering, but currently there is a bug in lowering, so we simply skip optimizations for this case.