### PR TITLE
XSMM & Stencil cleanups

### DIFF
--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -64,9 +64,15 @@ def AffineReduceOp : PXA_OpWithPP<"reduce"> {
 
 def AffineGemmOp : PXA_OpWithPP<"gemm"> {
   let arguments = (ins
-    AnyMemRef:$c, AffineMapAttr:$cAccessMap, AffineMapAttr:$cTileMap,
-    AnyMemRef:$a, AffineMapAttr:$aAccessMap, AffineMapAttr:$aTileMap,
-    AnyMemRef:$b, AffineMapAttr:$bAccessMap, AffineMapAttr:$bTileMap,
+    Arg<AnyMemRef, "the C memref to store to", [MemWrite]>:$c,
+    AffineMapAttr:$cAccessMap,
+    AffineMapAttr:$cTileMap,
+    Arg<AnyMemRef, "the A memref to load from", [MemRead]>:$a,
+    AffineMapAttr:$aAccessMap,
+    AffineMapAttr:$aTileMap,
+    Arg<AnyMemRef, "the B memref to load from", [MemRead]>:$b,
+    AffineMapAttr:$bAccessMap,
+    AffineMapAttr:$bTileMap,
     I64ArrayAttr:$tile,
     Variadic<Index>:$mapOperands);
   let results = (outs AnyMemRef:$out);

--- a/pmlc/dialect/pxa/transforms/BUILD
+++ b/pmlc/dialect/pxa/transforms/BUILD
@@ -29,6 +29,7 @@ plaidml_cc_library(
         "pass_detail.h",
         "resize_tmps.cc",
         "stencil.cc",
+        "stencil_gemm.cc",
         "test_analysis.cc",
         "tile.cc",
     ],

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -28,8 +28,7 @@ struct StencilCost {
   unsigned startupCost;
 };
 
-using StencilCostFunction =
-    std::function<StencilCost(llvm::ArrayRef<unsigned>)>;
+using StencilCostFunction = std::function<StencilCost(llvm::ArrayRef<int64_t>)>;
 
 std::unique_ptr<mlir::Pass> createTestStrideInfoPass();
 
@@ -37,7 +36,7 @@ std::unique_ptr<mlir::Pass> createTestIndirectUsesIteratorPass();
 
 std::unique_ptr<mlir::Pass> createTestIndirectValuesIteratorPass();
 
-std::unique_ptr<mlir::Pass> createXSMMStencilPass(unsigned numThreads,
+std::unique_ptr<mlir::Pass> createStencilGEMMPass(unsigned numThreads,
                                                   StencilCostFunction costFn);
 
 } // namespace pmlc::dialect::pxa

--- a/pmlc/target/x86/BUILD
+++ b/pmlc/target/x86/BUILD
@@ -36,7 +36,6 @@ plaidml_cc_library(
         "pipeline.cc",
         "trace_linking.cc",
         "xsmm_lowering.cc",
-        "xsmm_stencil.cc",
         ":heatmap",
     ],
     hdrs = [

--- a/pmlc/target/x86/heatmap.h
+++ b/pmlc/target/x86/heatmap.h
@@ -11,6 +11,6 @@
 
 namespace pmlc::target::x86 {
 
-dialect::pxa::StencilCost heatmapCost(llvm::ArrayRef<unsigned> tile);
+dialect::pxa::StencilCost heatmapCost(llvm::ArrayRef<int64_t> tile);
 
 } // namespace pmlc::target::x86

--- a/pmlc/target/x86/heatmap_impl.cc
+++ b/pmlc/target/x86/heatmap_impl.cc
@@ -36,7 +36,7 @@ struct Heatmap {
 
 static Heatmap heatmap;
 
-StencilCost heatmapCost(llvm::ArrayRef<unsigned> ranges) {
+StencilCost heatmapCost(llvm::ArrayRef<int64_t> ranges) {
   assert(ranges.size() == 3 && "heatmapCost expects a 3D tile");
 
   auto tile = Tile{ranges[0], ranges[1], ranges[2]};

--- a/pmlc/target/x86/xsmm_lowering.cc
+++ b/pmlc/target/x86/xsmm_lowering.cc
@@ -174,17 +174,6 @@ struct XSMMGemmInvokeLowering
     return success();
   }
 
-  Optional<Value> getOperandPtr(xsmm::GemmInvokeOp op,
-                                ConversionPatternRewriter &rewriter, Type type,
-                                Value memref, AffineMap accessMap,
-                                ValueRange indices) const {
-    auto operands = expandAffineMap(rewriter, op.getLoc(), accessMap, indices);
-    if (!operands)
-      return llvm::None;
-    return getDataPtr(op.getLoc(), type.cast<MemRefType>(), memref, *operands,
-                      rewriter, getModule());
-  }
-
   LLVM::LLVMFuncOp getOrInsertFunc(Operation *op,
                                    ConversionPatternRewriter &rewriter) const {
     const char *kGemmInvokeF32 = "plaidml_rt_xsmm_gemm_invoke_f32";


### PR DESCRIPTION
Generalize the stencil pass so that it is specific to GEMMs rather than XSMM.