### PR TITLE
Add AffineVectoreReduce instruction to the pxa layer.

### DIFF
--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -238,15 +238,14 @@ struct AffineVectorReduceOpConversion
     auto source = rewriter.create<AffineVectorLoadOp>(
         op.getLoc(), op.getVectorType(), op.mem(), op.idxs());
     // Get an attribute form of the map
-    auto srcMapAttr = AffineMapAttr::get(op.map());
-    // Set the nap attribute
-    source.setAttr(AffineVectorLoadOp::getMapAttrName(), srcMapAttr);
+    auto mapAttr = AffineMapAttr::get(op.map());
+    // Set the map attribute
+    source.setAttr(AffineVectorLoadOp::getMapAttrName(), mapAttr);
     auto reduce = createVectorReduction(rewriter, op, source.getResult());
     auto dest = rewriter.create<AffineVectorStoreOp>(
         op.getLoc(), ArrayRef<Type>{}, reduce, op.mem(), op.idxs());
-    // Set the nap attribute
-    auto destMapAttr = AffineMapAttr::get(op.map());
-    dest.setAttr(AffineVectorLoadOp::getMapAttrName(), destMapAttr);
+    // Set the map attribute
+    dest.setAttr(AffineVectorLoadOp::getMapAttrName(), mapAttr);
     op.replaceAllUsesWith(op.mem());
     rewriter.eraseOp(op);
   }

--- a/pmlc/dialect/pxa/ir/ops.cc
+++ b/pmlc/dialect/pxa/ir/ops.cc
@@ -70,7 +70,8 @@ struct SimplifyAffineOp : public OpRewritePattern<AffineOpTy> {
         // std::is_same<AffineOpTy, AffinePrefetchOp>::value ||
         // std::is_same<AffineOpTy, AffineStoreOp>::value ||
         std::is_same<AffineOpTy, AffineApplyOp>::value ||
-            std::is_same<AffineOpTy, AffineReduceOp>::value,
+            std::is_same<AffineOpTy, AffineReduceOp>::value ||
+            std::is_same<AffineOpTy, AffineVectorReduceOp>::value,
         "affine load/store/apply/reduce op expected");
     auto map = affineOp.getAffineMap();
     AffineMap oldMap = map;
@@ -87,13 +88,22 @@ struct SimplifyAffineOp : public OpRewritePattern<AffineOpTy> {
 };
 
 // Specialize the template to account for the different build signatures for
-// affine load, store, reduce, and apply ops.
+// affine load, store, reduce, vector_reduce, and apply ops.
 template <>
 void SimplifyAffineOp<AffineReduceOp>::replaceAffineOp(
     PatternRewriter &rewriter, AffineReduceOp op, AffineMap map,
     ArrayRef<Value> mapOperands) const {
   rewriter.replaceOpWithNewOp<AffineReduceOp>(
       op, op.getMemRefType(), op.agg(), op.val(), op.mem(), map, mapOperands);
+}
+
+template <>
+void SimplifyAffineOp<AffineVectorReduceOp>::replaceAffineOp(
+    PatternRewriter &rewriter, AffineVectorReduceOp op, AffineMap map,
+    ArrayRef<Value> mapOperands) const {
+  rewriter.replaceOpWithNewOp<AffineVectorReduceOp>(op, op.getMemRefType(),
+                                                    op.agg(), op.vector(),
+                                                    op.mem(), map, mapOperands);
 }
 
 /// This is a common class used for patterns of the form
@@ -126,6 +136,22 @@ struct SimplifyDeadReduce : public OpRewritePattern<AffineReduceOp> {
   }
 };
 
+/// Fold vector_reduce operations with no uses. Vector_reduce has side effects
+/// on the heap, but can still be deleted if it has zero uses.
+struct SimplifyDeadVectorReduce
+    : public OpRewritePattern<AffineVectorReduceOp> {
+  using OpRewritePattern<AffineVectorReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(AffineVectorReduceOp reduce,
+                                PatternRewriter &rewriter) const override {
+    if (reduce.use_empty()) {
+      rewriter.eraseOp(reduce);
+      return success();
+    }
+    return failure();
+  }
+};
+
 } // namespace
 
 // ---- AffineReduceOp ----
@@ -141,6 +167,23 @@ void printAffineReduceOp(OpAsmPrinter &p, AffineReduceOp op) {
   p.printOptionalAttrDict(op.getAttrs(), {"agg", "map"});
   p << " : ";
   p.printType(op.mem().getType());
+}
+
+// ---- AffineVectorReduceOp ----
+
+void printAffineVectorReduceOp(OpAsmPrinter &p, AffineVectorReduceOp op) {
+  p << op.getOperation()->getName() << ' ';
+  p << util::stringifyAggregationKind(op.agg()) << ' ';
+  p << op.vector() << ", ";
+  p << op.mem() << '[';
+  auto mapAttr = op.getAttrOfType<AffineMapAttr>("map");
+  p.printAffineMapOfSSAIds(mapAttr, op.idxs());
+  p << ']';
+  p.printOptionalAttrDict(op.getAttrs(), {"agg", "map"});
+  p << " : ";
+  p.printType(op.mem().getType());
+  p << ", ";
+  p.printType(op.vector().getType());
 }
 
 // <operation> ::= `pxa.reduce` keyword ssa-use `,` ssa-use `[` ssa-use-list `]`
@@ -175,6 +218,48 @@ void AffineReduceOp::getCanonicalizationPatterns(
 
 OpFoldResult AffineReduceOp::fold(ArrayRef<Attribute> cstOperands) {
   /// reduce(memrefcast) -> reduce
+  foldMemRefCast(*this);
+  return OpFoldResult();
+}
+
+// <operation> ::= `pxa.vector_reduce` keyword ssa-use `,` ssa-use `[`
+// ssa-use-list `]`
+//                 attribute-dict? `:` type
+ParseResult parseAffineVectorReduceOp(OpAsmParser &parser,
+                                      OperationState &result) {
+  auto indexTy = parser.getBuilder().getIndexType();
+  auto i64Ty = parser.getBuilder().getIntegerType(64);
+  MemRefType memrefType;
+  VectorType vectorType;
+  AffineMapAttr mapAttr;
+  OpAsmParser::OperandType val, out;
+  SmallVector<OpAsmParser::OperandType, 4> idxs;
+  auto symbolizeAggregationKind = [](StringRef str) {
+    return util::symbolizeAggregationKind(str);
+  };
+  return failure(
+      parseKeywordIntoEnumAttr(parser, result, "agg", i64Ty,
+                               symbolizeAggregationKind) ||
+      parser.parseOperand(val) || parser.parseComma() ||
+      parser.parseOperand(out) ||
+      parser.parseAffineMapOfSSAIds(idxs, mapAttr, "map", result.attributes) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonType(memrefType) ||
+      parser.addTypeToList(memrefType, result.types) || parser.parseComma() ||
+      parser.parseType(vectorType) ||
+      parser.resolveOperand(val, vectorType, result.operands) ||
+      parser.resolveOperand(out, memrefType, result.operands) ||
+      parser.resolveOperands(idxs, indexTy, result.operands));
+}
+
+void AffineVectorReduceOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SimplifyAffineOp<AffineVectorReduceOp>, SimplifyDeadReduce>(
+      context);
+}
+
+OpFoldResult AffineVectorReduceOp::fold(ArrayRef<Attribute> cstOperands) {
+  /// vectorReduce(memrefcast) -> vectorReduce
   foldMemRefCast(*this);
   return OpFoldResult();
 }

--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -29,7 +29,7 @@ class PXA_OpWithPP<string mnemonic, list<OpTrait> traits = []> :
 
 def AnyStdScalar : AnyTypeOf<[AnyFloat, AnySignlessInteger]> {}
 
-def AffineReduceOp : PXA_OpWithPP<"reduce", [NoSideEffect]> {
+def AffineReduceOp : PXA_OpWithPP<"reduce", []> {
   let summary = "affine reduction operation";
   let arguments = (ins
     AggregationKind:$agg,
@@ -62,7 +62,7 @@ def AffineReduceOp : PXA_OpWithPP<"reduce", [NoSideEffect]> {
   }];
 }
 
-def AffineVectorReduceOp : PXA_OpWithPP<"vector_reduce", [NoSideEffect]> {
+def AffineVectorReduceOp : PXA_OpWithPP<"vector_reduce", []> {
   let summary = "affine vector reduction operation";
   let arguments = (ins
     AggregationKind:$agg,

--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -29,8 +29,7 @@ class PXA_OpWithPP<string mnemonic, list<OpTrait> traits = []> :
 
 def AnyStdScalar : AnyTypeOf<[AnyFloat, AnySignlessInteger]> {}
 
-// TODO: Add NoSideEffect
-def AffineReduceOp : PXA_OpWithPP<"reduce", []> {
+def AffineReduceOp : PXA_OpWithPP<"reduce", [NoSideEffect]> {
   let summary = "affine reduction operation";
   let arguments = (ins
     AggregationKind:$agg,
@@ -60,6 +59,42 @@ def AffineReduceOp : PXA_OpWithPP<"reduce", []> {
     operand_range getMapOperands() { return idxs(); }
     static StringRef getMapAttrName() { return "map"; }
     Value getValueToStore() { return val(); }
+  }];
+}
+
+def AffineVectorReduceOp : PXA_OpWithPP<"vector_reduce", [NoSideEffect]> {
+  let summary = "affine vector reduction operation";
+  let arguments = (ins
+    AggregationKind:$agg,
+    AnyVector:$vector,
+    Arg<AnyMemRef, "the memref to reduce", [MemRead, MemWrite]>:$mem,
+    AffineMapAttr:$map,
+    Variadic<Index>:$idxs
+  );
+  let results = (outs AnyMemRef:$result);
+
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+
+  let builders = [OpBuilder<
+    "OpBuilder& builder, OperationState& result, AggregationKind agg,"
+    "Value vector, Value mem, AffineMap map, ValueRange idxs", [{
+      build(builder, result, mem.getType(), agg, vector, mem, map, idxs);
+    }]
+  >];
+
+  let extraClassDeclaration = [{
+    Value getMemRef() { return mem(); }
+    unsigned getMemRefOperandIndex() { return 1; }
+    void setMemRef(Value value) { setOperand(getMemRefOperandIndex(), value); }
+    MemRefType getMemRefType() { return mem().getType().cast<MemRefType>(); }
+    AffineMap getAffineMap() { return map(); }
+    operand_range getMapOperands() { return idxs(); }
+    static StringRef getMapAttrName() { return "map"; }
+    Value getValueToStore() { return vector(); }
+    mlir::VectorType getVectorType() {
+      return vector().getType().cast<mlir::VectorType>();
+    }
   }];
 }
 

--- a/pmlc/dialect/pxa/tests/ops.mlir
+++ b/pmlc/dialect/pxa/tests/ops.mlir
@@ -1,15 +1,159 @@
 // RUN: pmlc-opt -pxa-dataflow-opt -canonicalize -convert-pxa-to-affine %s | FileCheck %s
 
-// CHECK-LABEL: func @pxa_vector_reduce
-func @pxa_vector_reduce(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
-  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+// CHECK-LABEL: func @pxa_reduce_assign
+func @pxa_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    %red = pxa.reduce assign %2, %a[%i, %j] :  memref<100x100xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
+    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_vector_reduce_assign
+func @pxa_vector_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
     %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
-    pxa.vector_reduce add %2, %arg2[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %3 = affine.vector_load %arg2[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %4 = addf %3, %2 : vector<4xf32>
-    // CHECK: affine.vector_store %4, %arg2[] : memref<100x100xf32>, vector<4xf32>
+    %red = pxa.vector_reduce assign %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    affine.yield %red : memref<100x100xf32>
   }
-  return
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_reduce_add
+func @pxa_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    %red = pxa.reduce add %2, %a[%i, %j] :  memref<100x100xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
+    // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : f32
+    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_vector_reduce_add
+func @pxa_vector_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
+    %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
+    %2 = mulf %0, %1 : vector <4xf32>
+    %red = pxa.vector_reduce add %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_reduce_mul
+func @pxa_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    %red = pxa.reduce mul %2, %a[%i, %j] :  memref<100x100xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
+    // CHECK: %{{.*}} = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_vector_reduce_mul
+func @pxa_vector_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
+    %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
+    %2 = mulf %0, %1 : vector <4xf32>
+    %red = pxa.vector_reduce mul %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_reduce_max
+func @pxa_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    %red = pxa.reduce max %2, %a[%i, %j] :  memref<100x100xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
+    // CHECK: %{{.*}} = cmpf "ogt", %{{.*}}, %{{.*}} : f32
+    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_vector_reduce_max
+func @pxa_vector_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
+    %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
+    %2 = mulf %0, %1 : vector <4xf32>
+    %red = pxa.vector_reduce max %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = cmpf "ogt", %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_reduce_min
+func @pxa_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.load %arg1[%i, %k] : memref<100x100xf32>
+    %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
+    %2 = mulf %0, %1 : f32
+    %red = pxa.reduce min %2, %a[%i, %j] :  memref<100x100xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
+    // CHECK: %{{.*}} = cmpf "olt", %{{.*}}, %{{.*}} : f32
+    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
+}
+
+// CHECK-LABEL: func @pxa_vector_reduce_min
+func @pxa_vector_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> (memref<100x100xf32>) {
+  %a = alloc() : memref<100x100xf32>
+  %r = affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) reduce ("assign") -> (memref<100x100xf32>) {
+    %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
+    %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
+    %2 = mulf %0, %1 : vector <4xf32>
+    %red = pxa.vector_reduce min %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %{{.*}} = cmpf "olt", %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    affine.yield %red : memref<100x100xf32>
+  }
+  return %r : memref<100x100xf32>
 }

--- a/pmlc/dialect/pxa/tests/ops.mlir
+++ b/pmlc/dialect/pxa/tests/ops.mlir
@@ -1,0 +1,15 @@
+// RUN: pmlc-opt -pxa-dataflow-opt -canonicalize -convert-pxa-to-affine %s | FileCheck %s
+
+// CHECK-LABEL: func @pxa_vector_reduce
+func @pxa_vector_reduce(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>, %arg2: memref<100x100xf32>) {
+  affine.parallel (%i, %j, %k) = (0, 0, 0) to (100, 100, 100) {
+    %0 = affine.vector_load %arg1[%i, %k] : memref<100x100xf32>, vector<4xf32>
+    %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
+    %2 = mulf %0, %1 : vector <4xf32>
+    pxa.vector_reduce add %2, %arg2[%i, %j] :  memref<100x100xf32>, vector<4xf32>
+    // CHECK: %3 = affine.vector_load %arg2[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %4 = addf %3, %2 : vector<4xf32>
+    // CHECK: affine.vector_store %4, %arg2[] : memref<100x100xf32>, vector<4xf32>
+  }
+  return
+}

--- a/pmlc/dialect/pxa/tests/ops.mlir
+++ b/pmlc/dialect/pxa/tests/ops.mlir
@@ -10,7 +10,7 @@ func @pxa_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) 
     %red = pxa.reduce assign %2, %a[%i, %j] :  memref<100x100xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
     // CHECK: %{{.*}} = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
-    // CHECK: affine.store %[[MUL:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: affine.store %[[MUL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -26,7 +26,7 @@ func @pxa_vector_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100
     %red = pxa.vector_reduce assign %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
     // CHECK: %{{.*}} = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: affine.vector_store %[[MUL:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: affine.vector_store %[[MUL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -42,8 +42,8 @@ func @pxa_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %red = pxa.reduce add %2, %a[%i, %j] :  memref<100x100xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
     // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
-    // CHECK: %[[AGG:.*]] = addf %[[LOAD:.*]], %[[MUL:.*]] : f32
-    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = addf %[[LOAD]], %[[MUL:.*]] : f32
+    // CHECK: affine.store %[[AGG]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -59,8 +59,8 @@ func @pxa_vector_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %red = pxa.vector_reduce add %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
     // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %[[AGG:.*]] = addf %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
-    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = addf %[[LOAD]], %[[MUL]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -76,7 +76,7 @@ func @pxa_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %red = pxa.reduce mul %2, %a[%i, %j] :  memref<100x100xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
     // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
-    // CHECK: %[[AGG:.*]] = mulf %[[LOAD:.*]], %[[MUL:.*]] : f32
+    // CHECK: %[[AGG:.*]] = mulf %[[LOAD]], %[[MUL]] : f32
     // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
@@ -93,8 +93,8 @@ func @pxa_vector_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %red = pxa.vector_reduce mul %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
     // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %[[AGG:.*]] = mulf %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
-    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = mulf %[[LOAD]], %[[MUL]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -110,8 +110,9 @@ func @pxa_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %red = pxa.reduce max %2, %a[%i, %j] :  memref<100x100xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
     // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
-    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[LOAD:.*]], %[[MUL:.*]] : f32
-    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[MUL]], %[[LOAD]] : f32
+    // CHECK: %[[SEL:.*]] = select %[[AGG]], %[[MUL]], %[[LOAD]] : f32
+    // CHECK: affine.store %[[SEL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -127,8 +128,9 @@ func @pxa_vector_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %red = pxa.vector_reduce max %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
     // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
-    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[MUL]], %[[LOAD]] : vector<4xf32>
+    // CHECK: %[[SEL:.*]] = select %[[AGG]], %[[MUL]], %[[LOAD]] : vector<4xi1>, vector<4xf32>
+    // CHECK: affine.vector_store %[[SEL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -144,8 +146,9 @@ func @pxa_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %red = pxa.reduce min %2, %a[%i, %j] :  memref<100x100xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
     // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
-    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[LOAD:.*]], %[[MUL:.*]] : f32
-    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[MUL]], %[[LOAD]] : f32
+    // CHECK: %[[SEL:.*]] = select %[[AGG]], %[[MUL]], %[[LOAD]] : f32
+    // CHECK: affine.store %[[SEL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -161,8 +164,9 @@ func @pxa_vector_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %red = pxa.vector_reduce min %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
     // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
     // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
-    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[MUL]], %[[LOAD]] : vector<4xf32>
+    // CHECK: %[[SEL:.*]] = select %[[AGG]], %[[MUL]], %[[LOAD]] : vector<4xi1>, vector<4xf32>
+    // CHECK: affine.vector_store %[[SEL]], %[[ARG2]][%[[ARG3]], %[[ARG4]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>

--- a/pmlc/dialect/pxa/tests/ops.mlir
+++ b/pmlc/dialect/pxa/tests/ops.mlir
@@ -8,8 +8,9 @@ func @pxa_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) 
     %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
     %2 = mulf %0, %1 : f32
     %red = pxa.reduce assign %2, %a[%i, %j] :  memref<100x100xf32>
-    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
-    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: %{{.*}} = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: affine.store %[[MUL:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -23,8 +24,9 @@ func @pxa_vector_reduce_assign(%arg0: memref<100x100xf32>, %arg1: memref<100x100
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
     %red = pxa.vector_reduce assign %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: %{{.*}} = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: affine.vector_store %[[MUL:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -38,9 +40,10 @@ func @pxa_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
     %2 = mulf %0, %1 : f32
     %red = pxa.reduce add %2, %a[%i, %j] :  memref<100x100xf32>
-    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
-    // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : f32
-    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = addf %[[LOAD:.*]], %[[MUL:.*]] : f32
+    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -54,9 +57,10 @@ func @pxa_vector_reduce_add(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
     %red = pxa.vector_reduce add %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : vector<4xf32>
-    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = addf %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -70,9 +74,10 @@ func @pxa_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
     %2 = mulf %0, %1 : f32
     %red = pxa.reduce mul %2, %a[%i, %j] :  memref<100x100xf32>
-    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
-    // CHECK: %{{.*}} = mulf %{{.*}}, %{{.*}} : f32
-    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = mulf %[[LOAD:.*]], %[[MUL:.*]] : f32
+    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -86,9 +91,10 @@ func @pxa_vector_reduce_mul(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
     %red = pxa.vector_reduce mul %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = mulf %{{.*}}, %{{.*}} : vector<4xf32>
-    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = mulf %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -102,9 +108,10 @@ func @pxa_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
     %2 = mulf %0, %1 : f32
     %red = pxa.reduce max %2, %a[%i, %j] :  memref<100x100xf32>
-    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
-    // CHECK: %{{.*}} = cmpf "ogt", %{{.*}}, %{{.*}} : f32
-    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[LOAD:.*]], %[[MUL:.*]] : f32
+    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -118,9 +125,10 @@ func @pxa_vector_reduce_max(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
     %red = pxa.vector_reduce max %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = cmpf "ogt", %{{.*}}, %{{.*}} : vector<4xf32>
-    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "ogt", %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -134,9 +142,10 @@ func @pxa_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> 
     %1 = affine.load %arg0[%k, %j] : memref<100x100xf32>
     %2 = mulf %0, %1 : f32
     %red = pxa.reduce min %2, %a[%i, %j] :  memref<100x100xf32>
-    // CHECK: %{{.*}} = affine.load %{{.*}} : memref<100x100xf32>
-    // CHECK: %{{.*}} = cmpf "olt", %{{.*}}, %{{.*}} : f32
-    // CHECK: affine.store %{{.*}}, %{{.*}} : memref<100x100xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : f32
+    // CHECK: %[[LOAD:.*]] = affine.load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[LOAD:.*]], %[[MUL:.*]] : f32
+    // CHECK: affine.store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>
@@ -150,9 +159,10 @@ func @pxa_vector_reduce_min(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf3
     %1 = affine.vector_load %arg0[%k, %j] : memref<100x100xf32>, vector<4xf32>
     %2 = mulf %0, %1 : vector <4xf32>
     %red = pxa.vector_reduce min %2, %a[%i, %j] :  memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = affine.vector_load %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
-    // CHECK: %{{.*}} = cmpf "olt", %{{.*}}, %{{.*}} : vector<4xf32>
-    // CHECK: affine.vector_store %{{.*}}, %{{.*}}[] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[MUL:.*]] = mulf %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK: %[[LOAD:.*]] = affine.vector_load %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
+    // CHECK: %[[AGG:.*]] = cmpf "olt", %[[LOAD:.*]], %[[MUL:.*]] : vector<4xf32>
+    // CHECK: affine.vector_store %[[AGG:.*]], %[[ARG2:.*]][%[[ARG3:.*]], %[[ARG4:.*]]] : memref<100x100xf32>, vector<4xf32>
     affine.yield %red : memref<100x100xf32>
   }
   return %r : memref<100x100xf32>


### PR DESCRIPTION
This is needed to allow us to use the data flow analysis mechanisms that the AffineReduceOp exposes/utilizes, so Fusion and other passes can operate on the AffineVectorReduceOp.