### PR TITLE
Wip: Do not merge: Add OpenCL + SPIRV path

### DIFF
--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -170,4 +170,28 @@ def plaidml_workspace():
         build_file = clean_dep("//bzl:zlib.BUILD"),
     )
 
+    http_archive(
+        name = "opencl_headers",
+        url = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.06.16.zip",
+        sha256 = "518703d3c3a6333bcf8e4f80758e4e98f7af30fbd72a09fe8c2673da1628d80c",
+        strip_prefix = "OpenCL-Headers-2020.06.16",
+        build_file = clean_dep("//vendor/opencl_headers:opencl_headers.BUILD"),
+    )
+
+    http_archive(
+        name = "opencl_hpp_headers",
+        url = "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/v2.0.12.zip",
+        sha256 = "127936b3a5ef147f23b85fb043599d1480e9e57acabe2d2a67c5dac05aa4ad70",
+        strip_prefix = "OpenCL-CLHPP-2.0.12",
+        build_file = clean_dep("//vendor/opencl_hpp_headers:opencl_hpp_headers.BUILD"),
+    )
+
+    http_archive(
+        name = "opencl_icd_loader",
+        url = "https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/v2020.06.16.zip",
+        sha256 = "e4c27a5adcef4dbc0fee98864af203dc78dfc967ca7287c9bad9add030e7516e",
+        strip_prefix = "OpenCL-ICD-Loader-2020.06.16",
+        build_file = clean_dep("//vendor/opencl_icd_loader:opencl_icd_loader.BUILD"),
+    )
+
     openvino_workspace()

--- a/llvm_unified_diff.patch
+++ b/llvm_unified_diff.patch
@@ -1,0 +1,205 @@
+--- llvm\include\llvm\ADT\StringMap.h	2020-06-22 13:29:03.000000000 +0200
++++ llvm\include\llvm\ADT\StringMap.h	2020-07-10 01:37:22.000000000 +0200
+@@ -463,13 +463,18 @@
+ 
+   StringRef &operator*() {
+     Key = this->wrapped()->getKey();
+     return Key;
+   }
+ 
++  StringRef &operator*() const {
++    Key = this->wrapped()->getKey();
++    return Key;
++  }
++
+ private:
+   StringRef Key;
+ };
+ 
+ } // end namespace llvm
+ 
+ #endif // LLVM_ADT_STRINGMAP_H
+--- mlir\lib\Conversion\GPUToSPIRV\ConvertGPUToSPIRV.cpp	2020-06-22 13:29:03.000000000 +0200
++++ mlir\lib\Conversion\GPUToSPIRV\ConvertGPUToSPIRV.cpp	2020-07-13 01:10:30.000000000 +0200
+@@ -12,12 +12,13 @@
+ #include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRV.h"
+ #include "mlir/Dialect/GPU/GPUDialect.h"
+ #include "mlir/Dialect/SCF/SCF.h"
+ #include "mlir/Dialect/SPIRV/SPIRVDialect.h"
+ #include "mlir/Dialect/SPIRV/SPIRVLowering.h"
+ #include "mlir/Dialect/SPIRV/SPIRVOps.h"
++#include "mlir/Dialect/SPIRV/TargetAndABI.h"
+ #include "mlir/IR/Module.h"
+ 
+ using namespace mlir;
+ 
+ namespace {
+ 
+@@ -433,15 +434,23 @@
+ // ModuleOp with gpu.module.
+ //===----------------------------------------------------------------------===//
+ 
+ LogicalResult GPUModuleConversion::matchAndRewrite(
+     gpu::GPUModuleOp moduleOp, ArrayRef<Value> operands,
+     ConversionPatternRewriter &rewriter) const {
++  auto addressingModel = spirv::AddressingModel::Logical;
++  auto memoryModel = spirv::MemoryModel::GLSL450;
++  auto targetEnv = spirv::lookupTargetEnvOrDefault(moduleOp);
++  for (auto cap : targetEnv.getCapabilities()) {
++    if (cap == spirv::Capability::Addresses)
++      addressingModel = spirv::AddressingModel::Physical64;
++    if (cap == spirv::Capability::Kernel)
++      memoryModel = spirv::MemoryModel::OpenCL;
++  }
+   auto spvModule = rewriter.create<spirv::ModuleOp>(
+-      moduleOp.getLoc(), spirv::AddressingModel::Logical,
+-      spirv::MemoryModel::GLSL450);
++      moduleOp.getLoc(), addressingModel, memoryModel);
+ 
+   // Move the region from the module op into the SPIR-V module.
+   Region &spvModuleRegion = spvModule.body();
+   rewriter.inlineRegionBefore(moduleOp.body(), spvModuleRegion,
+                               spvModuleRegion.begin());
+   // The spv.module build method adds a block with a terminator. Remove that
+--- mlir\lib\Dialect\LLVMIR\IR\LLVMDialect.cpp	2020-06-22 13:29:03.000000000 +0200
++++ mlir\lib\Dialect\LLVMIR\IR\LLVMDialect.cpp	2020-07-11 09:08:17.000000000 +0200
+@@ -934,12 +934,14 @@
+ // Verifier for LLVM::DialectCastOp.
+ //===----------------------------------------------------------------------===//
+ 
+ static LogicalResult verify(DialectCastOp op) {
+   auto verifyMLIRCastType = [&op](Type type) -> LogicalResult {
+     if (auto llvmType = type.dyn_cast<LLVM::LLVMType>()) {
++      if (llvmType.isStructTy())
++        return success();
+       if (llvmType.isVectorTy())
+         llvmType = llvmType.getVectorElementType();
+       if (llvmType.isIntegerTy() || llvmType.isBFloatTy() ||
+           llvmType.isHalfTy() || llvmType.isFloatTy() ||
+           llvmType.isDoubleTy()) {
+         return success();
+@@ -948,12 +950,15 @@
+                             "types, or vector of mentioned types.");
+     }
+     if (auto vectorType = type.dyn_cast<VectorType>()) {
+       if (vectorType.getShape().size() > 1)
+         return op.emitOpError("only 1-d vector is allowed");
+       type = vectorType.getElementType();
++    }
++    if (auto memRefType = type.dyn_cast<MemRefType>()) {
++      type = memRefType.getElementType();
+     }
+     if (type.isSignlessIntOrFloat())
+       return success();
+     // Note that memrefs are not supported. We currently don't have a use case
+     // for it, but even if we do, there are challenges:
+     // * if we allow memrefs to cast from/to memref descriptors, then the
+--- mlir\lib\Dialect\SPIRV\Transforms\LowerABIAttributesPass.cpp	2020-06-22 13:29:03.000000000 +0200
++++ mlir\lib\Dialect\SPIRV\Transforms\LowerABIAttributesPass.cpp	2020-07-13 02:39:02.000000000 +0200
+@@ -116,14 +116,20 @@
+   // Adds the spv.EntryPointOp after collecting all the interface variables
+   // needed.
+   SmallVector<Attribute, 1> interfaceVars;
+   if (failed(getInterfaceVariables(funcOp, interfaceVars))) {
+     return failure();
+   }
++
++  spirv::TargetEnv targetEnv(spirv::lookupTargetEnv(funcOp));
++  auto executionModel = spirv::ExecutionModel::GLCompute;
++  if (targetEnv.allows(spirv::Capability::Kernel))
++    executionModel = spirv::ExecutionModel::Kernel;
++
+   builder.create<spirv::EntryPointOp>(
+-      funcOp.getLoc(), spirv::ExecutionModel::GLCompute, funcOp, interfaceVars);
++      funcOp.getLoc(), executionModel, funcOp, interfaceVars);
+   // Specifies the spv.ExecutionModeOp.
+   auto localSizeAttr = entryPointAttr.local_size();
+   SmallVector<int32_t, 3> localSize(localSizeAttr.getValues<int32_t>());
+   builder.create<spirv::ExecutionModeOp>(
+       funcOp.getLoc(), funcOp, spirv::ExecutionMode::LocalSize, localSize);
+   funcOp.removeAttr(entryPointAttrName);
+@@ -136,12 +142,25 @@
+ ///
+ /// Specifically, this pattern creates global variables according to interface
+ /// variable ABI attributes attached to function arguments and converts all
+ /// function argument uses to those global variables. This is necessary because
+ /// Vulkan requires all shader entry points to be of void(void) type.
+ class ProcessInterfaceVarABI final : public SPIRVOpLowering<spirv::FuncOp> {
++public:
++  using SPIRVOpLowering<spirv::FuncOp>::SPIRVOpLowering;
++  LogicalResult
++  matchAndRewrite(spirv::FuncOp funcOp, ArrayRef<Value> operands,
++                  ConversionPatternRewriter &rewriter) const override;
++};
++
++/// A pattern to convert function signature according to interface variable ABI
++/// attributes for OpenCL contract.
++///
++/// Currently it only strips ABI attributes to make function legal,
++/// since OpenCL expects entry point functions to have normal arguments.
++class ProcessInterfaceVarABIForOpenCL final : public SPIRVOpLowering<spirv::FuncOp> {
+ public:
+   using SPIRVOpLowering<spirv::FuncOp>::SPIRVOpLowering;
+   LogicalResult
+   matchAndRewrite(spirv::FuncOp funcOp, ArrayRef<Value> operands,
+                   ConversionPatternRewriter &rewriter) const override;
+ };
+@@ -210,32 +229,52 @@
+     funcOp.setType(rewriter.getFunctionType(
+         signatureConverter.getConvertedTypes(), llvm::None));
+   });
+   return success();
+ }
+ 
++LogicalResult ProcessInterfaceVarABIForOpenCL::matchAndRewrite(
++    spirv::FuncOp funcOp, ArrayRef<Value> operands,
++    ConversionPatternRewriter &rewriter) const {
++  rewriter.startRootUpdate(funcOp);
++  auto context = funcOp.getContext();
++  auto attrName = spirv::getInterfaceVarABIAttrName();
++  auto attrId = Identifier::get(attrName, context);
++  for (auto argType : llvm::enumerate(funcOp.getType().getInputs())) {
++    // Remove ABI attributes
++    funcOp.removeArgAttr(argType.index(), attrId);
++  }
++  rewriter.finalizeRootUpdate(funcOp);
++  return success();
++}
++
+ void LowerABIAttributesPass::runOnOperation() {
+   // Uses the signature conversion methodology of the dialect conversion
+   // framework to implement the conversion.
+   spirv::ModuleOp module = getOperation();
+   MLIRContext *context = &getContext();
+ 
+   spirv::TargetEnv targetEnv(spirv::lookupTargetEnv(module));
+ 
+   SPIRVTypeConverter typeConverter(targetEnv);
+   OwningRewritePatternList patterns;
+-  patterns.insert<ProcessInterfaceVarABI>(context, typeConverter);
++  if (targetEnv.allows(spirv::Capability::Kernel)) {
++    // TODO Should it be the pattern that rejects/accepts depending on capabilities?
++    patterns.insert<ProcessInterfaceVarABIForOpenCL>(context, typeConverter);
++  } else {
++    patterns.insert<ProcessInterfaceVarABI>(context, typeConverter);
++  }
+ 
+   ConversionTarget target(*context);
+   // "Legal" function ops should have no interface variable ABI attributes.
+   target.addDynamicallyLegalOp<spirv::FuncOp>([&](spirv::FuncOp op) {
+-    StringRef attrName = spirv::getInterfaceVarABIAttrName();
+-    for (unsigned i = 0, e = op.getNumArguments(); i < e; ++i)
+-      if (op.getArgAttr(i, attrName))
+-        return false;
+-    return true;
++   StringRef attrName = spirv::getInterfaceVarABIAttrName();
++   for (unsigned i = 0, e = op.getNumArguments(); i < e; ++i)
++     if (op.getArgAttr(i, attrName))
++       return false;
++   return true;
+   });
+   // All other SPIR-V ops are legal.
+   target.markUnknownOpDynamicallyLegal([](Operation *op) {
+     return op->getDialect()->getNamespace() ==
+            spirv::SPIRVDialect::getDialectNamespace();
+   });

--- a/networks/oplib/resnet50.cc
+++ b/networks/oplib/resnet50.cc
@@ -28,7 +28,8 @@ edsl::Tensor block(             //
     bool use_shortcut_conv,     //
     StringRef base_name) {
   // Add a tracepoint for diagnostics
-  auto I = edsl::trace(I_raw, base_name.str());
+  // auto I = edsl::trace(I_raw, base_name.str());
+  auto I = I_raw;
   // Note: The branch1 weights/biases are at the _end_ of the input vectors,
   // as their existence depends on use_shortcut_conv
   auto conv_2a = op::convolution(I, W[0])
@@ -331,8 +332,10 @@ edsl::Program build(int64_t batch_size, const edsl::Tensor& I, ArrayRef<edsl::Te
   auto W_dense = W[53];
   auto B_dense = B[53];
   auto dense = op::dot(global_mean, W_dense) + B_dense;
-  auto softmax = op::softmax(dense, 1);
-  return edsl::ProgramBuilder("resnet50", {edsl::trace(softmax, "done")}).compile();
+  // op::softmax(dense, 1);
+  // return edsl::ProgramBuilder("resnet50", {edsl::trace(softmax, "done")}).compile();
+  auto softmax = dense;
+  return edsl::ProgramBuilder("resnet50", {softmax}).compile();
 }
 
 }  // namespace

--- a/networks/oplib/run.cc
+++ b/networks/oplib/run.cc
@@ -15,7 +15,8 @@ int main(int argc, char** argv) {
     plaidml::exec::init();
     auto program = networks::oplib::buildResnet50();
     // std::cout << program.str() << std::endl;
-    auto executable = plaidml::exec::Binder(program).compile();
+    auto binder = plaidml::exec::Binder(program);
+    auto executable = binder.compile();
     std::cout << "Running..." << std::endl;
     executable->run();
     return EXIT_SUCCESS;

--- a/plaidml/exec/BUILD
+++ b/plaidml/exec/BUILD
@@ -35,6 +35,7 @@ plaidml_cc_library(
         "//pmlc/compiler",
         "//pmlc/target/demo",
         "//pmlc/target/intel_gen",
+        "//pmlc/target/intel_gen_ocl_spirv",
         "//pmlc/target/x86",
         "//pmlc/util",
     ],

--- a/pmlc/BUILD
+++ b/pmlc/BUILD
@@ -41,10 +41,12 @@ plaidml_cc_library(
     name = "all_passes_and_dialects_no_registration",
     visibility = ["//visibility:public"],
     deps = [
+        "//pmlc/conversion/comp",
         "//pmlc/conversion/gpu",
         "//pmlc/conversion/pxa_to_affine",
         "//pmlc/conversion/stdx_to_llvm",
         "//pmlc/conversion/tile_to_pxa",
+        "//pmlc/dialect/comp",
         "//pmlc/dialect/eltwise",
         "//pmlc/dialect/pxa",
         "//pmlc/dialect/stdx",

--- a/pmlc/BUILD
+++ b/pmlc/BUILD
@@ -53,6 +53,7 @@ plaidml_cc_library(
         "//pmlc/dialect/tile",
         "//pmlc/dialect/xsmm",
         "//pmlc/target/intel_gen",
+        "//pmlc/target/intel_gen_ocl_spirv",
         "//pmlc/target/x86",
         "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
     ],

--- a/pmlc/conversion/comp/BUILD
+++ b/pmlc/conversion/comp/BUILD
@@ -1,0 +1,40 @@
+# Copyright 2020 Intel Corporation
+
+package(default_visibility = ["//visibility:public"])
+
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
+load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+gentbl(
+    name = "gen-pass",
+    tbl_outs = [
+        (
+            "-gen-pass-decls",
+            "passes.h.inc",
+        ),
+    ],
+    td_file = "passes.td",
+    td_srcs = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+plaidml_cc_library(
+    name = "comp",
+    srcs = [
+        "pass_detail.h",
+        "gpu_to_comp.cc",
+        "comp_to_opencl.cc",
+    ],
+    hdrs = [
+        "passes.h"
+    ],
+    deps = [
+        ":gen-pass",
+        "//pmlc/dialect/comp/ir",
+        "//pmlc/util",
+        "@llvm-project//mlir:GPUToSPIRVTransforms",
+        "@llvm-project//mlir:GPUTransforms",
+        "@llvm-project//mlir:LLVMTransforms",
+    ],
+)

--- a/pmlc/conversion/comp/comp_to_opencl.cc
+++ b/pmlc/conversion/comp/comp_to_opencl.cc
@@ -1,0 +1,626 @@
+// Copyright 2020, Intel Corporation
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
+#include "mlir/Dialect/SPIRV/Serialization.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "pmlc/conversion/comp/pass_detail.h"
+#include "pmlc/dialect/comp/ir/dialect.h"
+
+namespace pmlc::conversion::comp {
+
+namespace comp = pmlc::dialect::comp;
+namespace spirv = mlir::spirv;
+namespace LLVM = mlir::LLVM;
+namespace gpu = mlir::gpu;
+
+static constexpr const char *kSpirvBinPrefix = "_ocl_spirv_bin_";
+
+static constexpr const char *kOclInit = "oclInit";
+static constexpr const char *kOclDeinit = "oclDeinit";
+static constexpr const char *kOclCreateKernel = "oclCreateKernel";
+static constexpr const char *kOclEnqueueKernel = "oclEnqueueKernel";
+static constexpr const char *kOclSetKernelArg = "oclSetKernelArg";
+static constexpr const char *kOclAllocBuffer = "oclAllocBuffer";
+static constexpr const char *kOclDeallocBuffer = "oclDeallocBuffer";
+static constexpr const char *kOclEnqueueRead = "oclEnqueueRead";
+static constexpr const char *kOclEnqueueWrite = "oclEnqueueWrite";
+static constexpr const char *kOclGroupEvents = "oclGroupEvents";
+static constexpr const char *kOclWait = "oclWait";
+
+struct HelperCache {
+  void init(mlir::MLIRContext &context) {
+    llvmDialect = context.getRegisteredDialect<LLVM::LLVMDialect>();
+    llvmVoidType = LLVM::LLVMType::getVoidTy(llvmDialect);
+    llvmPointerType = LLVM::LLVMType::getInt8PtrTy(llvmDialect);
+    llvmInt8Type = LLVM::LLVMType::getInt8Ty(llvmDialect);
+    llvmInt32Type = LLVM::LLVMType::getInt32Ty(llvmDialect);
+    llvmInt64Type = LLVM::LLVMType::getInt64Ty(llvmDialect);
+    mlirIndexType = mlir::IndexType::get(&context);
+  }
+
+  LLVM::LLVMDialect *llvmDialect;
+  LLVM::LLVMType llvmVoidType;
+  LLVM::LLVMType llvmPointerType;
+  LLVM::LLVMType llvmInt8Type;
+  LLVM::LLVMType llvmInt32Type;
+  LLVM::LLVMType llvmInt64Type;
+  mlir::Type mlirIndexType;
+};
+
+class ConvertCompToOpenCl
+    : public ConvertCompToOpenClBase<ConvertCompToOpenCl> {
+public:
+  void runOnOperation() override;
+
+  mlir::LogicalResult serializeSpirvKernel(spirv::ModuleOp moduleOp);
+  mlir::LogicalResult convertCompOps();
+  void declareOpenClFunctions();
+
+  HelperCache helperCache;
+
+  LLVM::LLVMDialect *getLLVMDialect() { return helperCache.llvmDialect; }
+  LLVM::LLVMType getLLVMVoidType() { return helperCache.llvmVoidType; }
+  LLVM::LLVMType getLLVMPointerType() { return helperCache.llvmPointerType; }
+  LLVM::LLVMType getLLVMInt8Type() { return helperCache.llvmInt8Type; }
+  LLVM::LLVMType getLLVMInt32Type() { return helperCache.llvmInt32Type; }
+  mlir::Type getMLIRIndexType() { return helperCache.mlirIndexType; }
+
+  struct BinaryKernelInfo {
+    LLVM::GlobalOp symbol;
+    size_t bytes;
+  };
+
+  using KernelsMap = std::map<std::string, BinaryKernelInfo>;
+  KernelsMap kernelsMap;
+};
+
+void ConvertCompToOpenCl::runOnOperation() {
+  helperCache.init(getContext());
+
+  auto moduleOp = getOperation();
+  auto serializationWalk =
+      moduleOp.walk([&](spirv::ModuleOp op) -> mlir::WalkResult {
+        return serializeSpirvKernel(op);
+      });
+  if (serializationWalk.wasInterrupted())
+    signalPassFailure();
+  if (mlir::failed(convertCompOps()))
+    signalPassFailure();
+  declareOpenClFunctions();
+}
+
+mlir::LogicalResult
+ConvertCompToOpenCl::serializeSpirvKernel(spirv::ModuleOp moduleOp) {
+  // Serialize kernel
+  mlir::SmallVector<uint32_t, 0> moduleBinary;
+  if (mlir::failed(spirv::serialize(moduleOp, moduleBinary)))
+    return mlir::failure();
+
+  // Add it to current top module
+  auto gpuModule =
+      mlir::dyn_cast<gpu::GPUModuleOp>(moduleOp.getOperation()->getNextNode());
+  if (!gpuModule)
+    return mlir::failure(); // This is a hack due to how kernel outlining works
+  std::string gpuModuleName = static_cast<std::string>(gpuModule.getName());
+  std::string binaryName = kSpirvBinPrefix + gpuModuleName;
+
+  auto topModule = getOperation();
+  auto llvmDialect = getContext().getRegisteredDialect<LLVM::LLVMDialect>();
+  mlir::OpBuilder builder(topModule.getBodyRegion());
+
+  auto binaryType =
+      LLVM::LLVMType::getArrayTy(getLLVMInt8Type(), moduleBinary.size() * 4);
+
+  auto binaryOp = builder.create<LLVM::GlobalOp>(
+      moduleOp.getLoc(), binaryType,
+      /*isConstant=*/true, LLVM::Linkage::Internal, binaryName,
+      builder.getStringAttr({reinterpret_cast<char *>(moduleBinary.data()),
+                             moduleBinary.size() * 4}));
+
+  // Update kernels map
+  kernelsMap[gpuModuleName] = {binaryOp, moduleBinary.size() * 4};
+
+  return mlir::success();
+}
+
+void ConvertCompToOpenCl::declareOpenClFunctions() {
+  auto module = getOperation();
+  auto loc = module.getLoc();
+  mlir::OpBuilder builder(module.getBody()->getTerminator());
+
+  if (!module.lookupSymbol(kOclInit)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclInit,
+        LLVM::LLVMType::getFunctionTy(getLLVMPointerType(), {},
+                                      /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclDeinit)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclDeinit,
+        LLVM::LLVMType::getFunctionTy(getLLVMVoidType(), {getLLVMPointerType()},
+                                      /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclCreateKernel)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclCreateKernel,
+        LLVM::LLVMType::getFunctionTy(
+            getLLVMPointerType(),
+            {getLLVMPointerType(), getLLVMPointerType(), getLLVMInt32Type()},
+            /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclEnqueueKernel)) {
+    auto &ctx = getContext();
+
+    builder.create<mlir::FuncOp>(
+        loc, kOclEnqueueKernel,
+        mlir::FunctionType::get(
+            mlir::ArrayRef<mlir::Type>{
+                getLLVMPointerType(), getLLVMPointerType(), getMLIRIndexType(),
+                getMLIRIndexType(), getMLIRIndexType(), getMLIRIndexType(),
+                getMLIRIndexType(), getMLIRIndexType(), getLLVMPointerType()},
+            {getLLVMPointerType()}, &ctx),
+        mlir::ArrayRef<std::pair<mlir::Identifier, mlir::Attribute>>());
+  }
+
+  if (!module.lookupSymbol(kOclSetKernelArg)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclSetKernelArg,
+        LLVM::LLVMType::getFunctionTy(getLLVMVoidType(),
+                                      {getLLVMPointerType(),
+                                       getLLVMPointerType(), getLLVMInt32Type(),
+                                       getLLVMPointerType()},
+                                      /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclAllocBuffer)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclAllocBuffer,
+        LLVM::LLVMType::getFunctionTy(
+            getLLVMPointerType(),
+            {getLLVMPointerType(), getLLVMInt32Type(), getLLVMPointerType()},
+            /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclDeallocBuffer)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclDeallocBuffer,
+        LLVM::LLVMType::getFunctionTy(getLLVMVoidType(), {getLLVMPointerType()},
+                                      /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclEnqueueRead)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclEnqueueRead,
+        LLVM::LLVMType::getFunctionTy(
+            getLLVMPointerType(),
+            {getLLVMPointerType(), getLLVMPointerType(), getLLVMPointerType(),
+             getLLVMPointerType()},
+            /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclEnqueueWrite)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclEnqueueWrite,
+        LLVM::LLVMType::getFunctionTy(
+            getLLVMPointerType(),
+            {getLLVMPointerType(), getLLVMPointerType(), getLLVMPointerType(),
+             getLLVMPointerType()},
+            /*isVarArg=*/false));
+  }
+
+  if (!module.lookupSymbol(kOclGroupEvents)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclGroupEvents,
+        LLVM::LLVMType::getFunctionTy(getLLVMPointerType(),
+                                      {getLLVMInt32Type()},
+                                      /*isVarArg=*/true));
+  }
+
+  if (!module.lookupSymbol(kOclWait)) {
+    builder.create<LLVM::LLVMFuncOp>(
+        loc, kOclWait,
+        LLVM::LLVMType::getFunctionTy(getLLVMVoidType(), {getLLVMPointerType()},
+                                      /*isVarArg=*/false));
+  }
+}
+
+struct CompLLVMTypeConverter : public mlir::TypeConverter {
+  explicit CompLLVMTypeConverter(HelperCache &helperCache)
+      : helperCache(helperCache) {
+    addConversion(
+        [&](comp::ExecEnvType) { return helperCache.llvmPointerType; });
+    addConversion([&](comp::EventType) { return helperCache.llvmPointerType; });
+    addConversion([&](mlir::MemRefType mem) {
+      return helperCache.llvmInt8Type.getPointerTo(mem.getMemorySpace());
+    });
+
+    // addMaterialization([&](mlir::PatternRewriter& rewriter,
+    //                        mlir::MemRefType memType,
+    //                        mlir::ValueRange memVals,
+    //                        mlir::Location loc) {
+    //   mlir::LLVMTypeConverter llvmConverter;
+    //   auto structMemType = llvmConverter.convertType(memType);
+    //   auto structMemRef = rewriter.create<LLVM::DialectCastOp>(loc,
+    //   structMemType, memVals[0]); auto bufferDesc =
+    //   mlir::MemRefDescriptor(structMemRef); auto flatMemAllocPtr =
+    //   bufferDesc.allocatedPtr(rewriter, loc); memPtr =
+    //   rewriter.create<LLVM::BitcastOp>(
+    //     loc, convertType(memType), flatMemAllocPtr
+    //   );
+    //   return memPtr;
+    // });
+  }
+
+  HelperCache &helperCache;
+};
+
+struct ConvertCreateExecEnv
+    : public mlir::OpConversionPattern<comp::CreateExecEnv> {
+  ConvertCreateExecEnv(mlir::MLIRContext *context, HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::CreateExecEnv>(context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::CreateExecEnv op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertDestroyExecEnv
+    : public mlir::OpConversionPattern<comp::DestroyExecEnv> {
+  ConvertDestroyExecEnv(mlir::MLIRContext *context, HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::DestroyExecEnv>(context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::DestroyExecEnv op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertAlloc : public mlir::OpConversionPattern<comp::Alloc> {
+  ConvertAlloc(mlir::MLIRContext *context, CompLLVMTypeConverter &converter,
+               HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::Alloc>(converter, context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::Alloc op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertDealloc : public mlir::OpConversionPattern<comp::Dealloc> {
+  ConvertDealloc(mlir::MLIRContext *context, HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::Dealloc>(context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::Dealloc op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertScheduleRead
+    : public mlir::OpConversionPattern<comp::ScheduleRead> {
+  ConvertScheduleRead(mlir::MLIRContext *context,
+                      CompLLVMTypeConverter &converter,
+                      HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::ScheduleRead>(converter, context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::ScheduleRead op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertWait : public mlir::OpConversionPattern<comp::Wait> {
+  ConvertWait(mlir::MLIRContext *context, HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::Wait>(context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::Wait op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+struct ConvertScheduleFunc
+    : public mlir::OpConversionPattern<comp::ScheduleFunc> {
+  ConvertScheduleFunc(mlir::MLIRContext *context, HelperCache &helperCache,
+                      ConvertCompToOpenCl::KernelsMap &kernelsMap)
+      : mlir::OpConversionPattern<comp::ScheduleFunc>(context),
+        helperCache(helperCache), kernelsMap(kernelsMap) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::ScheduleFunc op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+  ConvertCompToOpenCl::KernelsMap &kernelsMap;
+};
+
+struct ConvertGroupEvents
+    : public mlir::OpConversionPattern<comp::GroupEvents> {
+  ConvertGroupEvents(mlir::MLIRContext *context, HelperCache &helperCache)
+      : mlir::OpConversionPattern<comp::GroupEvents>(context),
+        helperCache(helperCache) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::GroupEvents op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const;
+
+  HelperCache &helperCache;
+};
+
+template <typename SourceOp>
+struct RemoveOpPattern : public mlir::OpConversionPattern<SourceOp> {
+  using mlir::OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(SourceOp op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op.getOperation());
+    return mlir::success();
+  }
+};
+
+mlir::LogicalResult ConvertCreateExecEnv::matchAndRewrite(
+    comp::CreateExecEnv op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(),
+      mlir::ArrayRef<mlir::Type>{helperCache.llvmPointerType},
+      rewriter.getSymbolRefAttr(kOclInit), mlir::ArrayRef<mlir::Value>{});
+  std::cout << "Replace" << std::endl;
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertDestroyExecEnv::matchAndRewrite(
+    comp::DestroyExecEnv op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(), mlir::ArrayRef<mlir::Type>{},
+      rewriter.getSymbolRefAttr(kOclDeinit),
+      mlir::ArrayRef<mlir::Value>{operands[0]});
+  return mlir::success();
+}
+
+mlir::LogicalResult
+ConvertAlloc::matchAndRewrite(comp::Alloc op,
+                              mlir::ArrayRef<mlir::Value> operands,
+                              mlir::ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto &converter = *getTypeConverter();
+  auto memRefType = op.getResult().getType().cast<mlir::MemRefType>();
+
+  auto shape = memRefType.getShape();
+  uint32_t numElement = 1;
+  for (auto dim : shape) {
+    numElement *= dim;
+  }
+
+  uint32_t elementTypeSize =
+      llvm::divideCeil(memRefType.getElementTypeBitWidth(), 8);
+
+  mlir::Value bufferByteSize = rewriter.create<LLVM::ConstantOp>(
+      loc, helperCache.llvmInt32Type,
+      rewriter.getI32IntegerAttr(numElement * elementTypeSize));
+
+  mlir::Value hostPtr;
+  if (auto hostMem = op.hostMem()) {
+    mlir::LLVMTypeConverter llvmConverter(rewriter.getContext());
+    auto hostType = hostMem.getType().cast<mlir::MemRefType>();
+    // hostPtr = getTypeConverter()->materializeConversion(rewriter, loc,
+    // getTypeConverter()->convertType(hostType), {hostMem});
+    auto structMemRef = rewriter.create<LLVM::DialectCastOp>(
+        loc, llvmConverter.convertType(hostType), hostMem);
+    auto bufferDesc = mlir::MemRefDescriptor(structMemRef);
+    auto flatMemAllocPtr = bufferDesc.allocatedPtr(rewriter, loc);
+    hostPtr = rewriter.create<LLVM::BitcastOp>(
+        loc, converter.convertType(hostType), flatMemAllocPtr);
+  } else {
+    hostPtr = rewriter.create<LLVM::NullOp>(loc, helperCache.llvmPointerType);
+  }
+
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(),
+      mlir::ArrayRef<mlir::Type>{helperCache.llvmPointerType},
+      rewriter.getSymbolRefAttr(kOclAllocBuffer),
+      mlir::ArrayRef<mlir::Value>{operands[0], bufferByteSize, hostPtr});
+
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertDealloc::matchAndRewrite(
+    comp::Dealloc op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(), mlir::ArrayRef<mlir::Type>{},
+      rewriter.getSymbolRefAttr(kOclDeallocBuffer),
+      mlir::ArrayRef<mlir::Value>(operands[0]));
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertScheduleRead::matchAndRewrite(
+    comp::ScheduleRead op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  mlir::LLVMTypeConverter llvmConverter(rewriter.getContext());
+  auto &converter = *getTypeConverter();
+  auto hostMem = op.hostMem();
+  auto hostType = hostMem.getType().cast<mlir::MemRefType>();
+  // hostPtr = getTypeConverter()->materializeConversion(rewriter, loc,
+  // getTypeConverter()->convertType(hostType), {hostMem});
+  auto structMemRef = rewriter.create<LLVM::DialectCastOp>(
+      loc, llvmConverter.convertType(hostType), hostMem);
+  auto bufferDesc = mlir::MemRefDescriptor(structMemRef);
+  auto flatMemAllocPtr = bufferDesc.allocatedPtr(rewriter, loc);
+  auto hostPtr = rewriter.create<LLVM::BitcastOp>(
+      loc, converter.convertType(hostType), flatMemAllocPtr);
+
+  mlir::Value depPtr;
+  if (auto depEvent = op.depEvent()) {
+    depPtr = operands[3];
+  } else {
+    depPtr =
+        rewriter.create<LLVM::NullOp>(op.getLoc(), helperCache.llvmPointerType);
+  }
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(),
+      mlir::ArrayRef<mlir::Type>(helperCache.llvmPointerType),
+      rewriter.getSymbolRefAttr(kOclEnqueueRead),
+      mlir::ArrayRef<mlir::Value>{operands[2], operands[1], hostPtr, depPtr});
+  return mlir::success();
+}
+
+mlir::LogicalResult
+ConvertWait::matchAndRewrite(comp::Wait op,
+                             mlir::ArrayRef<mlir::Value> operands,
+                             mlir::ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(), mlir::ArrayRef<mlir::Type>{},
+      rewriter.getSymbolRefAttr(kOclWait),
+      mlir::ArrayRef<mlir::Value>{operands[0]});
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertScheduleFunc::matchAndRewrite(
+    comp::ScheduleFunc op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  auto loc = op.getLoc();
+  auto execEnv = operands[0];
+  auto launchOp = mlir::cast<gpu::LaunchFuncOp>(op.body().front().front());
+  auto binaryName = static_cast<std::string>(launchOp.getKernelModuleName());
+  if (kernelsMap.count(binaryName) == 0)
+    return mlir::failure();
+  auto &kernelInfo = kernelsMap[binaryName];
+  // Get the pointer to the first character in the global string.
+  mlir::Value globalPtr =
+      rewriter.create<LLVM::AddressOfOp>(loc, kernelInfo.symbol);
+  mlir::Value cst0 = rewriter.create<LLVM::ConstantOp>(
+      loc, helperCache.llvmInt64Type,
+      rewriter.getIntegerAttr(rewriter.getIndexType(), 0));
+  mlir::Value binaryPtr =
+      rewriter.create<LLVM::GEPOp>(loc, helperCache.llvmPointerType, globalPtr,
+                                   mlir::ArrayRef<mlir::Value>({cst0, cst0}));
+
+  // mlir::Value binaryPtr = rewriter.create<LLVM::NullOp>(
+  //   loc, helperCache.llvmPointerType);
+  mlir::Value binarySize = rewriter.create<LLVM::ConstantOp>(
+      loc, helperCache.llvmInt32Type,
+      rewriter.getI32IntegerAttr(kernelInfo.bytes));
+  auto createOp = rewriter.create<LLVM::CallOp>(
+      loc, mlir::ArrayRef<mlir::Type>{helperCache.llvmPointerType},
+      rewriter.getSymbolRefAttr(kOclCreateKernel),
+      mlir::ArrayRef<mlir::Value>{execEnv, binaryPtr, binarySize});
+  auto kernel = createOp.getResult(0);
+  // // set args
+  for (unsigned argI = 0; argI < launchOp.getNumKernelOperands(); ++argI) {
+    mlir::Value argIndex = rewriter.create<LLVM::ConstantOp>(
+        loc, helperCache.llvmInt32Type, rewriter.getI32IntegerAttr(argI));
+
+    rewriter.create<LLVM::CallOp>(
+        loc, mlir::ArrayRef<mlir::Type>{},
+        rewriter.getSymbolRefAttr(kOclSetKernelArg),
+        mlir::ArrayRef<mlir::Value>{execEnv, kernel, argIndex,
+                                    launchOp.getKernelOperand(argI)});
+  }
+
+  auto gridSize = launchOp.getGridSizeOperandValues();
+  auto blockSize = launchOp.getBlockSizeOperandValues();
+  auto globalX = rewriter.create<mlir::MulIOp>(loc, gridSize.x, blockSize.x);
+  auto globalY = rewriter.create<mlir::MulIOp>(loc, gridSize.y, blockSize.y);
+  auto globalZ = rewriter.create<mlir::MulIOp>(loc, gridSize.z, blockSize.z);
+
+  mlir::Value depPtr;
+  if (auto depEvent = op.depEvent()) {
+    depPtr = operands[1];
+  } else {
+    depPtr =
+        rewriter.create<LLVM::NullOp>(op.getLoc(), helperCache.llvmPointerType);
+  }
+
+  rewriter.replaceOpWithNewOp<mlir::CallOp>(
+      op.getOperation(),
+      mlir::ArrayRef<mlir::Type>{helperCache.llvmPointerType},
+      rewriter.getSymbolRefAttr(kOclEnqueueKernel),
+      mlir::ArrayRef<mlir::Value>{execEnv, kernel, globalX, globalY, globalZ,
+                                  blockSize.x, blockSize.y, blockSize.z,
+                                  depPtr});
+  // rewriter.replaceOpWithNewOp<LLVM::NullOp>(op.getOperation(),
+  // helperCache.llvmPointerType);
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertGroupEvents::matchAndRewrite(
+    comp::GroupEvents op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  std::vector<mlir::Value> callOperands;
+  mlir::Value eventsCnt = rewriter.create<LLVM::ConstantOp>(
+      op.getLoc(), helperCache.llvmInt32Type,
+      rewriter.getI32IntegerAttr(operands.size()));
+
+  callOperands.push_back(eventsCnt);
+
+  for (auto &operand : operands) {
+    callOperands.push_back(operand);
+  }
+
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(),
+      mlir::ArrayRef<mlir::Type>{helperCache.llvmPointerType},
+      rewriter.getSymbolRefAttr(kOclGroupEvents),
+      mlir::ArrayRef<mlir::Value>(callOperands));
+
+  return mlir::success();
+}
+
+mlir::LogicalResult ConvertCompToOpenCl::convertCompOps() {
+  mlir::ConversionTarget target(getContext());
+  target.addLegalDialect<LLVM::LLVMDialect>();
+  target.addLegalDialect<mlir::StandardOpsDialect>();
+  target.addIllegalDialect<comp::COMPDialect>();
+
+  CompLLVMTypeConverter typeConverter(helperCache);
+
+  mlir::OwningRewritePatternList patterns;
+  patterns.insert<ConvertCreateExecEnv, ConvertDestroyExecEnv, ConvertDealloc,
+                  ConvertWait, ConvertGroupEvents>(&getContext(), helperCache);
+  patterns.insert<ConvertAlloc, ConvertScheduleRead>(
+      &getContext(), typeConverter, helperCache);
+  patterns.insert<ConvertScheduleFunc>(&getContext(), helperCache, kernelsMap);
+  patterns.insert<RemoveOpPattern<gpu::GPUModuleOp>,
+                  RemoveOpPattern<spirv::ModuleOp>>(&getContext());
+
+  if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,
+                                                patterns, nullptr)))
+    return mlir::failure();
+
+  return mlir::success();
+}
+
+std::unique_ptr<mlir::Pass> createConvertCompToOpenClPass() {
+  return std::make_unique<ConvertCompToOpenCl>();
+}
+
+} // namespace pmlc::conversion::comp

--- a/pmlc/conversion/comp/gpu_to_comp.cc
+++ b/pmlc/conversion/comp/gpu_to_comp.cc
@@ -1,0 +1,324 @@
+// Copyright 2020, Intel Corporation
+#include <iostream>
+#include <vector>
+
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "pmlc/conversion/comp/pass_detail.h"
+#include "pmlc/dialect/comp/ir/dialect.h"
+
+namespace pmlc::conversion::comp {
+
+namespace comp = pmlc::dialect::comp;
+namespace gpu = mlir::gpu;
+
+class ConvertGpuToComp : public ConvertGpuToCompBase<ConvertGpuToComp> {
+public:
+  void runOnOperation();
+};
+
+namespace {
+
+struct RewriteLaunchFunc : public mlir::OpRewritePattern<gpu::LaunchFuncOp> {
+  /// Rewrite gpu.launch_func into chain of comp dialect operations.
+  /// Wraps original launch operation into comp.schedule_func.
+  /// Execution environment and device memory are created and destroyed
+  /// separately for each launch_func, so further optimizations to reuse are
+  /// needed.
+  RewriteLaunchFunc(mlir::MLIRContext *context, comp::ExecEnvType execEnvType)
+      : mlir::OpRewritePattern<gpu::LaunchFuncOp>(context),
+        execEnvType(execEnvType) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(gpu::LaunchFuncOp op,
+                  mlir::PatternRewriter &rewriter) const override;
+
+  comp::ExecEnvType execEnvType;
+};
+
+struct RewriteGpuFunc : public mlir::OpConversionPattern<gpu::GPUFuncOp> {
+  /// Update gpu.func to signature with memrefs in device memory space.
+  RewriteGpuFunc(mlir::MLIRContext *context, unsigned memorySpace)
+      : mlir::OpConversionPattern<gpu::GPUFuncOp>(context),
+        memorySpace(memorySpace) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(gpu::GPUFuncOp op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const override;
+  unsigned memorySpace;
+};
+
+struct ReuseExecEnv : public mlir::OpRewritePattern<comp::DestroyExecEnv> {
+  /// Rewrites environment destruction and creation into reuse of previously
+  /// created environment. Does not cross block boundaries.
+  using mlir::OpRewritePattern<comp::DestroyExecEnv>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::DestroyExecEnv op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+struct ReuseAllocatedMemory : public mlir::OpRewritePattern<comp::Dealloc> {
+  /// Rewrites chain of device memory dealloc and alloc into reuse of previously
+  /// allocated memory. Does not cross block boundaries.
+  using mlir::OpRewritePattern<comp::Dealloc>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::Dealloc op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+} // namespace
+
+mlir::LogicalResult
+RewriteLaunchFunc::matchAndRewrite(gpu::LaunchFuncOp op,
+                                   mlir::PatternRewriter &rewriter) const {
+  // Replace gpu.launch_func %indexes..., %args... with:
+  // %env = comp.create_execenv
+  // %new_args = (comp.alloc %env %args)...
+  // %ev = comp.schedule_func %env {
+  //   gpu.launch_func %indexes..., %new_args...
+  // }
+  // %wr_events = comp.schedule_read %new_args to %args on %env wait for %ev
+  // %final_ev = comp.group_events %wr_events...
+  // comp.wait %final_ev
+  // comp.dealloc %new_args...
+  // comp.destroy_execenv %env
+
+  auto loc = op.getLoc();
+  auto context = rewriter.getContext();
+  auto runtime = execEnvType.getRuntime();
+
+  // Create execution environment
+  // TODO How to control what execenv gets created?
+  auto execEnvOp = rewriter.create<comp::CreateExecEnv>(loc, execEnvType);
+  auto execEnv = execEnvOp.getResult();
+  auto eventType = rewriter.getType<comp::EventType>(runtime);
+
+  // Allocate memory on device
+  std::vector<mlir::Value> newOperands;
+  std::vector<mlir::Value> allocOriginal;
+  std::vector<mlir::Value> allocNew;
+  newOperands.reserve(op.getNumKernelOperands());
+  for (auto &operand : op.getOperands()) {
+    if (auto memRefType =
+            operand.getType().dyn_cast_or_null<mlir::MemRefType>()) {
+      mlir::MemRefType newMemRefType =
+          mlir::MemRefType::Builder(memRefType)
+              .setMemorySpace(execEnvType.getDefaultMemorySpace());
+      auto allocOp =
+          rewriter.create<comp::Alloc>(loc, newMemRefType, execEnv, operand);
+      auto newMemRef = allocOp.getResult();
+      newOperands.push_back(newMemRef);
+      allocOriginal.push_back(operand);
+      allocNew.push_back(newMemRef);
+    } else {
+      newOperands.push_back(operand);
+    }
+  }
+  // Update operands for launch
+  op.getOperation()->setOperands(newOperands);
+  mlir::SymbolRefAttr kernel = op.kernel();
+
+  // Move original op into schedule func
+  auto scheduleFuncOp = rewriter.create<comp::ScheduleFunc>(
+      loc, eventType, execEnv, mlir::Value());
+  auto postScheduleIP = rewriter.saveInsertionPoint();
+  auto newBlock =
+      rewriter.createBlock(&scheduleFuncOp.body(), scheduleFuncOp.body().end());
+  // TODO Is there a better way to move operation into block insted of
+  // clone->erase
+  newBlock->push_back(op.clone());
+  rewriter.create<comp::ScheduleEnd>(loc);
+  // TODO Isn't there RAII-idiomatic way to save/restore insertion point
+  rewriter.restoreInsertionPoint(postScheduleIP);
+  auto funcEvent = scheduleFuncOp.getResult();
+  // Read back the memory
+  std::vector<mlir::Value> readEvents;
+  readEvents.reserve(allocNew.size());
+  for (size_t allocIdx = 0; allocIdx < allocNew.size(); ++allocIdx) {
+    auto &allocated = allocNew[allocIdx];
+    auto &original = allocOriginal[allocIdx];
+    auto readOp = rewriter.create<comp::ScheduleRead>(
+        loc, eventType, original, allocated, execEnv, funcEvent);
+    readEvents.push_back(readOp.getResult());
+  }
+  // Wait for all operations to finish
+  auto groupOp = rewriter.create<comp::GroupEvents>(loc, eventType, readEvents);
+  auto allEvent = groupOp.getResult();
+  rewriter.create<comp::Wait>(loc, allEvent);
+  // Deallocate memory on device
+  for (size_t allocIdx = 0; allocIdx < allocNew.size(); ++allocIdx) {
+    auto &allocated = allocNew[allocIdx];
+    rewriter.create<comp::Dealloc>(loc, allocated);
+  }
+  // Destroy environment
+  rewriter.create<comp::DestroyExecEnv>(loc, execEnv);
+  // Remove original op
+  rewriter.eraseOp(op.getOperation());
+  return mlir::success();
+}
+
+mlir::LogicalResult RewriteGpuFunc::matchAndRewrite(
+    gpu::GPUFuncOp op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::TypeConverter converter;
+  // Default pass-through conversion
+  converter.addConversion([](mlir::Type type) { return type; });
+  // Change memrefs memory space
+  converter.addConversion([&](mlir::MemRefType type) {
+    return mlir::MemRefType::get(type.getShape(), type.getElementType(),
+                                 type.getAffineMaps(), memorySpace);
+  });
+
+  auto funcType = op.getType();
+  mlir::TypeConverter::SignatureConversion signatureConversion(
+      funcType.getNumInputs());
+  for (auto argType : llvm::enumerate(funcType.getInputs())) {
+    auto convertedType = converter.convertType(argType.value());
+    signatureConversion.addInputs(argType.index(), convertedType);
+  }
+
+  if (mlir::failed(rewriter.convertRegionTypes(&op.body(), converter,
+                                               &signatureConversion)))
+    return mlir::failure();
+
+  // gpu.func_op should have no results
+  rewriter.updateRootInPlace(op, [&] {
+    op.setType(
+        rewriter.getFunctionType(signatureConversion.getConvertedTypes(), {}));
+  });
+
+  return mlir::success();
+}
+
+mlir::LogicalResult
+ReuseExecEnv::matchAndRewrite(comp::DestroyExecEnv op,
+                              mlir::PatternRewriter &rewriter) const {
+  // Pattern:
+  // comp.destroy_execenv %env1 : execenv<A>
+  // %env2 = comp.create_execenv : execenv<A>
+  auto destroyEnv = op.execEnv();
+  auto destroyType = destroyEnv.getType();
+
+  auto operation = op.getOperation()->getNextNode();
+  while (operation) {
+    if (auto createOp = mlir::dyn_cast<comp::CreateExecEnv>(operation)) {
+      auto createType = createOp.execEnv().getType();
+      if (createType == destroyType) {
+        rewriter.replaceOp(operation, {destroyEnv});
+        rewriter.eraseOp(op);
+        return mlir::success();
+      }
+    }
+
+    operation = operation->getNextNode();
+  }
+  return mlir::failure();
+}
+
+mlir::LogicalResult
+ReuseAllocatedMemory::matchAndRewrite(comp::Dealloc op,
+                                      mlir::PatternRewriter &rewriter) const {
+  // Pattern:
+  // %device = comp.alloc %env %host
+  // ... (1) - use %device
+  // comp.dealloc %device
+  // ... (2) - use %host
+  // %device2 = comp.alloc %env %host
+  // ... (3) - use %device2
+  // comp.dealloc %device2
+  //
+  // Into:
+  // %device = comp.alloc %env %host
+  // ... (1)
+  // ... (2)
+  // %ev = comp.write %host %device
+  // comp.wait %ev
+  // ... (3)
+  // comp.dealloc %device
+
+  auto deviceMem = op.deviceMem();
+  auto allocOp = mlir::cast<comp::Alloc>(deviceMem.getDefiningOp());
+  if (!allocOp)
+    return mlir::failure();
+  auto hostMem = allocOp.hostMem();
+  auto execEnv = allocOp.execEnv();
+  auto execEnvType = execEnv.getType().cast<comp::ExecEnvType>();
+  auto eventType = rewriter.getType<comp::EventType>(execEnvType.getRuntime());
+
+  // TODO More general memory reuse
+  if (!hostMem)
+    return mlir::failure();
+
+  auto operation = op.getOperation()->getNextNode();
+  while (operation) {
+    if (auto secondAlloc = mlir::dyn_cast<comp::Alloc>(operation)) {
+      if (secondAlloc.hostMem() == hostMem &&
+          secondAlloc.execEnv() == execEnv) {
+        rewriter.setInsertionPoint(operation);
+        auto writeOp = rewriter.create<comp::ScheduleWrite>(
+            operation->getLoc(), eventType, hostMem, deviceMem, execEnv,
+            mlir::Value());
+        auto writeEvent = writeOp.getResult();
+        rewriter.create<comp::Wait>(operation->getLoc(), writeEvent);
+        rewriter.eraseOp(op);
+        rewriter.replaceOp(operation, deviceMem);
+        return mlir::success();
+      }
+    }
+
+    operation = operation->getNextNode();
+  }
+  return mlir::failure();
+}
+
+void ConvertGpuToComp::runOnOperation() {
+  comp::ExecEnvRuntime runtime =
+      static_cast<comp::ExecEnvRuntime>(execEnvRuntime.getValue());
+  unsigned memorySpace = execEnvMemorySpace.getValue();
+  auto execEnvType =
+      comp::ExecEnvType::get(&getContext(), runtime, 0, {memorySpace});
+
+  mlir::ConversionTarget target(getContext());
+  target.addLegalDialect<comp::COMPDialect>();
+  target.addLegalDialect<gpu::GPUDialect>();
+  target.addDynamicallyLegalOp<gpu::LaunchFuncOp>(
+      [](gpu::LaunchFuncOp op) -> bool {
+        auto parent = op.getParentOp();
+        return parent && mlir::isa<comp::ScheduleFunc>(parent);
+      });
+  target.addDynamicallyLegalOp<gpu::GPUFuncOp>([&](gpu::GPUFuncOp op) -> bool {
+    for (auto arg : op.getArguments()) {
+      if (auto memRefType =
+              arg.getType().dyn_cast_or_null<mlir::MemRefType>()) {
+        if (memorySpace != memRefType.getMemorySpace())
+          return false;
+      }
+    }
+    return true;
+  });
+  target.addIllegalOp<gpu::LaunchOp>();
+  // Everything else should be legal
+  target.markUnknownOpDynamicallyLegal([](mlir::Operation *) { return true; });
+
+  // Setup rewrite patterns
+  mlir::OwningRewritePatternList patterns;
+  patterns.insert<RewriteLaunchFunc>(&getContext(), execEnvType);
+  patterns.insert<RewriteGpuFunc>(&getContext(), memorySpace);
+
+  // Run the conversion
+  if (mlir::failed(
+          mlir::applyFullConversion(getOperation(), target, patterns))) {
+    signalPassFailure();
+  }
+}
+
+std::unique_ptr<mlir::Pass> createConvertGpuToCompPass() {
+  return std::make_unique<ConvertGpuToComp>();
+}
+
+} // namespace pmlc::conversion::comp

--- a/pmlc/conversion/comp/pass_detail.h
+++ b/pmlc/conversion/comp/pass_detail.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+namespace pmlc::conversion::comp {
+
+#define GEN_PASS_CLASSES
+#include "pmlc/conversion/comp/passes.h.inc"
+
+} // namespace pmlc::conversion::comp

--- a/pmlc/conversion/comp/passes.h
+++ b/pmlc/conversion/comp/passes.h
@@ -1,0 +1,17 @@
+// Copyright 2020, Intel Corporation
+
+#pragma once
+
+#include <memory>
+
+namespace mlir {
+class Pass;
+} // namespace mlir
+
+namespace pmlc::conversion::comp {
+
+std::unique_ptr<mlir::Pass> createConvertGpuToCompPass();
+
+std::unique_ptr<mlir::Pass> createConvertCompToOpenClPass();
+
+} // namespace pmlc::conversion::comp

--- a/pmlc/conversion/comp/passes.td
+++ b/pmlc/conversion/comp/passes.td
@@ -1,0 +1,22 @@
+#ifndef __PMLC_CONVERSION_GPU_TO_COMP_PASSES__
+#define __PMLC_CONVERSION_GPU_TO_COMP_PASSES__
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertGpuToComp : Pass<"pmlc-convert-gpu-to-comp", "mlir::ModuleOp"> {
+  let summary = "Convert gpu operations to comp operations";
+  let constructor = "pmlc::conversion::comp::createConvertGpuToCompPass()";
+  let options = [
+    Option<"execEnvRuntime", "comp-execenv-runtime", "unsigned",
+           /*default=*/"0", "Runtime to use for gpu kernels.">,
+    Option<"execEnvMemorySpace", "comp-execenv-memory-space", "unsigned",
+           /*default=*/"0", "Memory space to use for data transferred to device.">
+  ];
+}
+
+def ConvertCompToOpenCl : Pass<"pmlc-convert-comp-to-opencl", "mlir::ModuleOp"> {
+  let summary = "TODO";
+  let constructor = "pmlc::conversion::comp::createConvertCompToOpenClPass()";
+}
+
+#endif // __PMLC_CONVERSION_GPU_TO_VULKAN_PASSES__

--- a/pmlc/conversion/comp/tests/BUILD
+++ b/pmlc/conversion/comp/tests/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2019 Intel Corporation.
+
+load("//pmlc:lit.bzl", "glob_lit_tests")
+
+glob_lit_tests()

--- a/pmlc/conversion/comp/tests/gpu_to_comp.mlir
+++ b/pmlc/conversion/comp/tests/gpu_to_comp.mlir
@@ -1,0 +1,60 @@
+// RUN: pmlc-opt -pmlc-convert-gpu-to-comp="comp-execenv-memory-space=11" %s | FileCheck %s
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, Int64, Int16, Int8, Float64, Float16], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @dot(%arg0: memref<16x32xf32>, %arg1: memref<8x16xf32>, %arg2: memref<8x32xf32>) {
+    %c8 = constant 8 : index
+    %c32 = constant 32 : index
+    %c1 = constant 1 : index
+    "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %arg2) {kernel = @dot_kernel::@dot_kernel} : (index, index, index, index, index, index, memref<8x32xf32>) -> ()
+    // CHECK: comp.create_execenv
+    // CHECK: comp.alloc {{.*}} -> memref<8x32xf32, 11>
+    // CHECK: comp.schedule_func
+    // CHECK: comp.schedule_read
+    // CHECK: comp.wait
+    // CHECK: comp.dealloc
+    // CHECK: comp.destroy_execenv
+    "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %arg1, %arg0, %arg2) {kernel = @dot_kernel_0::@dot_kernel} : (index, index, index, index, index, index, memref<8x16xf32>, memref<16x32xf32>, memref<8x32xf32>) -> ()
+    // CHECK: comp.create_execenv
+    // CHECK: comp.alloc {{.*}} -> memref<8x16xf32, 11>
+    // CHECK: comp.alloc {{.*}} -> memref<16x32xf32, 11>
+    // CHECK: comp.alloc {{.*}} -> memref<8x32xf32, 11>
+    // CHECK: comp.schedule_func
+    // CHECK: comp.schedule_read
+    // CHECK: comp.schedule_read
+    // CHECK: comp.schedule_read
+    // CHECK: comp.wait
+    // CHECK: comp.dealloc
+    // CHECK: comp.dealloc
+    // CHECK: comp.dealloc
+    // CHECK: comp.destroy_execenv
+    return
+  }
+  gpu.module @dot_kernel {
+    gpu.func @dot_kernel(%arg0: memref<8x32xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+    // CHECK: gpu.func @dot_kernel(%arg0: memref<8x32xf32, 11>)
+      %cst = constant 0.000000e+00 : f32
+      %0 = "gpu.block_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      store %cst, %arg0[%0, %1] : memref<8x32xf32>
+      gpu.return
+    }
+  }
+  gpu.module @dot_kernel_0 {
+    gpu.func @dot_kernel(%arg0: memref<8x16xf32>, %arg1: memref<16x32xf32>, %arg2: memref<8x32xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      // CHECK: gpu.func @dot_kernel(%arg0: memref<8x16xf32, 11>, %arg1: memref<16x32xf32, 11>, %arg2: memref<8x32xf32, 11>)
+      %c0 = constant 0 : index
+      %c16 = constant 16 : index
+      %c1 = constant 1 : index
+      %0 = "gpu.block_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      scf.for %arg3 = %c0 to %c16 step %c1 {
+        %2 = load %arg0[%0, %arg3] : memref<8x16xf32>
+        %3 = load %arg1[%arg3, %1] : memref<16x32xf32>
+        %4 = mulf %2, %3 : f32
+        %5 = load %arg2[%0, %1] : memref<8x32xf32>
+        %6 = addf %5, %4 : f32
+        store %6, %arg2[%0, %1] : memref<8x32xf32>
+      }
+      gpu.return
+    }
+  }
+}

--- a/pmlc/conversion/gpu/kernel_outlining.cc
+++ b/pmlc/conversion/gpu/kernel_outlining.cc
@@ -151,18 +151,32 @@ public:
     auto target_env = getOperation().getAttrOfType<spirv::TargetEnvAttr>(
         spirv::getTargetEnvAttrName());
     if (!target_env) {
-      auto triple = spirv::VerCapExtAttr::get(
-          spirv::Version::V_1_0,
-          {spirv::Capability::Shader, spirv::Capability::Int64,
-           spirv::Capability::Int16, spirv::Capability::Int8,
-           spirv::Capability::Float64, spirv::Capability::Float16},
-          ArrayRef<spirv::Extension>(
-              spirv::Extension::SPV_KHR_storage_buffer_storage_class),
-          &getContext());
-      getOperation().setAttr(
-          spirv::getTargetEnvAttrName(),
-          spirv::TargetEnvAttr::get(
-              triple, spirv::getDefaultResourceLimits(&getContext())));
+      if (!oclCapabilities.getValue()) {
+        auto triple = spirv::VerCapExtAttr::get(
+            spirv::Version::V_1_0,
+            {spirv::Capability::Shader, spirv::Capability::Int64,
+             spirv::Capability::Int16, spirv::Capability::Int8,
+             spirv::Capability::Float64, spirv::Capability::Float16},
+            ArrayRef<spirv::Extension>(
+                spirv::Extension::SPV_KHR_storage_buffer_storage_class),
+            &getContext());
+        getOperation().setAttr(
+            spirv::getTargetEnvAttrName(),
+            spirv::TargetEnvAttr::get(
+                triple, spirv::getDefaultResourceLimits(&getContext())));
+      } else {
+        auto triple = spirv::VerCapExtAttr::get(
+            spirv::Version::V_1_0,
+            {spirv::Capability::Kernel, spirv::Capability::Int64,
+             spirv::Capability::Int16, spirv::Capability::Int8,
+             spirv::Capability::Float64, spirv::Capability::Float16,
+             spirv::Capability::Addresses},
+            ArrayRef<spirv::Extension>(), &getContext());
+        getOperation().setAttr(
+            spirv::getTargetEnvAttrName(),
+            spirv::TargetEnvAttr::get(
+                triple, spirv::getDefaultResourceLimits(&getContext())));
+      }
     }
 
     SymbolTable symbolTable(getOperation());

--- a/pmlc/conversion/gpu/llvm_lowering.cc
+++ b/pmlc/conversion/gpu/llvm_lowering.cc
@@ -103,10 +103,11 @@ struct ConvertToLLVMPass
 
     OwningRewritePatternList patterns;
     populateStdToLLVMBarePtrConversionPatterns(typeConverter, patterns,
-                                               /*useAlloca=*/true);
+                                               /*useAlloca=*/false);
 
     ConversionTarget target(*context);
     target.addLegalDialect<LLVM::LLVMDialect>();
+    target.addIllegalOp<LLVM::DialectCastOp>();
     if (failed(applyPartialConversion(module, target, patterns))) {
       signalPassFailure();
     }

--- a/pmlc/conversion/gpu/passes.td
+++ b/pmlc/conversion/gpu/passes.td
@@ -11,6 +11,10 @@ def ConvertGpuLaunchFuncToVulkanCalls : Pass<"pmlc-convert-gpu-to-vulkan", "mlir
 def GpuKernelOutliningPass : Pass<"pmlc-kernel_outlining", "mlir::ModuleOp"> {
   let summary = "Outline gpu.launch bodies to kernel functions";
   let constructor = "pmlc::conversion::gpu::createGpuKernelOutliningPass()";
+  let options = [
+    Option<"oclCapabilities", "ocl-capabilities", "bool", /*default=*/"false",
+           "Flag to generate OpenCL flavor SPIRV capabilities instead of default Vulkan ones">,
+  ];
 }
 
 #endif // __PMLC_CONVERSION_GPU_TO_VULKAN_PASSES__

--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -110,6 +110,10 @@ struct AffineParallelOpConversion
       rewriter.setInsertionPointToStart(&af.region().front());
       ivs.push_back(af.getInductionVar());
     }
+    for (unsigned i = op.lowerBoundsMap().getNumResults(); i < 2; ++i) {
+      auto af = rewriter.create<mlir::AffineForOp>(op.getLoc(), 0, 1, 1);
+      rewriter.setInsertionPointToStart(&af.region().front());
+    }
     // Move ParallelOp's operations (single block) to Affine innermost loop.
     auto &innerLoopOps = rewriter.getInsertionBlock()->getOperations();
     auto &parallelBodyOps = op.region().front().getOperations();

--- a/pmlc/dialect/comp/BUILD
+++ b/pmlc/dialect/comp/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2020 Intel Corporation
+
+package(default_visibility = ["//visibility:public"])
+
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+plaidml_cc_library(
+    name = "comp",
+    deps = [
+        "//pmlc/dialect/comp/ir",
+        "//pmlc/dialect/comp/transforms"
+    ],
+)

--- a/pmlc/dialect/comp/ir/BUILD
+++ b/pmlc/dialect/comp/ir/BUILD
@@ -1,0 +1,63 @@
+# Copyright 2020 Intel Corporation.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+filegroup(
+    name = "td_files",
+    srcs = [
+        "//pmlc/util:td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "interfaces-gen",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "interfaces.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "interfaces.cc.inc",
+        ),
+    ],
+    td_file = "interfaces.td",
+    td_srcs = [":td_files"],
+)
+
+gentbl(
+    name = "gen-ops",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "ops.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "ops.cc.inc",
+        ),
+        (
+            "-gen-dialect-decls",
+            "dialect.h.inc",
+        ),
+    ],
+    td_file = "ops.td",
+    td_srcs = [":td_files"],
+)
+
+plaidml_cc_library(
+    name = "ir",
+    srcs = ["dialect.cc"],
+    hdrs = ["dialect.h", "types.h"],
+    deps = [
+        ":gen-ops",
+        ":interfaces-gen",
+        "//pmlc/util",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Affine",
+    ],
+)

--- a/pmlc/dialect/comp/ir/dialect.cc
+++ b/pmlc/dialect/comp/ir/dialect.cc
@@ -1,0 +1,178 @@
+#include "pmlc/dialect/comp/ir/dialect.h"
+
+#include <string>
+
+#include "mlir/IR/DialectImplementation.h"
+
+namespace pmlc::dialect::comp {
+
+using namespace mlir; // NOLINT
+
+#include "pmlc/dialect/comp/ir/interfaces.cc.inc"
+
+#define GET_OP_CLASSES
+#include "pmlc/dialect/comp/ir/ops.cc.inc"
+#undef GET_OP_CLASSES
+
+COMPDialect::COMPDialect(::mlir::MLIRContext *context)
+    : mlir::Dialect(getDialectNamespace(), context) {
+  addTypes<ExecEnvType, EventType>();
+#define GET_OP_LIST
+  addOperations<
+#include "pmlc/dialect/comp/ir/ops.cc.inc" // NOLINT
+      >();
+#undef GET_OP_LIST
+}
+
+// ============================================================================
+// Type parsing and prinitng
+// ============================================================================
+namespace {
+
+std::string execEnvToString(ExecEnvRuntime runtime) {
+  switch (runtime) {
+  case ExecEnvRuntime::Vulkan:
+    return "vk";
+  case ExecEnvRuntime::OpenCL:
+    return "ocl";
+  default: {
+    unsigned customNr = static_cast<unsigned>(runtime);
+    return std::to_string(customNr);
+  }
+  }
+}
+
+ExecEnvRuntime execEnvFromString(StringRef str) {
+  if (str == "vk")
+    return ExecEnvRuntime::Vulkan;
+  if (str == "ocl")
+    return ExecEnvRuntime::OpenCL;
+  unsigned customNr;
+  str.getAsInteger(10, customNr);
+  return static_cast<ExecEnvRuntime>(customNr);
+}
+
+void printEventType(EventType type, DialectAsmPrinter &printer) {
+  printer << "event<" << execEnvToString(type.getRuntime()) << ">";
+}
+
+Type parseEventType(DialectAsmParser &parser, Location loc) {
+  if (parser.parseLess())
+    return nullptr;
+
+  StringRef runtimeKeyword;
+  if (failed(parser.parseKeyword(&runtimeKeyword)))
+    return nullptr;
+
+  ExecEnvRuntime runtime = execEnvFromString(runtimeKeyword);
+
+  if (parser.parseGreater())
+    return nullptr;
+
+  return EventType::getChecked(runtime, loc);
+}
+
+void printExecEnvType(ExecEnvType type, DialectAsmPrinter &printer) {
+  printer << "execenv<";
+  printer << execEnvToString(type.getRuntime());
+  printer << ":" << type.getTag() << ",(";
+  bool first = true;
+  for (auto &memSpace : type.getMemorySpaces()) {
+    if (!first)
+      printer << ",";
+    printer << memSpace;
+    first = false;
+  }
+  printer << ")>";
+}
+
+Type parseExecEnvType(DialectAsmParser &parser, Location loc) {
+  StringRef runtimeKeyword;
+  unsigned tag;
+  if (parser.parseLess() || parser.parseKeyword(&runtimeKeyword) ||
+      parser.parseColon() || parser.parseInteger(tag) || parser.parseComma() ||
+      parser.parseLParen())
+    return nullptr;
+
+  SmallVector<unsigned, 1> memorySpaces;
+  bool first = true;
+  while (true) {
+    if (!first) {
+      if (parser.parseOptionalComma())
+        break;
+    }
+    unsigned memSpace;
+    auto optionalInt = parser.parseOptionalInteger(memSpace);
+    if (optionalInt.hasValue())
+      memorySpaces.push_back(memSpace);
+    else
+      break;
+    first = false;
+  }
+
+  if (parser.parseRParen() || parser.parseGreater())
+    return nullptr;
+
+  ExecEnvRuntime runtime = execEnvFromString(runtimeKeyword);
+  return ExecEnvType::getChecked(runtime, tag, memorySpaces, loc);
+}
+
+} // namespace
+
+void COMPDialect::printType(Type type, DialectAsmPrinter &printer) const {
+  switch (type.getKind()) {
+  case CompTypes::Event:
+    printEventType(type.cast<EventType>(), printer);
+    break;
+  case CompTypes::ExecEnv:
+    printExecEnvType(type.cast<ExecEnvType>(), printer);
+    break;
+  default:
+    llvm_unreachable("Unhandled comp type");
+  }
+}
+
+Type COMPDialect::parseType(DialectAsmParser &parser) const {
+  Location loc = parser.getEncodedSourceLoc(parser.getNameLoc());
+
+  StringRef typeKeyword;
+  if (failed(parser.parseKeyword(&typeKeyword)))
+    return nullptr;
+
+  if (typeKeyword == "event")
+    return parseEventType(parser, loc);
+  if (typeKeyword == "execenv")
+    return parseExecEnvType(parser, loc);
+
+  parser.emitError(parser.getNameLoc(), "unknown comp type " + typeKeyword);
+
+  return nullptr;
+}
+
+// ============================================================================
+// Operations
+// ============================================================================
+::mlir::Value ScheduleRead::getSource() { return deviceMem(); }
+::mlir::Value ScheduleRead::getDestination() { return hostMem(); }
+::mlir::Value ScheduleRead::getSourceExecEnv() { return execEnv(); }
+::mlir::Value ScheduleRead::getDestinationExecEnv() { return mlir::Value(); }
+
+::mlir::Value ScheduleWrite::getSource() { return hostMem(); }
+::mlir::Value ScheduleWrite::getDestination() { return deviceMem(); }
+::mlir::Value ScheduleWrite::getSourceExecEnv() { return mlir::Value(); }
+::mlir::Value ScheduleWrite::getDestinationExecEnv() { return execEnv(); }
+
+::mlir::Value ScheduleCopy::getSource() { return srcMem(); }
+::mlir::Value ScheduleCopy::getDestination() { return dstMem(); }
+::mlir::Value ScheduleCopy::getSourceExecEnv() { return execEnv(); }
+::mlir::Value ScheduleCopy::getDestinationExecEnv() { return execEnv(); }
+
+OpFoldResult GroupEvents::fold(ArrayRef<Attribute> operands) {
+  // If just one event to group, pass it on
+  if (operands.size() == 1)
+    return events()[0];
+
+  return {};
+}
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/ir/dialect.h
+++ b/pmlc/dialect/comp/ir/dialect.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "pmlc/dialect/comp/ir/types.h"
+
+namespace pmlc::dialect::comp {
+using mlir::ArrayRef;
+using mlir::Attribute;
+using mlir::DialectAsmParser;
+using mlir::DialectAsmPrinter;
+using mlir::DictionaryAttr;
+using mlir::Location;
+using mlir::LogicalResult;
+using mlir::MemoryEffectOpInterface;
+using mlir::MemRefType;
+using mlir::NamedAttribute;
+using mlir::Op;
+using mlir::OpAsmParser;
+using mlir::OpAsmPrinter;
+using mlir::OpAsmSetValueNameFn;
+using mlir::OpBuilder;
+using mlir::Operation;
+using mlir::OperationState;
+using mlir::OpFoldResult;
+using mlir::OpInterface;
+using mlir::ParseResult;
+using mlir::Region;
+using mlir::SmallVectorImpl;
+using mlir::StringRef;
+using mlir::Type;
+using mlir::Value;
+using mlir::ValueRange;
+
+namespace OpTrait = mlir::OpTrait;
+namespace SideEffects = mlir::SideEffects;
+namespace MemoryEffects = mlir::MemoryEffects;
+
+#include "mlir/IR/OpAsmInterface.h.inc"
+
+#include "pmlc/dialect/comp/ir/interfaces.h.inc"
+
+#define GET_OP_CLASSES
+#include "pmlc/dialect/comp/ir/ops.h.inc"
+#undef GET_OP_CLASSES
+
+#include "pmlc/dialect/comp/ir/dialect.h.inc"
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/ir/interfaces.td
+++ b/pmlc/dialect/comp/ir/interfaces.td
@@ -1,0 +1,67 @@
+// Copyright 2020, Intel Corporation
+
+#ifndef __PMLC_COMP_INTERFACES__
+#define __PMLC_COMP_INTERFACES__
+
+include "mlir/IR/OpBase.td"
+
+def COMP_ExecEnvOpInterface : OpInterface<"ExecEnvOpInterface"> {
+  let description = [{
+
+  }];
+
+  let methods = [
+    InterfaceMethod<"", "::mlir::Value", "getExecEnv", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return op.execEnv();
+    }]>
+  ];
+}
+
+def COMP_ScheduleOpInterface : OpInterface<"ScheduleOpInterface"> {
+  let description = [{
+    Interface for operations that are scheduled on execution environment.
+    Provides access for dependant event and produced event.
+  }];
+
+  let methods = [
+    InterfaceMethod<"", "::mlir::Value", "getDependency", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return op.depEvent();
+    }]>,
+    InterfaceMethod<"", "::mlir::MutableOperandRange", "getDependencyMutable", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return op.depEventMutable();
+    }]>,
+    InterfaceMethod<"", "bool", "hasDependency", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return static_cast<bool>(op.depEvent());
+    }]>,
+    InterfaceMethod<"", "::mlir::Value", "getResultingEvent", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return op.getResult();
+    }]>,
+  ];
+}
+
+def COMP_MemoryTransferOpInterface : OpInterface<"MemoryTransferOpInterface"> {
+  let description = [{
+  }];
+
+  let methods = [
+    InterfaceMethod<"", "::mlir::Value", "getSource">,
+    InterfaceMethod<"", "::mlir::Value", "getDestination">,
+    InterfaceMethod<"", "::mlir::Value", "getSourceExecEnv">,
+    InterfaceMethod<"", "::mlir::Value", "getDestinationExecEnv">,
+    InterfaceMethod<"", "bool", "sourceHasExecEnv", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return static_cast<bool>(op.getSourceExecEnv());
+    }]>,
+    InterfaceMethod<"", "bool", "destinationHasExecEnv", (ins), [{}], [{
+      ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
+      return static_cast<bool>(op.getDestinationExecEnv());
+    }]>,
+  ];
+}
+
+#endif  // __PMLC_COMP_INTERFACES__

--- a/pmlc/dialect/comp/ir/ops.td
+++ b/pmlc/dialect/comp/ir/ops.td
@@ -1,0 +1,267 @@
+// Copyright 2020, Intel Corporation
+
+#ifndef __PMLC_COMP_OPS__
+#define __PMLC_COMP_OPS__
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+// include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+
+include "interfaces.td"
+
+// TODO Type constraints
+// TODO Verification
+// TODO Builders
+// TODO Descriptions
+
+// =============================================================================
+// Dialect
+// =============================================================================
+def COMP_Dialect : Dialect {
+  let name = "comp";
+  let cppNamespace = "pmlc::dialect::comp";
+  let extraClassDeclaration = [{
+    Type parseType(DialectAsmParser& parser) const override;
+    void printType(Type, DialectAsmPrinter& printer) const override;
+  }];
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+def COMP_IsExecEnvTypePred : CPred<"$_self.isa<::pmlc::dialect::comp::ExecEnvType>()">;
+def COMP_AnyExecEnv : Type<COMP_IsExecEnvTypePred>;
+
+def COMP_IsEventTypePred : CPred<"$_self.isa<::pmlc::dialect::comp::EventType>()">;
+def COMP_AnyEvent : Type<COMP_IsEventTypePred>;
+
+// =============================================================================
+// Operations
+// =============================================================================
+class COMP_Op<string mnemonic, list<OpTrait> traits = []> :
+    Op<COMP_Dialect, mnemonic, traits>;
+
+def COMP_CreateExecEnv : COMP_Op<"create_execenv",
+                                 [MemoryEffects<[MemAlloc<DefaultResource>]>]>
+                       , Results<(outs COMP_AnyExecEnv:$execEnv)> {
+  let summary = "Creates execution environment.";
+
+  let description = [{
+    Execution environment provides functionality for scheduling operations and
+    synchronizing between them.
+  }];
+
+  let assemblyFormat = [{
+    attr-dict `:` type($execEnv)
+  }];
+}
+
+def COMP_DestroyExecEnv : COMP_Op<"destroy_execenv",
+                                  [MemoryEffects<[MemFree<DefaultResource>]>]> {
+  let summary = "Destroys execution environment.";
+
+  let description = [{
+    Any usage of environment or connected with it memory and events is invalid
+    after this operation.
+    Does not guarantee that submitted tasks finished executing.
+  }];
+
+  let arguments = (ins COMP_AnyExecEnv:$execEnv);
+
+  let assemblyFormat = [{
+     $execEnv attr-dict `:` type($execEnv)
+  }];
+}
+
+def COMP_ScheduleEnd : COMP_Op<"schedule_end", [Terminator]> {
+  let summary = "End of scheduling block.";
+}
+
+def COMP_ScheduleSingleBlock : SingleBlockImplicitTerminator<"ScheduleEnd">;
+
+def COMP_ScheduleFunc : COMP_Op<"schedule_func",
+                                [COMP_ScheduleSingleBlock,
+                                 DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                 DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>]>
+                  , Arguments<(ins COMP_AnyExecEnv:$execEnv,
+                                   Optional<COMP_AnyEvent>:$depEvent)>
+                  , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules function in region for execution on device.";
+  let description = [{
+    This is a wrapper around gpu.launch_func that schedules function
+    to execute on environment and provides synchronization with
+    event dependencies and output event.
+    The region is expected to have only this single gpu.launch_func operation
+    and implicit terminator - comp.schedule_end.
+    Example:
+    %ev = "comp.launch_func"(%execEnv, %depEvent) ( {
+      "gpu.launch_func"(...)
+      "comp.schedule_end"
+    })
+    comp.wait %ev
+  }];
+
+  let regions = (region AnyRegion:$body);
+}
+
+
+def COMP_Submit : COMP_Op<"submit",
+                          [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>]>
+                , Arguments<(ins COMP_AnyExecEnv:$execEnv)> {
+  let summary = "Submits all scheduled tasks.";
+
+  let description = [{
+    Forces all previously scheduled tasks to start executing.
+  }];
+
+  let assemblyFormat = [{
+    $execEnv attr-dict `:` type($execEnv)
+  }];
+}
+
+def COMP_Alloc : COMP_Op<"alloc", [MemoryEffects<[MemAlloc<DefaultResource>]>,
+                                   DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>]>
+               , Arguments<(ins COMP_AnyExecEnv:$execEnv,
+                                Optional<AnyMemRef>:$hostMem)>
+               , Results<(outs AnyMemRef:$out)> {
+  let summary = "Allocates memory for use in execution environment.";
+
+  let description = [{
+    Optionally accepts host memory, in which case there is guarantee that
+    after allocation new device memory will contain the same data.
+  }];
+
+  let assemblyFormat = [{
+     $execEnv ($hostMem^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_Dealloc : COMP_Op<"dealloc", [MemoryEffects<[MemFree<DefaultResource>]>]>
+                 , Arguments<(ins AnyMemRef:$deviceMem)> {
+  let summary = "Deallocates memory previously allocated for use in executon environment.";
+
+  let assemblyFormat = [{
+      $deviceMem attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_ScheduleWrite : COMP_Op<"schedule_write",
+                                 [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                  DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>,
+                                  DeclareOpInterfaceMethods<COMP_MemoryTransferOpInterface, ["getSource", "getDestination", "getSourceExecEnv", "getDestinationExecEnv"]>]>
+                       , Arguments<(ins AnyMemRef:$hostMem,
+                                        AnyMemRef:$deviceMem,
+                                        COMP_AnyExecEnv:$execEnv,
+                                        Optional<COMP_AnyEvent>:$depEvent)>
+                       , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules data copy from host for use in execution environment.";
+
+  let assemblyFormat = [{
+    $hostMem `to` $deviceMem `on` $execEnv (`wait` `for` $depEvent^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_ScheduleRead : COMP_Op<"schedule_read",
+                                [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                 DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>,
+                                 DeclareOpInterfaceMethods<COMP_MemoryTransferOpInterface, ["getSource", "getDestination", "getSourceExecEnv", "getDestinationExecEnv"]>]>
+                      , Arguments<(ins AnyMemRef:$hostMem,
+                                       AnyMemRef:$deviceMem,
+                                       COMP_AnyExecEnv:$execEnv,
+                                       Optional<COMP_AnyEvent>:$depEvent)>
+                      , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules data copy from execution environment for use on host.";
+
+  let assemblyFormat = [{
+    $hostMem `from` $deviceMem `on` $execEnv (`wait` `for` $depEvent^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_ScheduleCopy : COMP_Op<"schedule_copy",
+                                [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                 DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>,
+                                 DeclareOpInterfaceMethods<COMP_MemoryTransferOpInterface,
+                                                           ["getSource", "getDestination", "getSourceExecEnv", "getDestinationExecEnv"]>]>
+                      , Arguments<(ins AnyMemRef:$srcMem,
+                                       AnyMemRef:$dstMem,
+                                       COMP_AnyExecEnv:$execEnv,
+                                       Optional<COMP_AnyEvent>:$depEvent)>
+                      , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules data copy between two memrefs on same execeution device.";
+
+  let assemblyFormat = [{
+    $srcMem `to` $dstMem `on` $execEnv (`wait` `for` $depEvent^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_Wait : COMP_Op<"wait">
+               , Arguments<(ins COMP_AnyEvent:$event)> {
+  let summary = "Waits for event being finished.";
+
+  let description = [{
+    After this operation it is guaranteed that operations marked by event are finished,
+    and it is save to use their results from host.
+  }];
+
+  let assemblyFormat = [{
+    $event attr-dict `:` type($event)
+  }];
+}
+
+def COMP_ScheduleBarrier : COMP_Op<"schedule_barrier",
+                                   [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                    DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>]>
+                          , Arguments<(ins COMP_AnyExecEnv:$execEnv,
+                                           Optional<COMP_AnyEvent>:$depEvent)>
+                          , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules barrier between previous and next sheduling operations.";
+
+  let description = [{
+    Barrier serves as one of synchronization primitives.
+    After scheduling it provides guarantee that all operations scheduled after
+    barrier will start executing only after operations before barrier are finished.
+    Optionally if additional event dependency is specified the barrier loosens
+    the guarantee that only this event needs to finish before processing later tasks.
+  }];
+
+  let assemblyFormat = [{
+    $execEnv (`wait` `for` $depEvent^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_ScheduleMarker : COMP_Op<"schedule_marker",
+                                  [DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>,
+                                   DeclareOpInterfaceMethods<COMP_ScheduleOpInterface>]>
+                        , Arguments<(ins COMP_AnyExecEnv:$execEnv,
+                                         Optional<COMP_AnyEvent>:$depEvent)>
+                        , Results<(outs COMP_AnyEvent:$outEvent)> {
+  let summary = "Schedules marker between previous and next sheduling operations.";
+
+  let description = [{
+    Marker works similarly to barrier, but does not create a synchronization point.
+  }];
+
+  let assemblyFormat = [{
+    $execEnv (`wait` `for` $depEvent^)? attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def COMP_GroupEvents : COMP_Op<"group_events", [NoSideEffect]>
+               , Arguments<(ins Variadic<COMP_AnyEvent>:$events)>
+               , Results<(outs COMP_AnyEvent:$grouped)> {
+  let summary = "Groups multiple events into one.";
+
+  let description = [{
+    This is syntactic only operation that groups several events into one for
+    easier operation.
+  }];
+
+  let assemblyFormat = [{
+    $events attr-dict `:` functional-type(operands, results)
+  }];
+
+  let hasFolder = 1;
+}
+
+#endif // __PMLC_COMP_OPS__

--- a/pmlc/dialect/comp/ir/types.h
+++ b/pmlc/dialect/comp/ir/types.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <tuple>
+
+#include "mlir/IR/Types.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace pmlc::dialect::comp {
+
+namespace CompTypes {
+enum Kinds {
+  ExecEnv = mlir::Type::Kind::FIRST_PRIVATE_EXPERIMENTAL_9_TYPE,
+  Event
+};
+} // namespace CompTypes
+
+enum ExecEnvRuntime : unsigned { Vulkan, OpenCL, Custom_0 };
+
+using ExecEnvTag = unsigned;
+
+struct ExecEnvStorage : public mlir::TypeStorage {
+  ExecEnvStorage(ExecEnvRuntime runtime, ExecEnvTag tag,
+                 mlir::ArrayRef<unsigned> memorySpaces)
+      : runtime(runtime), tag(tag),
+        memorySpaces(memorySpaces.begin(), memorySpaces.end()) {}
+
+  using KeyTy =
+      std::tuple<ExecEnvRuntime, ExecEnvTag, mlir::SmallVector<unsigned, 1>>;
+
+  bool operator==(const KeyTy &key) const {
+    return key == KeyTy(runtime, tag, memorySpaces);
+  }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_combine(std::get<0>(key), std::get<1>(key),
+                              mlir::ArrayRef<unsigned>(std::get<2>(key)));
+  }
+
+  static KeyTy getKey(ExecEnvRuntime runtime, ExecEnvTag tag,
+                      mlir::ArrayRef<unsigned> memorySpaces) {
+    return KeyTy(runtime, tag,
+                 mlir::SmallVector<unsigned, 1>(memorySpaces.begin(),
+                                                memorySpaces.end()));
+  }
+
+  static ExecEnvStorage *construct(mlir::TypeStorageAllocator &allocator,
+                                   const KeyTy &key) {
+    return new (allocator.allocate<ExecEnvStorage>())
+        ExecEnvStorage(std::get<0>(key), std::get<1>(key), std::get<2>(key));
+  }
+
+  ExecEnvRuntime runtime;
+  ExecEnvTag tag;
+  mlir::SmallVector<unsigned, 1> memorySpaces;
+};
+
+class ExecEnvType
+    : public mlir::Type::TypeBase<ExecEnvType, mlir::Type, ExecEnvStorage> {
+public:
+  using Base::Base;
+
+  static bool kindof(unsigned kind) { return kind == CompTypes::ExecEnv; }
+  static ExecEnvType get(mlir::MLIRContext *context, ExecEnvRuntime runtime,
+                         ExecEnvTag tag,
+                         mlir::ArrayRef<unsigned> memorySpaces) {
+    return Base::get(context, CompTypes::ExecEnv, runtime, tag, memorySpaces);
+  }
+
+  static ExecEnvType getChecked(ExecEnvRuntime runtime, ExecEnvTag tag,
+                                mlir::ArrayRef<unsigned> memorySpaces,
+                                mlir::Location location) {
+    return Base::getChecked(location, CompTypes::ExecEnv, runtime, tag,
+                            memorySpaces);
+  }
+
+  ExecEnvRuntime getRuntime() const { return getImpl()->runtime; }
+
+  ExecEnvTag getTag() const { return getImpl()->tag; }
+
+  mlir::ArrayRef<unsigned> getMemorySpaces() const {
+    return getImpl()->memorySpaces;
+  }
+
+  unsigned getDefaultMemorySpace() const { return getMemorySpaces()[0]; }
+};
+
+struct EventTypeStorage : public mlir::TypeStorage {
+  explicit EventTypeStorage(ExecEnvRuntime runtime) : runtime(runtime) {}
+
+  using KeyTy = ExecEnvRuntime;
+
+  bool operator==(const KeyTy &key) const { return key == KeyTy(runtime); }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_value(key);
+  }
+
+  static KeyTy getKey(ExecEnvRuntime runtime) { return KeyTy(runtime); }
+
+  static EventTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+                                     const KeyTy &key) {
+    return new (allocator.allocate<EventTypeStorage>()) EventTypeStorage(key);
+  }
+
+  ExecEnvRuntime runtime;
+};
+
+class EventType
+    : public mlir::Type::TypeBase<EventType, mlir::Type, EventTypeStorage> {
+public:
+  using Base::Base;
+
+  static bool kindof(unsigned kind) { return kind == CompTypes::Event; }
+  static EventType get(mlir::MLIRContext *context, ExecEnvRuntime runtime) {
+    return Base::get(context, CompTypes::Event, runtime);
+  }
+
+  static EventType getChecked(ExecEnvRuntime runtime, mlir::Location location) {
+    return Base::getChecked(location, CompTypes::Event, runtime);
+  }
+
+  static EventType get(mlir::MLIRContext *context, ExecEnvType envType) {
+    return EventType::get(context, envType.getRuntime());
+  }
+
+  static EventType getChecked(ExecEnvType envType, mlir::Location location) {
+    return EventType::getChecked(envType.getRuntime(), location);
+  }
+
+  ExecEnvRuntime getRuntime() { return getImpl()->runtime; }
+};
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/tests/BUILD
+++ b/pmlc/dialect/comp/tests/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2020 Intel Corporation.
+
+load("//pmlc:lit.bzl", "glob_lit_tests")
+
+glob_lit_tests()

--- a/pmlc/dialect/comp/tests/canonicalize.mlir
+++ b/pmlc/dialect/comp/tests/canonicalize.mlir
@@ -1,0 +1,16 @@
+// RUN: pmlc-opt -canonicalize %s | FileCheck %s
+func @test(%arg0: memref<3x4xf16>) {
+  %env = comp.create_execenv : !comp.execenv<ocl:0,(11)>
+  // CHECK: comp.create_execenv
+
+  %all_ev = comp.schedule_marker %env : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
+  %gr1 = comp.group_events %all_ev : (!comp.event<ocl>) -> !comp.event<ocl>
+  comp.wait %gr1 : !comp.event<ocl>
+  // CHECK: comp.schedule_marker
+  // CHECK-NOT: comp.group_events
+  // CHECK: comp.wait
+
+  comp.destroy_execenv %env : !comp.execenv<ocl:0,(11)>
+  // CHECK: comp.destroy_execenv
+  return
+}

--- a/pmlc/dialect/comp/tests/execenv_coalescing.mlir
+++ b/pmlc/dialect/comp/tests/execenv_coalescing.mlir
@@ -1,0 +1,69 @@
+// RUN: pmlc-opt -pmlc-execenv-coalescing %s | FileCheck %s
+
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, Int64, Int16, Int8, Float64, Float16], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @dot(%arg0: memref<16x32xf32>, %arg1: memref<8x16xf32>, %arg2: memref<8x32xf32>) {
+    %c8 = constant 8 : index
+    %c32 = constant 32 : index
+    %c1 = constant 1 : index
+    %0 = comp.create_execenv : !comp.execenv<vk:0,(11)>
+    %1 = comp.alloc %0 %arg2 : (!comp.execenv<vk:0,(11)>, memref<8x32xf32>) -> memref<8x32xf32, 11>
+    %2 = "comp.schedule_func"(%0) ( {
+      "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %1) {kernel = @dot_kernel::@dot_kernel} : (index, index, index, index, index, index, memref<8x32xf32, 11>) -> ()
+      "comp.schedule_end"() : () -> ()
+    }) : (!comp.execenv<vk:0,(11)>) -> !comp.event<vk>
+    %3 = comp.schedule_read %arg2 from %1 on %0 wait for %2 : (memref<8x32xf32>, memref<8x32xf32, 11>, !comp.execenv<vk:0,(11)>, !comp.event<vk>) -> !comp.event<vk>
+    comp.wait %3 : !comp.event<vk>
+    comp.dealloc %1 : (memref<8x32xf32, 11>) -> ()
+    comp.destroy_execenv %0 : !comp.execenv<vk:0,(11)>
+    %4 = comp.create_execenv : !comp.execenv<vk:0,(11)>
+    %5 = comp.alloc %4 %arg1 : (!comp.execenv<vk:0,(11)>, memref<8x16xf32>) -> memref<8x16xf32, 11>
+    %6 = comp.alloc %4 %arg0 : (!comp.execenv<vk:0,(11)>, memref<16x32xf32>) -> memref<16x32xf32, 11>
+    %7 = comp.alloc %4 %arg2 : (!comp.execenv<vk:0,(11)>, memref<8x32xf32>) -> memref<8x32xf32, 11>
+    %8 = "comp.schedule_func"(%4) ( {
+      "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %5, %6, %7) {kernel = @dot_kernel_0::@dot_kernel} : (index, index, index, index, index, index, memref<8x16xf32, 11>, memref<16x32xf32, 11>, memref<8x32xf32, 11>) -> ()
+      "comp.schedule_end"() : () -> ()
+    }) : (!comp.execenv<vk:0,(11)>) -> !comp.event<vk>
+    %9 = comp.schedule_read %arg1 from %5 on %4 wait for %8 : (memref<8x16xf32>, memref<8x16xf32, 11>, !comp.execenv<vk:0,(11)>, !comp.event<vk>) -> !comp.event<vk>
+    %10 = comp.schedule_read %arg0 from %6 on %4 wait for %8 : (memref<16x32xf32>, memref<16x32xf32, 11>, !comp.execenv<vk:0,(11)>, !comp.event<vk>) -> !comp.event<vk>
+    %11 = comp.schedule_read %arg2 from %7 on %4 wait for %8 : (memref<8x32xf32>, memref<8x32xf32, 11>, !comp.execenv<vk:0,(11)>, !comp.event<vk>) -> !comp.event<vk>
+    %12 = comp.group_events %9, %10, %11 : (!comp.event<vk>, !comp.event<vk>, !comp.event<vk>) -> !comp.event<vk>
+    comp.wait %12 : !comp.event<vk>
+    comp.dealloc %5 : (memref<8x16xf32, 11>) -> ()
+    comp.dealloc %6 : (memref<16x32xf32, 11>) -> ()
+    comp.dealloc %7 : (memref<8x32xf32, 11>) -> ()
+    comp.destroy_execenv %4 : !comp.execenv<vk:0,(11)>
+    return
+    // CHECK: comp.create_execenv
+    // CHECK: comp.schedule_func
+    // CHECK-NOT: comp.create_execenv
+    // CHECK: comp.schedule_func
+    // CHECK: comp.destroy_execenv
+  }
+  gpu.module @dot_kernel {
+    gpu.func @dot_kernel(%arg0: memref<8x32xf32, 11>) kernel attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      %cst = constant 0.000000e+00 : f32
+      %0 = "gpu.block_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      store %cst, %arg0[%0, %1] : memref<8x32xf32, 11>
+      gpu.return
+    }
+  }
+  gpu.module @dot_kernel_0 {
+    gpu.func @dot_kernel(%arg0: memref<8x16xf32, 11>, %arg1: memref<16x32xf32, 11>, %arg2: memref<8x32xf32, 11>) kernel attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      %c0 = constant 0 : index
+      %c16 = constant 16 : index
+      %c1 = constant 1 : index
+      %0 = "gpu.block_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      scf.for %arg3 = %c0 to %c16 step %c1 {
+        %2 = load %arg0[%0, %arg3] : memref<8x16xf32, 11>
+        %3 = load %arg1[%arg3, %1] : memref<16x32xf32, 11>
+        %4 = mulf %2, %3 : f32
+        %5 = load %arg2[%0, %1] : memref<8x32xf32, 11>
+        %6 = addf %5, %4 : f32
+        store %6, %arg2[%0, %1] : memref<8x32xf32, 11>
+      }
+      gpu.return
+    }
+  }
+}

--- a/pmlc/dialect/comp/transforms/BUILD
+++ b/pmlc/dialect/comp/transforms/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2020 Intel Corporation
+
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
+load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
+
+gentbl(
+    name = "gen-pass",
+    tbl_outs = [
+        (
+            "-gen-pass-decls",
+            "passes.h.inc",
+        ),
+    ],
+    td_file = "passes.td",
+    td_srcs = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+plaidml_cc_library(
+    name = "transforms",
+    srcs = [
+        "execenv_coalescing.cc"
+    ],
+    hdrs = [
+        "pass_detail.h",
+        "passes.h"
+    ],
+    deps = [
+        ":gen-pass",
+        "//pmlc/dialect/comp/ir",
+        "@llvm-project//mlir:GPUTransforms",
+    ],
+)

--- a/pmlc/dialect/comp/transforms/execenv_coalescing.cc
+++ b/pmlc/dialect/comp/transforms/execenv_coalescing.cc
@@ -1,0 +1,436 @@
+// Copyright 2020 Intel Corporation
+#include <iostream>
+#include <map>
+#include <memory>
+
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/IR/Builders.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include "pmlc/dialect/comp/transforms/pass_detail.h"
+#include "pmlc/dialect/comp/transforms/passes.h"
+
+namespace pmlc::dialect::comp {
+
+namespace gpu = mlir::gpu;
+
+namespace {
+
+void reuseExecEnv(mlir::FuncOp funcOp) {
+  // Finds earliest creation of exec environment with each type and latest
+  // destruction. Reuse environment from first creation and remove all
+  // destructions except last.
+  // TODO This may fail if there are multiple blocks
+  llvm::DenseMap<mlir::Type, CreateExecEnv> earliestCreation;
+  llvm::DenseMap<mlir::Type, DestroyExecEnv> latestDestruction;
+
+  auto findCreateDestroyFn = [&](mlir::Operation *op) -> void {
+    if (auto createOp = mlir::dyn_cast<CreateExecEnv>(op)) {
+      auto execEnv = createOp.getResult();
+      auto execEnvType = execEnv.getType();
+      if (earliestCreation.count(execEnvType) == 0) {
+        earliestCreation[execEnvType] = createOp;
+      }
+    }
+    if (auto destroyOp = mlir::dyn_cast<DestroyExecEnv>(op)) {
+      auto execEnv = destroyOp.execEnv();
+      auto execEnvType = execEnv.getType();
+      latestDestruction[execEnvType] = destroyOp;
+    }
+  };
+
+  auto replaceCreateDestroyFn = [&](mlir::Operation *op) -> void {
+    if (auto createOp = mlir::dyn_cast<CreateExecEnv>(op)) {
+      auto execEnv = createOp.getResult();
+      auto execEnvType = execEnv.getType();
+      if (earliestCreation[execEnvType] != createOp) {
+        op->replaceAllUsesWith(earliestCreation[execEnvType]);
+        op->erase();
+      }
+      return;
+    }
+    if (auto destroyOp = mlir::dyn_cast<DestroyExecEnv>(op)) {
+      auto execEnv = destroyOp.execEnv();
+      auto execEnvType = execEnv.getType();
+
+      if (latestDestruction[execEnvType] != destroyOp) {
+        op->erase();
+      }
+      return;
+    }
+  };
+
+  funcOp.walk(findCreateDestroyFn);
+  funcOp.walk(replaceCreateDestroyFn);
+}
+
+void reuseMemory(mlir::FuncOp funcOp) {
+  struct AllocationInfo {
+    mlir::Value execEnv;
+    Alloc allocOp;
+    Dealloc deallocOp;
+  };
+
+  llvm::DenseMap<mlir::Value, AllocationInfo> deallocatedMemory;
+  std::list<std::pair<mlir::Operation *, AllocationInfo>> reusePossibilities;
+
+  auto findReusePossibilitesFn = [&](mlir::Operation *op) -> void {
+    if (auto deallocOp = mlir::dyn_cast<Dealloc>(op)) {
+      auto deviceMem = deallocOp.deviceMem();
+      auto allocOp = mlir::cast<Alloc>(deviceMem.getDefiningOp());
+      auto hostMem = allocOp.hostMem();
+      if (!hostMem)
+        return;
+      auto execEnv = allocOp.execEnv();
+      deallocatedMemory[hostMem] = AllocationInfo{execEnv, allocOp, deallocOp};
+    }
+    if (auto allocOp = mlir::dyn_cast<Alloc>(op)) {
+      auto hostMem = allocOp.hostMem();
+      if (!hostMem || deallocatedMemory.count(hostMem) == 0)
+        return;
+      auto execEnv = allocOp.execEnv();
+      auto deallocated = deallocatedMemory[hostMem];
+      if (deallocated.execEnv != execEnv)
+        return;
+      reusePossibilities.emplace_front(op, deallocated);
+      deallocatedMemory.erase(hostMem);
+    }
+  };
+
+  funcOp.walk(findReusePossibilitesFn);
+
+  for (auto &reuse : reusePossibilities) {
+    auto &op = reuse.first;
+    auto &allocOp = reuse.second.allocOp;
+    auto hostMem = allocOp.hostMem();
+    auto deviceMem = allocOp.getResult();
+    auto execEnv = reuse.second.execEnv;
+    mlir::OpBuilder builder(op);
+    // Insert write and wait to make sure that memory is up to data
+    auto eventType = builder.getType<EventType>(
+        execEnv.getType().cast<ExecEnvType>().getRuntime());
+    auto writeOp =
+        builder.create<ScheduleWrite>(op->getLoc(), eventType, hostMem,
+                                      deviceMem, reuse.second.execEnv, Value());
+    auto waitOp = builder.create<Wait>(op->getLoc(), writeOp.getResult());
+
+    op->replaceAllUsesWith(reuse.second.allocOp);
+    reuse.second.deallocOp.erase();
+    op->erase();
+  }
+}
+
+mlir::LogicalResult eraseEventDependencies(mlir::FuncOp funcOp) {
+  // Check that dependencies can be safely removed
+  // Check that schedule operations have known event dependency and dependees
+  auto checkSchedule =
+      funcOp.walk([&](ScheduleOpInterface op) -> mlir::WalkResult {
+        auto outEvent = op.getResultingEvent();
+        for (auto user : outEvent.getUsers()) {
+          if (!mlir::isa<Wait>(user) && !mlir::isa<GroupEvents>(user) &&
+              !mlir::isa<ScheduleOpInterface>(user))
+            return mlir::WalkResult::interrupt();
+        }
+        auto depEvent = op.getDependency();
+        if (depEvent) {
+          auto definingOp = depEvent.getDefiningOp();
+          if (!definingOp || (!mlir::isa<GroupEvents>(definingOp) &&
+                              !mlir::isa<ScheduleOpInterface>(definingOp)))
+            return mlir::WalkResult::interrupt();
+        }
+        return mlir::WalkResult::advance();
+      });
+  if (checkSchedule.wasInterrupted())
+    return mlir::failure();
+  // All defining operations for waits are known
+  auto checkWait = funcOp.walk([&](Wait op) -> mlir::WalkResult {
+    auto depEvent = op.event();
+    auto definingOp = depEvent.getDefiningOp();
+    return mlir::success(definingOp &&
+                         (mlir::isa<ScheduleOpInterface>(definingOp) ||
+                          mlir::isa<GroupEvents>(definingOp)));
+  });
+  if (checkSchedule.wasInterrupted())
+    return mlir::failure();
+  // All defining operations for group events are known
+  auto checkGroup = funcOp.walk([&](GroupEvents op) -> mlir::WalkResult {
+    for (auto user : op.getResult().getUsers()) {
+      if (!mlir::isa<Wait>(user) && !mlir::isa<GroupEvents>(user) &&
+          !mlir::isa<ScheduleOpInterface>(user))
+        return mlir::WalkResult::interrupt();
+    }
+    for (auto ev : op.events()) {
+      auto definingOp = ev.getDefiningOp();
+      if (!definingOp || (!mlir::isa<ScheduleOpInterface>(definingOp) &&
+                          !mlir::isa<GroupEvents>(definingOp)))
+        return mlir::WalkResult::interrupt();
+    }
+
+    return mlir::WalkResult::advance();
+  });
+  if (checkGroup.wasInterrupted())
+    return mlir::failure();
+
+  // Erase all waits
+  funcOp.walk([&](Wait op) { op.erase(); });
+  // Erase all dependency information from schedule operations
+  funcOp.walk(
+      [&](ScheduleOpInterface op) { op.getDependencyMutable().clear(); });
+  // Erase all group events
+  bool allGroupErased = false;
+  while (!allGroupErased) {
+    allGroupErased = true;
+    bool atLeastOneErased = false;
+    funcOp.walk([&](GroupEvents op) {
+      if (op.use_empty()) {
+        atLeastOneErased = true;
+        op.erase();
+      } else {
+        allGroupErased = false;
+      }
+    });
+    if (!allGroupErased && !atLeastOneErased) {
+      // Something went terribly wrong, there is something holding the use of
+      // event that wasn't discovered in first checks. This shouldn't happen,
+      // but just for safety of not having infinite loop.
+      return mlir::failure();
+    }
+  }
+
+  return mlir::success();
+}
+
+void removeRedundantRW(mlir::FuncOp funcOp) {
+  mlir::DenseMap<mlir::Value, std::list<mlir::Operation *>> allOperations;
+  mlir::DenseMap<mlir::Value, mlir::DenseSet<mlir::Value>> possibleAliases;
+
+  auto isUsingAlias = [&](mlir::Operation *op, mlir::Value val) -> bool {
+    for (auto operand : op->getOperands()) {
+      if (operand == val)
+        return true;
+      for (auto alias : possibleAliases[val]) {
+        if (operand == alias)
+          return true;
+      }
+    }
+    return false;
+  };
+
+  auto fillAliases = [&](mlir::Operation *op) -> void {
+    for (auto aliased : possibleAliases) {
+      if (isUsingAlias(op, aliased.first))
+        allOperations[aliased.first].push_back(op);
+    }
+  };
+
+  auto gatherReadWriteOps = [&](mlir::Operation *op) -> void {
+    if (auto allocOp = mlir::dyn_cast<Alloc>(op)) {
+      auto deviceMem = allocOp.getResult();
+      allOperations[deviceMem] = {};
+      possibleAliases[deviceMem] = {};
+      auto hostMem = allocOp.hostMem();
+      if (hostMem)
+        possibleAliases[deviceMem].insert(hostMem);
+      allOperations[deviceMem].push_back(op);
+    } else if (auto readOp = mlir::dyn_cast<ScheduleRead>(op)) {
+      auto deviceMem = readOp.deviceMem();
+      auto hostMem = readOp.hostMem();
+      possibleAliases[deviceMem].insert(hostMem);
+      allOperations[deviceMem].push_back(op);
+    } else if (auto writeOp = mlir::dyn_cast<ScheduleWrite>(op)) {
+      auto deviceMem = writeOp.deviceMem();
+      auto hostMem = writeOp.hostMem();
+      possibleAliases[deviceMem].insert(hostMem);
+      allOperations[deviceMem].push_back(op);
+    } else {
+      fillAliases(op);
+    }
+  };
+
+  funcOp.walk(gatherReadWriteOps);
+
+  llvm::DenseSet<mlir::Operation *> toRemove;
+  // Analyse what can be removed
+  for (auto valUsers : allOperations) {
+    auto deviceMem = valUsers.first;
+    mlir::DenseSet<mlir::Value> synchronizedHostMem;
+    for (auto user : valUsers.second) {
+      if (auto allocOp = mlir::dyn_cast<Alloc>(user)) {
+        auto hostMem = allocOp.hostMem();
+        if (hostMem)
+          synchronizedHostMem.insert(hostMem);
+      } else if (auto readOp = mlir::dyn_cast<ScheduleRead>(user)) {
+        auto hostMem = readOp.hostMem();
+
+        if (synchronizedHostMem.count(hostMem))
+          toRemove.insert(user);
+        else
+          synchronizedHostMem.insert(hostMem);
+      } else if (auto writeOp = mlir::dyn_cast<ScheduleWrite>(user)) {
+        auto hostMem = writeOp.hostMem();
+
+        if (synchronizedHostMem.count(hostMem)) {
+          toRemove.insert(user);
+        } else {
+          synchronizedHostMem.clear();
+          synchronizedHostMem.insert(hostMem);
+        }
+      } else {
+        for (auto operand : user->getOperands()) {
+          if (operand == deviceMem) {
+            synchronizedHostMem.clear();
+            break;
+          } else if (synchronizedHostMem.count(operand)) {
+            synchronizedHostMem.erase(operand);
+          }
+        }
+      }
+    }
+  }
+
+  // Find read -> (...) -> read pattern with (...) not using device memory
+  for (auto valUsers : allOperations) {
+    llvm::DenseSet<mlir::Value> unusedHost;
+    llvm::DenseMap<mlir::Value, mlir::Operation *> previousRead;
+    for (auto user : valUsers.second) {
+      if (toRemove.count(user))
+        continue;
+      if (auto readOp = mlir::dyn_cast<ScheduleRead>(user)) {
+        auto hostMem = readOp.hostMem();
+
+        if (unusedHost.count(hostMem)) {
+          toRemove.insert(previousRead[hostMem]);
+        } else {
+          unusedHost.insert(hostMem);
+          previousRead[hostMem] = user;
+        }
+      } else {
+        for (auto operand : user->getOperands()) {
+          if (unusedHost.count(operand)) {
+            unusedHost.erase(operand);
+            previousRead.erase(operand);
+          }
+        }
+      }
+    }
+  }
+
+  // Remove
+  for (auto op : toRemove) {
+    op->erase();
+  }
+}
+
+void recalculateEventDependencies(mlir::FuncOp funcOp) {
+  // Recreate waits by analysing memory dependencies
+  llvm::DenseMap<mlir::Value, mlir::Value> memoryEventMap;
+
+  auto gatherEventDependencies = [&](mlir::Operation *op) {
+    // Skip gpu.launch_func as it will be handled by parent comp.schedule_func
+    if (mlir::isa<gpu::LaunchFuncOp>(op))
+      return;
+
+    mlir::OpBuilder builder(op);
+    std::vector<mlir::Value> dependencies;
+    std::vector<mlir::Value> dependees;
+
+    if (auto scheduleFuncOp = mlir::dyn_cast<ScheduleFunc>(op)) {
+      // Special case for schedule_func, as its dependencies should be taken
+      // from actual function launch
+      auto launchOp =
+          mlir::cast<gpu::LaunchFuncOp>(scheduleFuncOp.body().front().front());
+      for (auto &operand : launchOp.getOperation()->getOperands()) {
+        if (memoryEventMap.count(operand)) {
+          dependencies.push_back(memoryEventMap[operand]);
+          dependees.push_back(operand);
+        } else if (operand.getType().isa<mlir::MemRefType>()) {
+          dependees.push_back(operand);
+        }
+      }
+    } else {
+      for (auto operand : op->getOperands()) {
+        if (memoryEventMap.count(operand)) {
+          dependencies.push_back(memoryEventMap[operand]);
+          dependees.push_back(operand);
+        } else if (operand.getType().isa<mlir::MemRefType>()) {
+          dependees.push_back(operand);
+        }
+      }
+    }
+
+    if (auto scheduleOp = mlir::dyn_cast<ScheduleOpInterface>(op)) {
+      // For operations with schedule interface dependencies become operation
+      // parameter
+      if (!dependencies.empty()) {
+        auto execEnvOp = mlir::cast<ExecEnvOpInterface>(op);
+        auto execEnvType = execEnvOp.getExecEnv().getType().cast<ExecEnvType>();
+        auto eventType = builder.getType<EventType>(execEnvType.getRuntime());
+        auto groupOp = builder.createOrFold<GroupEvents>(
+            op->getLoc(), eventType, dependencies);
+        scheduleOp.getDependencyMutable().assign(groupOp);
+      }
+      // Update dependees with resulting event
+      for (auto dep : dependees) {
+        memoryEventMap[dep] = scheduleOp.getResultingEvent();
+      }
+    } else {
+      // For non-schedule operations waits are needed to ensure correct
+      // ordering. Separate wait for each environment.
+      llvm::DenseMap<mlir::Type, std::vector<mlir::Value>> eventTypeGroups;
+      for (auto dep : dependencies) {
+        auto eventType = dep.getType().cast<EventType>();
+        if (eventTypeGroups.count(eventType)) {
+          eventTypeGroups[eventType].push_back(dep);
+        } else {
+          eventTypeGroups[eventType] = {dep};
+        }
+      }
+
+      for (auto typeEvents : eventTypeGroups) {
+        auto &eventType = typeEvents.first;
+        auto &events = typeEvents.second;
+        auto groupOp =
+            builder.createOrFold<GroupEvents>(op->getLoc(), eventType, events);
+        builder.createOrFold<Wait>(op->getLoc(), groupOp);
+      }
+
+      for (auto dep : dependees) {
+        memoryEventMap.erase(dep);
+      }
+    }
+  };
+
+  funcOp.walk(gatherEventDependencies);
+}
+
+} // namespace
+
+class ExecEnvCoalescing : public ExecEnvCoalescingBase<ExecEnvCoalescing> {
+public:
+  void runOnFunction() override {
+    auto funcOp = getFunction();
+
+    // Currently only single block is correctly optimized as optimizations rely
+    // on knowing the order of execution
+    // TODO Loosen this restriction
+    if (funcOp.getBlocks().size() != 1)
+      return;
+
+    reuseExecEnv(funcOp);
+    reuseMemory(funcOp);
+    if (mlir::failed(eraseEventDependencies(funcOp))) {
+      // Can't erase event dependencies, so optimizations stop here
+      // TODO Extend following passes to work gracefully with existing
+      // dependencies
+      return;
+    }
+    removeRedundantRW(funcOp);
+    recalculateEventDependencies(funcOp);
+  }
+};
+
+std::unique_ptr<mlir::Pass> createExecEnvCoalescingPass() {
+  return std::make_unique<ExecEnvCoalescing>();
+}
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/transforms/pass_detail.h
+++ b/pmlc/dialect/comp/transforms/pass_detail.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+#include "pmlc/dialect/comp/ir/dialect.h"
+
+namespace pmlc::dialect::comp {
+
+#define GEN_PASS_CLASSES
+#include "pmlc/dialect/comp/transforms/passes.h.inc"
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/transforms/passes.h
+++ b/pmlc/dialect/comp/transforms/passes.h
@@ -1,0 +1,16 @@
+// Copyright 2020 Intel Corporation
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace mlir {
+class Pass;
+} // namespace mlir
+
+namespace pmlc::dialect::comp {
+
+std::unique_ptr<mlir::Pass> createExecEnvCoalescingPass();
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/transforms/passes.td
+++ b/pmlc/dialect/comp/transforms/passes.td
@@ -1,0 +1,13 @@
+// Copyright 2020 Intel Corporation
+
+#ifndef __PMLC_DIALECT_COMP_PASSES__
+#define __PMLC_DIALECT_COMP_PASSES__
+
+include "mlir/Pass/PassBase.td"
+
+def ExecEnvCoalescing : FunctionPass<"pmlc-execenv-coalescing"> {
+  let summary = "Combines same execution environments.";
+  let constructor = "pmlc::dialect::comp::createExecEnvCoalescingPass()";
+}
+
+#endif // __PMLC_DIALECT_COMP_PASSES__

--- a/pmlc/dialect/stdx/transforms/BUILD
+++ b/pmlc/dialect/stdx/transforms/BUILD
@@ -23,6 +23,7 @@ plaidml_cc_library(
     name = "transforms",
     srcs = [
         "boundscheck.cc",
+        "i1_to_i32.cc",
         "pass_detail.h",
     ],
     hdrs = [

--- a/pmlc/dialect/stdx/transforms/i1_to_i32.cc
+++ b/pmlc/dialect/stdx/transforms/i1_to_i32.cc
@@ -1,0 +1,113 @@
+// Copyright 2020 Intel Corporation
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/Pass/Pass.h"
+#include "pmlc/dialect/stdx/transforms/pass_detail.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+namespace pmlc::dialect::stdx {
+
+namespace {
+
+/// Changes loadOp from i1 memref to loadOp i32 followed by creting constant
+/// value 0 of i32 type and doing cmpi afterwards, next this bool-like type will
+/// be produced
+class LoadOpI1ToI32 final : public OpRewritePattern<LoadOp> {
+public:
+  using OpRewritePattern<LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LoadOp loadOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+/// Changes storeOp to i1 memref to i32 select(val, 1, 0) followed by storeOp to
+/// i32
+class StoreOpI1ToI32 final : public OpRewritePattern<StoreOp> {
+public:
+  using OpRewritePattern<StoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StoreOp storeOp,
+                                PatternRewriter &rewriter) const override;
+};
+} // namespace
+
+/// Changes loadOp from i1 memref to loadOp i32 followed by creting constant
+/// value 0 of i32 type and doing cmpi afterwards, next this bool-like type will
+/// be produced
+LogicalResult LoadOpI1ToI32::matchAndRewrite(LoadOp loadOp,
+                                             PatternRewriter &rewriter) const {
+  auto elementType = loadOp.result().getType();
+  if (!elementType.isInteger(1)) {
+    return failure();
+  }
+
+  auto destType = rewriter.getIntegerType(32);
+  auto loc = loadOp.getLoc();
+
+  loadOp.getMemRef().setType(
+      MemRefType::get(loadOp.getMemRefType().getShape(), destType));
+
+  auto newLoadOp =
+      rewriter.create<LoadOp>(loc, loadOp.memref(), loadOp.indices());
+
+  auto const0 =
+      rewriter.create<ConstantOp>(loc, rewriter.getIntegerAttr(destType, 0));
+  auto cmpOp = rewriter.create<CmpIOp>(
+      loc, CmpIPredicate::ne, newLoadOp.getResult(), const0.getResult());
+
+  rewriter.replaceOp(loadOp, {cmpOp});
+  return success();
+}
+
+/// Changes storeOp to i1 memref to i32 select(val, 1, 0) followed by storeOp to
+/// i32
+LogicalResult StoreOpI1ToI32::matchAndRewrite(StoreOp storeOp,
+                                              PatternRewriter &rewriter) const {
+  auto elementType = storeOp.value().getType();
+  if (!elementType.isInteger(1)) {
+    return failure();
+  }
+
+  auto destType = rewriter.getIntegerType(32);
+  auto loc = storeOp.getLoc();
+
+  auto const0 =
+      rewriter.create<ConstantOp>(loc, rewriter.getIntegerAttr(destType, 0));
+  auto const1 =
+      rewriter.create<ConstantOp>(loc, rewriter.getIntegerAttr(destType, 1));
+  auto selOp = rewriter.create<SelectOp>(
+      loc, storeOp.value(), const1.getResult(), const0.getResult());
+
+  storeOp.getMemRef().setType(
+      MemRefType::get(storeOp.getMemRefType().getShape(), destType));
+
+  rewriter.replaceOpWithNewOp<StoreOp>(storeOp, selOp.getResult(),
+                                       storeOp.memref(), storeOp.indices());
+
+  return success();
+}
+
+/// Hook for adding patterns.
+void populateI1StorageToI32(MLIRContext *context,
+                            OwningRewritePatternList &patterns) {
+  patterns.insert<LoadOpI1ToI32, StoreOpI1ToI32>(context);
+}
+
+struct I1StorageToI32Pass : public I1StorageToI32Base<I1StorageToI32Pass> {
+  void runOnFunction() final {
+    OwningRewritePatternList patterns;
+    auto *context = &getContext();
+
+    populateI1StorageToI32(context, patterns);
+    applyPatternsAndFoldGreedily(getOperation(), patterns);
+  }
+};
+
+std::unique_ptr<mlir::Pass> createI1StorageToI32Pass() {
+  return std::make_unique<I1StorageToI32Pass>();
+}
+
+} // namespace pmlc::dialect::stdx

--- a/pmlc/dialect/stdx/transforms/passes.h
+++ b/pmlc/dialect/stdx/transforms/passes.h
@@ -12,5 +12,6 @@ class Pass;
 namespace pmlc::dialect::stdx {
 
 std::unique_ptr<mlir::Pass> createBoundsCheckPass();
+std::unique_ptr<mlir::Pass> createI1StorageToI32Pass();
 
 } // namespace pmlc::dialect::stdx

--- a/pmlc/dialect/stdx/transforms/passes.td
+++ b/pmlc/dialect/stdx/transforms/passes.td
@@ -8,4 +8,9 @@ def BoundsCheck : FunctionPass<"stdx-check-bounds"> {
   let constructor = "pmlc::dialect::stdx::createBoundsCheckPass()";
 }
 
+def I1StorageToI32 : FunctionPass<"stdx-i1-storage-to-i32"> {
+  let summary = "Convert i1 storage type to i32";
+  let constructor = "pmlc::dialect::stdx::createI1StorageToI32Pass()";
+}
+
 #endif // __PMLC_DIALECT_STDX_PASSES__

--- a/pmlc/rt/opencl/BUILD
+++ b/pmlc/rt/opencl/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2020 Intel Corporation
+
+package(default_visibility = ["//visibility:public"])
+
+load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
+
+plaidml_cc_library(
+    name = "opencl",
+    srcs = [
+        "opencl_runtime.cc",
+        "wrappers.cc",
+    ],
+    hdrs = [
+        "opencl_runtime.h",
+    ],
+    deps = [
+        "//pmlc/compiler",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SPIRVLowering",
+        "@llvm-project//mlir:mlir_runner_utils",
+        "@opencl_hpp_headers",
+        "@opencl_icd_loader"
+    ],
+    alwayslink = 1,
+)
+
+
+plaidml_cc_binary(
+    name = "clprobe",
+    srcs = ["clprobe.cc"],
+    deps = ["@opencl_icd_loader", "@opencl_hpp_headers"],
+)

--- a/pmlc/rt/opencl/clprobe.cc
+++ b/pmlc/rt/opencl/clprobe.cc
@@ -1,0 +1,22 @@
+// Copyright 2020 Intel Corporation
+
+#include <iostream>
+#include <vector>
+
+#include "CL/cl2.hpp"
+
+int main(int argc, char **argv) {
+  std::cout << "Availiable platforms and devices:" << std::endl;
+  std::vector<cl::Platform> platforms;
+  cl::Platform::get(&platforms);
+  for (auto &p : platforms) {
+    std::cout << p.getInfo<CL_PLATFORM_NAME>() << std::endl;
+    std::vector<cl::Device> devices;
+    p.getDevices(CL_DEVICE_TYPE_ALL, &devices);
+    for (auto &d : devices) {
+      std::cout << "  " << d.getInfo<CL_DEVICE_NAME>() << std::endl;
+    }
+  }
+
+  return 1;
+}

--- a/pmlc/rt/opencl/opencl_runtime.cc
+++ b/pmlc/rt/opencl/opencl_runtime.cc
@@ -1,0 +1,259 @@
+// Copyright 2020 Intel Corporation
+
+#include "pmlc/rt/opencl/opencl_runtime.h"
+
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+namespace oclrt {
+
+struct OpenClKernel {
+  cl::Kernel kernel;
+};
+
+struct OpenClBuffer {
+  cl::Buffer buffer;
+  uint32_t length;
+};
+
+struct OpenClEvent {
+  std::vector<cl::Event> events;
+  OpenClRuntime *runtime;
+};
+
+namespace {
+
+cl::Device createDevice() {
+  std::vector<cl::Platform> platforms;
+  std::vector<cl::Device> devices;
+  cl::Platform::get(&platforms);
+  for (auto &p : platforms) {
+    auto vendor = p.getInfo<CL_PLATFORM_VENDOR>();
+    if (vendor.find("Intel") != std::string::npos) {
+      p.getDevices(CL_DEVICE_TYPE_GPU, &devices);
+      if (!devices.empty())
+        return devices.front();
+      devices.clear();
+    }
+  }
+  // TODO Fix this
+  return cl::Device();
+}
+
+} // namespace
+
+OpenClRuntime::OpenClRuntime()
+    : rtDevice(createDevice()), rtContext(rtDevice), rtQueue(rtContext) {}
+
+OpenClRuntime::~OpenClRuntime() { rtQueue.finish(); }
+
+mlir::FailureOr<OpenClKernel *> OpenClRuntime::createKernel(uint8_t *spirv,
+                                                            uint32_t length) {
+  cl_int err = CL_SUCCESS;
+  auto clProgram = clCreateProgramWithIL(rtContext.get(), spirv, length, &err);
+  if (CL_SUCCESS != err)
+    return mlir::failure();
+  auto program = cl::Program(clProgram);
+  if (CL_SUCCESS != program.build({rtDevice})) {
+    auto log = program.getBuildInfo<CL_PROGRAM_BUILD_LOG>();
+    for (auto &l : log) {
+      std::cout << l.second << std::endl;
+    }
+    return mlir::failure();
+  }
+
+  auto log = program.getBuildInfo<CL_PROGRAM_BUILD_LOG>();
+  for (auto &l : log) {
+    std::cout << l.second << std::endl;
+  }
+
+  std::vector<cl::Kernel> kernels;
+
+  if (CL_SUCCESS != program.createKernels(&kernels) || kernels.size() != 1) {
+    std::cout << "kernels " << kernels.size() << std::endl;
+    return mlir::failure();
+  }
+
+  rtKernels.emplace_back(new OpenClKernel{kernels[0]});
+  return rtKernels.back().get();
+}
+
+mlir::FailureOr<OpenClEvent *>
+OpenClRuntime::enqueueKernel(OpenClKernel *kernel, uint32_t dimX, uint32_t dimY,
+                             uint32_t dimZ, uint32_t localX, uint32_t localY,
+                             uint32_t localZ, OpenClEvent *dep) {
+  if (!kernel)
+    return mlir::failure();
+  auto clKernel = kernel->kernel;
+
+  auto offset = cl::NDRange();
+  auto global = cl::NDRange(dimX, dimY, dimZ);
+  auto local = cl::NDRange(localX, localY, localZ);
+  cl::Event ev;
+  std::vector<cl::Event> dependencies;
+  if (dep)
+    dependencies = dep->events;
+
+  auto status = rtQueue.enqueueNDRangeKernel(clKernel, offset, global, local,
+                                             &dependencies, &ev);
+  if (CL_SUCCESS != status) {
+    std::cout << "status: " << status << std::endl;
+    std::cout << "global: " << dimX << " " << dimY << " " << dimZ << std::endl;
+    std::cout << "local: " << localX << " " << localY << " " << localZ
+              << std::endl;
+    return mlir::failure();
+  }
+
+  auto wrappedEvent = new OpenClEvent();
+  wrappedEvent->events.push_back(ev);
+  wrappedEvent->runtime = this;
+  rtEvents.emplace_back(wrappedEvent);
+  return wrappedEvent;
+}
+
+mlir::LogicalResult OpenClRuntime::setBufferArg(OpenClKernel *kernel,
+                                                int32_t idx,
+                                                OpenClBuffer *buffer) {
+  if (!kernel || !buffer)
+    return mlir::failure();
+
+  auto status = kernel->kernel.setArg(idx, buffer->buffer);
+  return mlir::success(CL_SUCCESS == status);
+}
+
+mlir::FailureOr<OpenClBuffer *> OpenClRuntime::allocBuffer(void *ptr,
+                                                           int32_t length) {
+  cl_int err = CL_SUCCESS;
+  cl_mem_flags flags = CL_MEM_READ_WRITE;
+  if (ptr)
+    flags = flags | CL_MEM_COPY_HOST_PTR;
+  std::cout << flags << std::endl;
+  auto buffer = cl::Buffer(rtContext, flags, (size_t)length, ptr, &err);
+  if (CL_SUCCESS != err) {
+    std::cout << "status: " << err << ", " << length << std::endl;
+    return mlir::failure();
+  }
+  std::cout << "allocated" << std::endl;
+
+  auto rtBuffer = new OpenClBuffer();
+  rtBuffer->buffer = buffer;
+  rtBuffer->length = length;
+  return rtBuffer;
+}
+
+mlir::FailureOr<OpenClEvent *>
+OpenClRuntime::enqueueRead(OpenClBuffer *buffer, void *ptr, OpenClEvent *dep) {
+  if (!buffer || !ptr)
+    return mlir::failure();
+
+  cl::Event ev;
+  std::vector<cl::Event> dependencies;
+  if (dep)
+    dependencies = dep->events;
+  // cl_int err;
+  // auto mapPtr = rtQueue.enqueueMapBuffer(buffer->buffer, true, CL_MAP_READ |
+  // CL_MAP_WRITE, 0, buffer->length, &dependencies, nullptr, &err); if
+  // (CL_SUCCESS != err) {
+  //   std::cout << "map failed: " << err << std::endl;
+  //   return mlir::failure();
+  // }
+  // std::cout << "mapped " << buffer->length << std::endl;
+  // // for (size_t i = 0; i < buffer->length; ++i) {
+  // //   std::cout << i << std::endl;
+  // //   static_cast<char*>(ptr)[i] = static_cast<char*>(mapPtr)[i];
+  // // }
+  // std::cout << "copied" << std::endl;
+  // err = rtQueue.enqueueUnmapMemObject(buffer->buffer, mapPtr, nullptr, &ev);
+  // if (CL_SUCCESS != err) {
+  //   std::cout << "unmap failed: " << err << std::endl;
+  //   return mlir::failure();
+  // }
+  //   std::cout << "unmapped" << std::endl;
+
+  //
+  auto err = rtQueue.enqueueReadBuffer(buffer->buffer, false, 0, buffer->length,
+                                       ptr, &dependencies, &ev);
+  if (CL_SUCCESS != err) {
+    std::cout << "status: " << err << std::endl;
+    return mlir::failure();
+  }
+
+  auto rtEvent = new OpenClEvent();
+  rtEvent->events.push_back(ev);
+  rtEvent->runtime = this;
+  rtEvents.emplace_back(rtEvent);
+  return rtEvent;
+}
+
+mlir::FailureOr<OpenClEvent *>
+OpenClRuntime::enqueueWrite(OpenClBuffer *buffer, void *ptr, OpenClEvent *dep) {
+  if (!buffer)
+    return mlir::failure();
+
+  cl::Event ev;
+  std::vector<cl::Event> dependencies;
+  if (dep)
+    dependencies = dep->events;
+
+  auto status = rtQueue.enqueueWriteBuffer(
+      buffer->buffer, false, 0, buffer->length, ptr, &dependencies, &ev);
+  if (CL_SUCCESS != status)
+    return mlir::failure();
+
+  auto rtEvent = new OpenClEvent();
+  rtEvent->events.push_back(ev);
+  rtEvent->runtime = this;
+  rtEvents.emplace_back(rtEvent);
+  return rtEvent;
+}
+
+mlir::LogicalResult OpenClRuntime::flush() {
+  return mlir::success(CL_SUCCESS == rtQueue.flush());
+}
+
+void OpenClRuntime::registerEvent(OpenClEvent *event) {
+  rtEvents.emplace_back(event);
+}
+
+mlir::LogicalResult deallocBuffer(OpenClBuffer *ptr) {
+  if (!ptr)
+    return mlir::failure();
+  delete ptr;
+  return mlir::success();
+}
+
+mlir::FailureOr<OpenClEvent *> groupEvents(std::vector<OpenClEvent *> events) {
+  if (events.empty())
+    return mlir::failure();
+
+  std::vector<cl::Event> grouped;
+  for (auto &rtEvent : events) {
+    if (!rtEvent)
+      continue; // Should it be failure?
+    for (auto &ev : rtEvent->events) {
+      grouped.push_back(ev);
+    }
+  }
+  OpenClRuntime *runtime;
+  runtime = events[0]->runtime;
+
+  auto rtEvent = new OpenClEvent();
+  rtEvent->events = grouped;
+  rtEvent->runtime = runtime;
+  runtime->registerEvent(rtEvent);
+  return rtEvent;
+}
+
+mlir::LogicalResult wait(OpenClEvent *event) {
+  if (!event)
+    return mlir::failure();
+
+  for (auto &ev : event->events) {
+    ev.wait();
+  }
+  return mlir::success();
+}
+
+} // namespace oclrt

--- a/pmlc/rt/opencl/opencl_runtime.h
+++ b/pmlc/rt/opencl/opencl_runtime.h
@@ -1,0 +1,54 @@
+// Copyright 2020 Intel Corporation
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "CL/cl2.hpp"
+
+#include "mlir/Support/LogicalResult.h"
+
+namespace oclrt {
+
+struct OpenClKernel;
+struct OpenClEvent;
+struct OpenClBuffer;
+
+class OpenClRuntime {
+public:
+  OpenClRuntime();
+  virtual ~OpenClRuntime();
+
+  mlir::FailureOr<OpenClKernel *> createKernel(uint8_t *spirv, uint32_t length);
+  mlir::FailureOr<OpenClEvent *> enqueueKernel(OpenClKernel *kernel,
+                                               uint32_t dimX, uint32_t dimY,
+                                               uint32_t dimZ, uint32_t localX,
+                                               uint32_t localY, uint32_t localZ,
+                                               OpenClEvent *dep);
+  mlir::LogicalResult setBufferArg(OpenClKernel *kernel, int32_t idx,
+                                   OpenClBuffer *buffer);
+
+  mlir::FailureOr<OpenClBuffer *> allocBuffer(void *ptr, int32_t length);
+  mlir::FailureOr<OpenClEvent *> enqueueRead(OpenClBuffer *buf, void *ptr,
+                                             OpenClEvent *dep);
+  mlir::FailureOr<OpenClEvent *> enqueueWrite(OpenClBuffer *buf, void *ptr,
+                                              OpenClEvent *dep);
+
+  mlir::LogicalResult flush();
+
+  void registerEvent(OpenClEvent *event);
+
+private:
+  cl::Device rtDevice;
+  cl::Context rtContext;
+  cl::CommandQueue rtQueue;
+  std::vector<std::unique_ptr<OpenClKernel>> rtKernels;
+  std::vector<std::unique_ptr<OpenClEvent>> rtEvents;
+};
+
+mlir::LogicalResult deallocBuffer(OpenClBuffer *ptr);
+mlir::FailureOr<OpenClEvent *> groupEvents(std::vector<OpenClEvent *> events);
+mlir::LogicalResult wait(OpenClEvent *event);
+
+} // namespace oclrt

--- a/pmlc/rt/opencl/tests/BUILD
+++ b/pmlc/rt/opencl/tests/BUILD
@@ -1,0 +1,45 @@
+# Copyright 2020 Intel Corporation
+
+package(default_visibility = ["//visibility:public"])
+
+load("//pmlc:lit.bzl", "glob_lit_tests", "lit_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_test","plaidml_cc_library")
+
+glob_lit_tests(
+  data = ["//pmlc/rt/opencl:clprobe"]
+)
+
+plaidml_cc_library(
+    name = "testenv",
+    testonly = 1,
+    srcs = ["testenv.cc"],
+    hdrs = ["testenv.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//plaidml",
+        "@gmock//:gtest",
+    ],
+    alwayslink = 1,
+)
+
+plaidml_cc_test(
+    name = "cc_test_gpu",
+    srcs = ["edsl_test_gpu.cc"],
+    tags = ["manual"],  # the `edsl_test.cc.test` rule will run this test via lit
+    deps = [
+        ":testenv",
+        "//plaidml/edsl",
+        "//plaidml/exec",
+        "//pmlc/rt/opencl",
+    ],
+    linkstatic = 1,
+)
+
+lit_test(
+	name="edsl_test_gpu.cc",
+    data = [
+    	":cc_test_gpu",
+    	"lit.local.cfg",
+    	"//pmlc/rt/opencl:clprobe",
+    ],
+)

--- a/pmlc/rt/opencl/tests/CPPLINT.cfg
+++ b/pmlc/rt/opencl/tests/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace/line_length

--- a/pmlc/rt/opencl/tests/edsl_test_gpu.cc
+++ b/pmlc/rt/opencl/tests/edsl_test_gpu.cc
@@ -1,0 +1,582 @@
+// Copyright 2020 Intel Corporation
+// RUN: cc_test_gpu | FileCheck %s
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "llvm/ADT/StringRef.h"
+
+#include "plaidml/edsl/autodiff.h"
+#include "plaidml/edsl/edsl.h"
+#include "plaidml/exec/exec.h"
+#include "plaidml/op/op.h"
+#include "pmlc/rt/opencl/tests/testenv.h"
+#include "pmlc/util/env.h"
+#include "pmlc/util/logging.h"
+
+using llvm::StringRef;
+using ::testing::ContainerEq;
+using ::testing::Eq;
+
+namespace plaidml::edsl {
+namespace {
+
+class CppEdsl : public TestFixture {};
+
+Program makeProgram(const std::string &name,
+                    const std::vector<Tensor> &outputs) {
+  auto program = ProgramBuilder(name, outputs).compile();
+  std::cout << program << std::endl;
+  return program;
+}
+
+Tensor Dot(const Tensor &X, const Tensor &Y) {
+  TensorDim I, J, K;
+  TensorIndex i("i"), j("j"), k("k");
+  X.bind_dims(I, K);
+  Y.bind_dims(K, J);
+  auto R = TensorOutput(I, J);
+  R(i, j) += X(i, k) * Y(k, j);
+  return R;
+}
+
+Tensor Relu(const Tensor &I) { return select(I < 0.0, Tensor{0.0}, I); }
+
+Tensor Softmax(const Tensor &X) {
+  TensorDim I, J;
+  TensorIndex i, j;
+  X.bind_dims(I, J);
+  auto M = TensorOutput(I, 1);
+  M(i, 0) >= X(i, j);
+  auto E = exp(X - M);
+  auto N = TensorOutput(I, 1);
+  N(i, 0) += E(i, j);
+  return E / N;
+}
+
+TEST_F(CppEdsl, Dot) {
+  int64_t M = 8;
+  int64_t N = 32;
+  int64_t K = 16;
+  auto A = Placeholder(DType::FLOAT32, {M, K});
+  auto B = Placeholder(DType::FLOAT32, {K, N});
+  auto C = Dot(A, B);
+  auto program = makeProgram("dot", {C});
+
+  // CHECK-LABEL: CppEdsl.Dot
+  // CHECK: func @dot
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"{{.*}}-> tensor<f32>
+  // CHECK: %[[cion:.*]] = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}}
+  // tensor<8x32xf32> CHECK: return %[[cion]] : tensor<8x32xf32>
+
+  std::default_random_engine rng(2);
+  std::normal_distribution<float> normal_dist(0.0, 1.0);
+
+  std::vector<float> in1(M * K);
+  for (unsigned i = 0; i < in1.size(); i++) {
+    in1[i] = normal_dist(rng);
+  }
+  std::vector<float> in2(K * N);
+  for (unsigned i = 0; i < in2.size(); i++) {
+    in2[i] = normal_dist(rng);
+  }
+  std::vector<float> expected(M * N);
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        expected[i * N + j] += in1[i * K + k] * in2[k * N + j];
+      }
+    }
+  }
+  checkProgram(program, {{A, in1}, {B, in2}}, {{C, expected}});
+}
+
+TEST_F(CppEdsl, DoubleDot) {
+  auto A = Placeholder(DType::FLOAT32, {10, 20});
+  auto B = Placeholder(DType::FLOAT32, {20, 30});
+  auto C = Placeholder(DType::FLOAT32, {30, 40});
+  auto program = makeProgram("double_dot", {Dot(Dot(A, B), C)});
+
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.DoubleDot
+  // CHECK: func @double_dot
+  // CHECK: tensor<10x20xf32>) -> tensor<10x40xf32> {
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<10x20xf32>, tensor<20x30xf32> -> tensor<10x30xf32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<10x30xf32>, tensor<30x40xf32> -> tensor<10x40xf32>
+  // CHECK: return %{{.*}} : tensor<10x40xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, EltwiseAdd) {
+  auto A = Placeholder(DType::FLOAT32, {10, 20});
+  auto B = Placeholder(DType::FLOAT32, {10, 20});
+  auto program = makeProgram("eltwise_add", {A + B});
+
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.EltwiseAdd
+  // CHECK: func @eltwise_add
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<10x20xf32>, tensor<10x20xf32>) -> tensor<10x20xf32>
+  // CHECK: return %{{.*}} : tensor<10x20xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+Tensor Convolution2(const Tensor &I, const Tensor &K) {
+  TensorDim CI, CO, K0, K1, N, X0, X1;
+  TensorIndex n, x0, x1, co, ci, k0, k1;
+  I.bind_dims(N, X0, X1, CI);
+  K.bind_dims(K0, K1, CI, CO);
+  auto R = TensorOutput(N, X0, X1, CO);
+  R(n, x0, x1, co) +=
+      I(n, x0 + k0 - (K0 / 2), x1 + k1 - (K1 / 2), ci) * K(k0, k1, ci, co);
+  return R;
+}
+
+TEST_F(CppEdsl, Convolution) {
+  auto I = Placeholder(DType::FLOAT32, {1, 224, 224, 3});
+  auto K = Placeholder(DType::FLOAT32, {3, 3, 1, 32});
+  auto program = makeProgram("convolution", {Convolution2(I, K)});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.Convolution
+  // CHECK: func @convolution
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x224x224x3xf32>, tensor<3x3x1x32xf32> -> tensor<1x224x224x32xf32>
+  // CHECK: return %{{.*}} : tensor<1x224x224x32xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+Tensor MaxPooling2(const Tensor &I) {
+  TensorDim N, X0, X1, C;
+  TensorIndex n, x0, x1, i, j, c;
+  I.bind_dims(N, X0, X1, C);
+  auto R = TensorOutput(N, (X0 + 1) / 2, (X1 + 1) / 2, C);
+  R(n, x0, x1, c) >= I(n, 2 * x0 + i, 2 * x1 + j, c);
+  R.add_constraints({i < 2, j < 2});
+  return R;
+}
+
+Tensor Flatten(const Tensor &X) {
+  std::vector<TensorDim> X_dims(X.rank());
+  X.bind_dims(X_dims);
+  if (X_dims.empty()) {
+    return X;
+  }
+  TensorDim product{1};
+  for (size_t i = 1; i < X_dims.size() - 1; i++) {
+    product = product * X_dims[i];
+  }
+  return reshape(X, {TensorDim{1}, product});
+}
+
+TEST_F(CppEdsl, MnistCnn) {
+  // model.add(Conv2D(32, kernel_size=(3, 3), activation='relu',
+  // input_shape=input_shape))
+  auto input = Placeholder(DType::FLOAT32, {1, 224, 224, 1});
+  auto kernel1 = Placeholder(DType::FLOAT32, {3, 3, 1, 32});
+  auto bias1 = Placeholder(DType::FLOAT32, {32});
+  auto conv1 = Relu(Convolution2(input, kernel1) + bias1);
+  // model.add(Conv2D(64, (3, 3), activation='relu'))
+  auto kernel2 = Placeholder(DType::FLOAT32, {3, 3, 32, 64});
+  auto bias2 = Placeholder(DType::FLOAT32, {64});
+  auto conv2 = Relu(Convolution2(conv1, kernel2) + bias2);
+  // model.add(MaxPooling2D(pool_size=(2, 2)))
+  auto pool1 = MaxPooling2(conv2);
+  // model.add(Flatten())
+  auto flat = Flatten(pool1);
+  EXPECT_THAT(flat.compute_shape(),
+              Eq(LogicalShape(DType::FLOAT32, {1, 12544})));
+  // model.add(Dense(128, activation='relu'))
+  auto kernel3 = Placeholder(DType::FLOAT32, {12544, 128});
+  auto bias3 = Placeholder(DType::FLOAT32, {128});
+  auto dense1 = Relu(Dot(flat, kernel3) + bias3);
+  const std::int64_t kNumClasses = 100;
+  // model.add(Dense(num_classes, activation='softmax'))
+  auto kernel4 = Placeholder(DType::FLOAT32, {128, kNumClasses});
+  auto bias4 = Placeholder(DType::FLOAT32, {kNumClasses});
+  auto dense2 = Softmax(Dot(dense1, kernel4) + bias4);
+  auto program = ProgramBuilder("mnist_cnn", {dense2}).target("").compile();
+  std::cout << program << std::endl;
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.MnistCnn
+  // CHECK: func @mnist_cnn
+  // CHECK-DAG: %[[c12544:.*]] = tile.constant 12544
+  // CHECK-DAG: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK-DAG: %[[c1:.*]] = tile.constant 1
+  // CHECK-DAG: %[[cst_0:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x224x224x1xf32>, tensor<3x3x1x32xf32> -> tensor<1x224x224x32xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x224x224x32xf32>, tensor<32xf32>) -> tensor<1x224x224x32xf32>
+  // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x224x224x32xf32>, tensor<f32>) -> tensor<1x224x224x32xi1>
+  // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x224x224x32xi1>, tensor<f32>, tensor<1x224x224x32xf32>) -> tensor<1x224x224x32xf32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x224x224x32xf32>, tensor<3x3x32x64xf32> -> tensor<1x224x224x64xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x224x224x64xf32>, tensor<64xf32>) -> tensor<1x224x224x64xf32>
+  // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x224x224x64xf32>, tensor<f32>) -> tensor<1x224x224x64xi1>
+  // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x224x224x64xi1>, tensor<f32>, tensor<1x224x224x64xf32>) -> tensor<1x224x224x64xf32>
+  // CHECK: %{{.*}} = tile.contract max, none, %[[cst_0]], %{{.*}} {cons = #set{{[0-9]+}}, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<1x224x224x64xf32> -> tensor<1x112x112x64xf32>
+  // CHECK: %{{.*}} = "tile.reshape"(%{{.*}}, %[[c1]], %[[c12544]]) : (tensor<1x112x112x64xf32>, index, index) -> tensor<1x12544xf32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x12544xf32>, tensor<12544x128xf32> -> tensor<1x128xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x128xf32>, tensor<128xf32>) -> tensor<1x128xf32>
+  // CHECK: %{{.*}} = "eltwise.cmp_lt"(%{{.*}}, %[[cst]]) : (tensor<1x128xf32>, tensor<f32>) -> tensor<1x128xi1>
+  // CHECK: %{{.*}} = "eltwise.select"(%{{.*}}, %[[cst]], %{{.*}}) : (tensor<1x128xi1>, tensor<f32>, tensor<1x128xf32>) -> tensor<1x128xf32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {idxs = ["i", "j", "k"], sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x128xf32>, tensor<128x100xf32> -> tensor<1x100xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<1x100xf32>, tensor<100xf32>) -> tensor<1x100xf32>
+  // CHECK: %{{.*}} = tile.contract max, none,  %[[cst_0]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<1x100xf32> -> tensor<1x1xf32>
+  // CHECK: %{{.*}} = "eltwise.sub"(%{{.*}}, %{{.*}}) : (tensor<1x100xf32>, tensor<1x1xf32>) -> tensor<1x100xf32>
+  // CHECK: %{{.*}} = "eltwise.exp"(%{{.*}}) : (tensor<1x100xf32>) -> tensor<1x100xf32>
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<1x100xf32> -> tensor<1x1xf32>
+  // CHECK: %{{.*}} = "eltwise.div"(%{{.*}}, %{{.*}}) : (tensor<1x100xf32>, tensor<1x1xf32>) -> tensor<1x100xf32>
+  // CHECK: return %{{.*}} : tensor<1x100xf32>
+  // clang-format on
+  // TODO: error: failed to legalize operation 'tile.reshape'
+  // runProgram(program);
+}
+
+Tensor Normalize(const Tensor &X) {
+  auto XSqr = X * X;
+  auto X_MS = TensorOutput();
+  std::vector<TensorIndex> idxs(X.rank());
+  X_MS() += XSqr(idxs);
+  return sqrt(X_MS);
+}
+
+std::tuple<Tensor, Tensor> LarsMomentum( //
+    const Tensor &X,                     //
+    const Tensor &Grad,                  //
+    const Tensor &Veloc,                 //
+    const Tensor &LR,                    //
+    double lars_coeff,                   //
+    double lars_weight_decay,            //
+    double momentum) {
+  auto XNorm = Normalize(X);
+  auto GradNorm = Normalize(Grad);
+  auto LocLR = LR * lars_coeff * XNorm / (GradNorm + lars_weight_decay * XNorm);
+  auto NewVeloc = momentum * Veloc + LocLR * (Grad + lars_weight_decay * X);
+  return std::make_tuple(X - NewVeloc, NewVeloc);
+}
+
+TEST_F(CppEdsl, LarsMomentum4d) {
+  auto X_shape = LogicalShape(DType::FLOAT32, {4, 7, 3, 9});
+  auto LR_shape = LogicalShape(DType::FLOAT32, {});
+  auto X = Placeholder(X_shape);
+  auto Grad = Placeholder(X_shape);
+  auto Veloc = Placeholder(X_shape);
+  auto LR = Placeholder(LR_shape);
+  auto R = LarsMomentum(X, Grad, Veloc, LR, 1. / 1024., 1. / 2048., 1. / 8.);
+  auto program =
+      makeProgram("lars_momentum4d", {std::get<0>(R), std::get<1>(R)});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.LarsMomentum4d
+  // CHECK: func @lars_momentum4d
+  // CHECK-DAG: %[[cst:.*]] = "eltwise.sconst"() {value = 1.250000e-01 : f64} : () -> tensor<f32>
+  // CHECK-DAG: %[[cst_0:.*]] = "eltwise.sconst"() {value = 9.765625E-4 : f64} : () -> tensor<f32>
+  // CHECK-DAG: %[[cst_1:.*]] = "eltwise.sconst"() {value = 4.8828125E-4 : f64} : () -> tensor<f32>
+  // CHECK-DAG: %[[cst_2:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_1]]) : (tensor<4x7x3x9xf32>, tensor<f32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<4x7x3x9xf32> -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.sqrt"(%{{.*}}) : (tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_1]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = tile.contract add, none, %[[cst_2]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<4x7x3x9xf32> -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.sqrt"(%{{.*}}) : (tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst_0]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.div"(%{{.*}}, %{{.*}}) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %{{.*}}) : (tensor<f32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = "eltwise.mul"(%{{.*}}, %[[cst]]) : (tensor<4x7x3x9xf32>, tensor<f32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = "eltwise.add"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: %{{.*}} = "eltwise.sub"(%{{.*}}, %{{.*}}) : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>
+  // CHECK: return %{{.*}}, %{{.*}} : tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, RepeatElements) {
+  auto I = Placeholder(DType::FLOAT32, {10, 10, 10});
+  TensorDim N0, N1, N2;
+  TensorIndex n0, n1, n2, k;
+  I.bind_dims(N0, N1, N2);
+  auto O = TensorOutput(N0, 3 * N1, N2);
+  O(n0, 3 * n1 + k, n2) = I(n0, n1, n2);
+  O.add_constraint(k < 3);
+  O.no_reduce();
+  auto program = makeProgram("repeat_elts", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.RepeatElements
+  // CHECK: func @repeat_elts
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract assign, none, %[[cst]], %{{.*}} {cons = #set{{[0-9]+}}, no_reduce, sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<10x10x10xf32> -> tensor<10x30x10xf32>
+  // CHECK: return %{{.*}} : tensor<10x30x10xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, UseDefault) {
+  auto P = Placeholder(DType::FLOAT32, {1, 7, 10, 10});
+  auto I = Placeholder(DType::FLOAT32, {1, 10, 10});
+  TensorDim B, N1, N2;
+  TensorIndex b, i1, i2;
+  I.bind_dims(B, N1, N2);
+  auto O = TensorOutput(B, 7, N1, N2);
+  O(b, 3, i1, i2) = I(b, i1, i2);
+  O.use_default(P);
+  auto program = makeProgram("use_default", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.UseDefault
+  // CHECK: func @use_default
+  // CHECK: %{{.*}} = tile.contract assign, none, %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<1x7x10x10xf32>, tensor<1x10x10xf32> -> tensor<1x7x10x10xf32>
+  // CHECK: return %{{.*}} : tensor<1x7x10x10xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+Tensor Winograd(const Tensor &I, const Tensor &K, const Tensor &A,
+                const Tensor &B, const Tensor &G) {
+  TensorDim N, S, X, Y, CI, CO, BI, BO;
+  I.bind_dims(N, X, Y, CI);
+  K.bind_dims(S, S, CI, CO);
+  A.bind_dims(BI, BO);
+  B.bind_dims(BI, BI);
+  G.bind_dims(BI, S);
+  auto XO = (X - S + 1) / 1;
+  auto YO = (Y - S + 1) / 1;
+  auto XB = (XO + BO - 1) / BO;
+  auto YB = (YO + BO - 1) / BO;
+  auto XP = 0, YP = 0;
+  // assert(BI - CI + 1 == BO);
+  auto U1 = TensorOutput(BI, S, CI, CO);
+  auto U = TensorOutput(BI, BI, CI, CO);
+  auto V1 = TensorOutput(N, BI, BI, XB, YB, CI);
+  auto V = TensorOutput(N, BI, BI, XB, YB, CI);
+  auto M = TensorOutput(N, BI, BI, XB, YB, CO);
+  auto O1 = TensorOutput(N, BO, BI, XB, YB, CO);
+  auto O = TensorOutput(N, XO, YO, CO);
+  TensorIndex n, i, j, k, x, y, ci, co;
+  U1(i, j, ci, co) += G(i, k) * K(k, j, ci, co);
+  U(i, j, ci, co) += U1(i, k, ci, co) * G(j, k);
+  V1(n, i, j, x, y, ci) += B(k, i) * I(n, BO * x + k - XP, BO * y + j - YP, ci);
+  V(n, i, j, x, y, ci) += V1(n, i, k, x, y, ci) * B(k, j);
+  M(n, i, j, x, y, co) += V(n, i, j, x, y, ci) * U(i, j, ci, co);
+  O1(n, i, j, x, y, co) += A(k, i) * M(n, k, j, x, y, co);
+  O(n, BO * x + i, BO * y + j, co) += O1(n, i, k, x, y, co) * A(k, j);
+  O.no_reduce();
+  return O;
+}
+
+TEST_F(CppEdsl, Winograd) {
+  const std::int64_t N = 1, X = 224, Y = 224, CI = 3, S = 3, CO = 32, BI = 32,
+                     BO = BI - CI + 1;
+  auto I = Placeholder(DType::FLOAT32, {N, X, Y, CI});
+  auto K = Placeholder(DType::FLOAT32, {S, S, CI, CO});
+  auto A = Placeholder(DType::FLOAT32, {BI, BO});
+  auto B = Placeholder(DType::FLOAT32, {BI, BI});
+  auto G = Placeholder(DType::FLOAT32, {BI, S});
+  auto W = Winograd(I, K, A, B, G);
+  auto program = makeProgram("winograd", {W});
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, GlobalMin) {
+  auto I = Placeholder(DType::FLOAT32, {10, 10, 10}, "I");
+  TensorIndex i, j, k;
+  auto O_Neg = TensorOutput();
+  auto Neg = -I;
+  O_Neg() >= Neg(i, j, k);
+  auto O = -O_Neg;
+  auto program = makeProgram("global_min", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.GlobalMin
+  // CHECK: func @global_min
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0xFFF0000000000000 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.neg"(%{{.*}}) : (tensor<10x10x10xf32>) -> tensor<10x10x10xf32>
+  // CHECK: %{{.*}} = tile.contract max, none, %[[cst]], %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}]} : tensor<f32>, tensor<10x10x10xf32> -> tensor<f32>
+  // CHECK: %{{.*}} = "eltwise.neg"(%{{.*}}) : (tensor<f32>) -> tensor<f32>
+  // CHECK: return %{{.*}} : tensor<f32>
+  // clang-format on
+  runProgram(program);
+}
+
+Tensor ComplexConv2d(             //
+    const Tensor &I,              //
+    const Tensor &K,              //
+    const std::vector<size_t> &s, // stride coeffs
+    const std::vector<size_t> &d  // dilation coeffs
+) {
+  // "same-lower" autopadding will be applied
+  TensorDim N, G, GCI, GCO;
+  std::vector<TensorDim> X(2);
+  std::vector<TensorDim> KX(2);
+  TensorIndex n, g, gci, gco;
+  std::vector<TensorIndex> x(2);
+  std::vector<TensorIndex> k(2);
+  I.bind_dims(N, X[0], X[1], G, GCI);
+  K.bind_dims(KX[0], KX[1], G, GCI, GCO);
+  // Compute output spatial dimensions
+  std::vector<TensorDim> Y(2);
+  for (size_t i = 0; i < Y.size(); ++i) {
+    Y[i] = (X[i] + s[i] - 1) / s[i];
+  }
+  // Compute the effective kernel size after dilation
+  std::vector<TensorDim> EK(2);
+  for (size_t i = 0; i < EK.size(); ++i) {
+    EK[i] = d[i] * (KX[i] - 1) + 1;
+  }
+  // Compute the padding offset
+  std::vector<TensorDim> P(2);
+  for (size_t i = 0; i < P.size(); ++i) {
+    P[i] = ((Y[i] - 1) * s[i] + EK[i] - X[i]) / 2;
+  }
+  // Specify the output size
+  auto O = TensorOutput(N, Y[0], Y[1], G, GCO);
+  // Compute the convolution
+  O(n, x[0], x[1], g, gco) += I(n, s[0] * x[0] + d[0] * k[0] - P[0],
+                                s[1] * x[1] + d[1] * k[1] - P[1], g, gci) *
+                              K(k[0], k[1], g, gci, gco);
+  return O;
+}
+
+TEST_F(CppEdsl, ComplexConv2d) {
+  auto I = Placeholder(DType::FLOAT32, {1, 224, 224, 3, 3});
+  auto K = Placeholder(DType::FLOAT32, {3, 3, 3, 3, 32});
+  auto O = ComplexConv2d(I, K, {2, 2}, {3, 3});
+  auto program = makeProgram("complex_conv_2d", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.ComplexConv2d
+  // CHECK: func @complex_conv_2d
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x224x224x3x3xf32>, tensor<3x3x3x3x32xf32> -> tensor<1x112x112x3x32xf32>
+  // CHECK: return %{{.*}} : tensor<1x112x112x3x32xf32>
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, GradientDot) {
+  auto A = Placeholder(DType::FLOAT32, {100, 100}, "A");
+  auto B = Placeholder(DType::FLOAT32, {100, 100}, "B");
+  auto O = Dot(A, B);
+  auto grads = Gradient({A, B}, O);
+  auto program = makeProgram("gradient_dot", {grads});
+  //clang-format off
+  //  EXPECT_THAT(program, Eq(R"(function (
+  //   A[A_0, A_1],
+  //   B[B_0, B_1]
+  // ) -> (
+  //   _X3,
+  //   _X2
+  // ) {
+  //   _X0 = 1.000000;
+  //   _X1[x0, x1 : 100, 100] = +(_X0[]);
+  //   _X2[k, j : 100, 100] = +(A[i, k] * _X1[i, j]);
+  //   _X3[i, k : 100, 100] = +(_X1[i, j] * B[k, j]);
+  // }
+  // )"));
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, DISABLED_GradientDotSqrt) {
+  auto A = Placeholder(DType::FLOAT32, {100, 100}, "A");
+  auto B = Placeholder(DType::FLOAT32, {100, 100}, "B");
+  auto C = Dot(A, B);
+  auto O = sqrt(C);
+  auto grads = Gradient({A, B}, O);
+  auto program = makeProgram("gradient_dot", {grads});
+  // clang-format off
+  //   EXPECT_THAT(program, Eq(R"(function (
+  //   A[A_0, A_1],
+  //   B[B_0, B_1]
+  // ) -> (
+  //   _X8,
+  //   _X7
+  // ) {
+  //   _X0 = 1.000000;
+  //   _X1[x0, x1 : 100, 100] = +(_X0[]);
+  //   _X2 = 2;
+  //   _X3[i, j : 100, 100] = +(A[i, k] * B[k, j]);
+  //   _X4 = sqrt(_X3);
+  //   _X5 = mul(_X2, _X4);
+  //   _X6 = div(_X1, _X5);
+  //   _X7[k, j : 100, 100] = +(A[i, k] * _X6[i, j]);
+  //   _X8[i, k : 100, 100] = +(_X6[i, j] * B[k, j]);
+  // }
+  // )"));
+  // clang-format on
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, DefractLong) {
+  std::vector<int64_t> input_shape{1, 3, 3, 1};
+  std::vector<int64_t> output_shape{1, 5, 5, 1};
+  auto I = Placeholder(DType::FLOAT32, input_shape, "I");
+  auto K = Placeholder(DType::FLOAT32, input_shape, "K");
+  auto O = TensorOutput(output_shape);
+  TensorIndex n, x0, x1, k0, k1, co, ci;
+  O(n, x0, x1, co) += I(n, (x0 + k0 - 1) / 2, (x1 + k1 - 1) / 2, ci) *
+                      K(2 - k0, 2 - k1, co, ci);
+  auto program = makeProgram("defract_long", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.DefractLong
+  // CHECK: func @defract_long
+  // CHECK: %[[cst:.*]] = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  // CHECK: %{{.*}} = tile.contract add, mul, %[[cst]], %{{.*}}, %{{.*}} {sink = #map{{[0-9]+}}, srcs = [#map{{[0-9]+}}, #map{{[0-9]+}}]} : tensor<f32>, tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32> -> tensor<1x5x5x1xf32>
+  // CHECK: return %{{.*}} : tensor<1x5x5x1xf32>
+  // clang-format on
+  // TODO: This causes out of bounds access!
+  // runProgram(program);
+}
+
+TEST_F(CppEdsl, DupOut) {
+  auto A = Placeholder(DType::FLOAT32, {10, 20});
+  auto B = Placeholder(DType::FLOAT32, {20, 30});
+  auto C = Placeholder(DType::FLOAT32, {30, 40});
+  auto R = Dot(Dot(A, B), C);
+  auto program = makeProgram("dup_out", {R, R, R});
+  runProgram(program);
+}
+
+TEST_F(CppEdsl, Shape) {
+  auto I = Placeholder(DType::FLOAT32, {10, 20});
+  auto O = shape(I);
+  auto program = makeProgram("shape", {O});
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.Shape
+  // CHECK: func @shape
+  // CHECK: %{{.*}} = "tile.shape"(%{{.*}}) : (tensor<10x20xf32>) -> tensor<2xsi32>
+  // CHECK: return %{{.*}} : tensor<2xsi32>
+  // clang-format on
+  exec::Binder binder(program);
+  binder.compile()->run();
+  IVLOG(1, "output: " << O.as_ptr());
+  auto view = binder.output(O).mmap_current();
+  auto data = reinterpret_cast<const int32_t *>(view.data());
+  ASSERT_THAT(view.size(), sizeof(int32_t) * 2);
+  EXPECT_THAT(data[0], 10);
+  EXPECT_THAT(data[1], 20);
+}
+
+TEST_F(CppEdsl, Prng) {
+  auto S = Placeholder(DType::UINT32, {3, 2048});
+  auto O = prng(S, {2, 3, 4, 5});
+  auto program = ProgramBuilder("prng", {O}).target("").compile();
+  std::cout << program << std::endl;
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.Prng
+  // CHECK: func @prng
+  // CHECK-DAG: %[[c2:.*]] = "eltwise.sconst"() {value = 2 : i64} : () -> tensor<si32>
+  // CHECK-DAG: %[[c3:.*]] = "eltwise.sconst"() {value = 3 : i64} : () -> tensor<si32>
+  // CHECK-DAG: %[[c4:.*]] = "eltwise.sconst"() {value = 4 : i64} : () -> tensor<si32>
+  // CHECK-DAG: %[[c5:.*]] = "eltwise.sconst"() {value = 5 : i64} : () -> tensor<si32>
+  // CHECK: %result, %new_state = "tile.prng"(%{{.*}}, %[[c2]], %[[c3]], %[[c4]], %[[c5]]) : (tensor<3x2048xui32>, tensor<si32>, tensor<si32>, tensor<si32>, tensor<si32>) -> (tensor<2x3x4x5xf32>, tensor<3x2048xui32>)
+  // CHECK: return %result, %new_state : tensor<2x3x4x5xf32>, tensor<3x2048xui32>
+  // clang-format on
+  // TODO: lowering for PrngOp
+  // runProgram(program);
+}
+} // namespace
+} // namespace plaidml::edsl

--- a/pmlc/rt/opencl/tests/lit.local.cfg
+++ b/pmlc/rt/opencl/tests/lit.local.cfg
@@ -1,0 +1,14 @@
+import os
+import platform
+import subprocess
+
+clprobe = os.path.join('pmlc/rt/opencl/clprobe')
+if platform.system() == 'Windows':
+    clprobe += '.exe'
+
+if platform.system() == 'Darwin':
+	config.unsupported = True
+
+proc = subprocess.run(clprobe)
+if proc.returncode:
+    config.unsupported = True

--- a/pmlc/rt/opencl/tests/testenv.cc
+++ b/pmlc/rt/opencl/tests/testenv.cc
@@ -1,0 +1,29 @@
+// Copyright 2019, Intel Corp.
+
+#include <gmock/gmock.h>
+
+#include "plaidml/edsl/edsl.h"
+#include "plaidml/exec/exec.h"
+#include "plaidml/op/op.h"
+
+#include "pmlc/rt/opencl/tests/testenv.h"
+
+namespace {
+
+class Environment : public ::testing::Environment {
+  void SetUp() override {
+    plaidml::init();
+    plaidml::edsl::init();
+    plaidml::op::init();
+    plaidml::exec::init();
+    plaidml::Settings::set("PLAIDML_DEVICE", "intel_gen_ocl_spirv");
+    plaidml::Settings::set("PLAIDML_TARGET", "intel_gen_ocl_spirv");
+  }
+};
+
+[[gnu::unused]] auto init = []() {
+  ::testing::AddGlobalTestEnvironment(new Environment);
+  return 0;
+}();
+
+} // namespace

--- a/pmlc/rt/opencl/tests/testenv.h
+++ b/pmlc/rt/opencl/tests/testenv.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <iostream>
+#include <map>
+#include <variant>
+#include <vector>
+
+#include "plaidml/exec/exec.h"
+
+namespace plaidml::edsl {
+
+using MultiBuffer = std::variant< //
+    std::vector<float>,           //
+    std::vector<double>,          //
+    std::vector<int>,             //
+    std::vector<int32_t>,         //
+    std::vector<int64_t>,         //
+    std::vector<uint32_t>,        //
+    std::vector<uint64_t>>;
+
+using TensorBuffers = std::map<TensorRef, MultiBuffer>;
+
+class TestFixture : public ::testing::Test {
+protected:
+  template <typename T>
+  void compareElements(T a, T b) {
+    EXPECT_EQ(a, b);
+  }
+
+  void compareElements(float a, float b) {
+    EXPECT_NEAR(a, b, (fabs(a) + fabs(b)) / 10000.0);
+  }
+  void compareElements(double a, double b) {
+    EXPECT_NEAR(a, b, (fabs(a) + fabs(b)) / 10000.0);
+  }
+
+  template <typename T>
+  void compareBuffers(plaidml::View view, const std::vector<T> &expected) {
+    ASSERT_THAT(view.size(), expected.size() * sizeof(expected[0]));
+    auto data = reinterpret_cast<T *>(view.data());
+    std::vector<T> actual(data, data + expected.size());
+    for (size_t i = 0; i < actual.size(); i++) {
+      compareElements(actual[i], expected[i]);
+    }
+  }
+
+  void checkProgram(               //
+      const Program &program,      //
+      const TensorBuffers &inputs, //
+      const TensorBuffers &expected) {
+    // #if !defined(_WIN32)
+    auto binder = exec::Binder(program);
+    auto executable = binder.compile();
+    for (const auto &kvp : inputs) {
+      std::visit(
+          [&](auto &&vec) { binder.input(kvp.first).copy_from(vec.data()); },
+          kvp.second);
+    }
+    executable->run();
+    for (auto kvp : expected) {
+      auto view = binder.output(kvp.first).mmap_current();
+      std::visit([&](auto &&vec) { compareBuffers(view, vec); }, kvp.second);
+    }
+    // #endif
+  }
+
+  void runProgram(const Program &program) {
+    // #if !defined(_WIN32)
+    exec::Binder(program).compile()->run();
+    // #endif
+  }
+};
+
+} // namespace plaidml::edsl

--- a/pmlc/rt/opencl/wrappers.cc
+++ b/pmlc/rt/opencl/wrappers.cc
@@ -1,0 +1,146 @@
+// Copyright 2020 Intel Corporation
+
+#include <cstdarg>
+
+#include "pmlc/rt/opencl/opencl_runtime.h"
+
+#include "mlir/ExecutionEngine/RunnerUtils.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "pmlc/compiler/registry.h"
+
+using namespace oclrt; // NOLINT
+
+template <typename T>
+T *wrapFailure(mlir::FailureOr<T *> result, std::string message) {
+  if (mlir::failed(result)) {
+    std::cout << message << " failed" << std::endl;
+    return nullptr;
+  }
+  return result.getValue();
+}
+
+void wrapFailure(mlir::LogicalResult result, std::string message) {
+  if (mlir::failed(result))
+    std::cout << message << " failed" << std::endl;
+}
+
+extern "C" {
+
+void *oclInit() {
+  std::cout << "init" << std::endl;
+  return new OpenClRuntime();
+}
+
+void oclDeinit(void *runtime) {
+  std::cout << "deinit" << std::endl;
+  delete reinterpret_cast<OpenClRuntime *>(runtime);
+}
+
+void *oclCreateKernel(void *runtime, uint8_t *spirv, uint32_t spirv_size) {
+  std::cout << "kernel" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->createKernel(
+      spirv, spirv_size);
+  return wrapFailure(result, "oclCreateKernel");
+}
+
+void *oclEnqueueKernel(void *runtime, void *kernel, uint64_t dimX,
+                       uint64_t dimY, uint64_t dimZ, uint64_t localX,
+                       uint64_t localY, uint64_t localZ, void *dep) {
+  std::cout << "enqueue" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->enqueueKernel(
+      reinterpret_cast<OpenClKernel *>(kernel), dimX, dimY, dimZ, localX,
+      localY, localZ, reinterpret_cast<OpenClEvent *>(dep));
+  return wrapFailure(result, "oclEnqueueKernel");
+}
+
+void oclSetKernelArg(void *runtime, void *kernel, uint32_t idx, void *buffer) {
+  std::cout << "arg" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->setBufferArg(
+      reinterpret_cast<OpenClKernel *>(kernel), idx,
+      reinterpret_cast<OpenClBuffer *>(buffer));
+  return wrapFailure(result, "oclSetKernelArg");
+}
+
+void *oclAllocBuffer(void *runtime, uint32_t length, void *ptr) {
+  std::cout << "alloc" << std::endl;
+  auto result =
+      reinterpret_cast<OpenClRuntime *>(runtime)->allocBuffer(ptr, length);
+  return wrapFailure(result, "oclAllocBuffer");
+}
+
+void oclDeallocBuffer(void *buffer) {
+  std::cout << "dealloc" << std::endl;
+  auto result = deallocBuffer(reinterpret_cast<OpenClBuffer *>(buffer));
+  return wrapFailure(result, "oclDeallocBuffer");
+}
+
+void *oclEnqueueRead(void *runtime, void *buffer, void *ptr, void *dep) {
+  std::cout << "read" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->enqueueRead(
+      reinterpret_cast<OpenClBuffer *>(buffer), ptr,
+      reinterpret_cast<OpenClEvent *>(dep));
+  return wrapFailure(result, "oclEnqueueRead");
+}
+
+void *oclEnqueueWrite(void *runtime, void *buffer, void *ptr, void *dep) {
+  std::cout << "write" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->enqueueWrite(
+      reinterpret_cast<OpenClBuffer *>(buffer), ptr,
+      reinterpret_cast<OpenClEvent *>(dep));
+  return wrapFailure(result, "oclEnqueueWrite");
+}
+
+void oclFlush(void *runtime) {
+  std::cout << "flush" << std::endl;
+  auto result = reinterpret_cast<OpenClRuntime *>(runtime)->flush();
+  return wrapFailure(result, "oclFlush");
+}
+
+void *oclGroupEvents(uint32_t count, ...) {
+  std::cout << "group" << std::endl;
+  va_list args;
+  va_start(args, count);
+  std::vector<OpenClEvent *> events;
+  for (uint32_t i = 0; i < count; ++i)
+    events.push_back(reinterpret_cast<OpenClEvent *>(va_arg(args, void *)));
+  va_end(args);
+  auto result = groupEvents(events);
+  return wrapFailure(result, "oclGroupEvents");
+}
+
+void oclWait(void *event) {
+  std::cout << "wait" << std::endl;
+  auto result = wait(reinterpret_cast<OpenClEvent *>(event));
+  return wrapFailure(result, "oclWait");
+}
+
+} // extern "C"
+
+namespace {
+struct Registration {
+  Registration() {
+    using pmlc::compiler::registerSymbol;
+    std::cout << "Register" << std::endl;
+
+    // OpenCL Runtime functions
+    registerSymbol("oclInit", reinterpret_cast<void *>(oclInit));
+    registerSymbol("oclDeinit", reinterpret_cast<void *>(oclDeinit));
+    registerSymbol("oclCreateKernel",
+                   reinterpret_cast<void *>(oclCreateKernel));
+    registerSymbol("oclEnqueueKernel",
+                   reinterpret_cast<void *>(oclEnqueueKernel));
+    registerSymbol("oclSetKernelArg",
+                   reinterpret_cast<void *>(oclSetKernelArg));
+    registerSymbol("oclAllocBuffer", reinterpret_cast<void *>(oclAllocBuffer));
+    registerSymbol("oclDeallocBuffer",
+                   reinterpret_cast<void *>(oclDeallocBuffer));
+    registerSymbol("oclEnqueueRead", reinterpret_cast<void *>(oclEnqueueRead));
+    registerSymbol("oclEnqueueWrite",
+                   reinterpret_cast<void *>(oclEnqueueWrite));
+    registerSymbol("oclGroupEvents", reinterpret_cast<void *>(oclGroupEvents));
+    registerSymbol("oclWait", reinterpret_cast<void *>(oclWait));
+  }
+};
+static Registration reg;
+} // namespace

--- a/pmlc/target/intel_gen/BUILD
+++ b/pmlc/target/intel_gen/BUILD
@@ -21,6 +21,7 @@ plaidml_cc_library(
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:LLVMTransforms",
         "@llvm-project//mlir:SCFToGPUPass",
+        "//pmlc/rt/vulkan"
     ],
     alwayslink = 1,
 )

--- a/pmlc/target/intel_gen_ocl_spirv/BUILD
+++ b/pmlc/target/intel_gen_ocl_spirv/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2019 Intel Corporation.
+
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+plaidml_cc_library(
+    name = "intel_gen_ocl_spirv",
+    srcs = glob(["*.cc"]),
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//pmlc/compiler",
+        "//pmlc/conversion/SCFToGPU",
+        "//pmlc/conversion/gpu",
+        "//pmlc/conversion/comp",
+        "//pmlc/conversion/pxa_to_affine",
+        "//pmlc/conversion/tile_to_pxa",
+        "//pmlc/dialect/tile/transforms",
+        "//pmlc/dialect/stdx/transforms",
+        "//pmlc/dialect/comp",
+        "@llvm-project//mlir:AffineToStandardTransforms",
+        "@llvm-project//mlir:GPUToSPIRVTransforms",
+        "@llvm-project//mlir:GPUToVulkanTransforms",
+        "@llvm-project//mlir:GPUTransforms",
+        "@llvm-project//mlir:LLVMTransforms",
+        "@llvm-project//mlir:SCFToGPUPass",
+        "//pmlc/rt/opencl",
+    ],
+    alwayslink = 1,
+)

--- a/pmlc/target/intel_gen_ocl_spirv/passes.h
+++ b/pmlc/target/intel_gen_ocl_spirv/passes.h
@@ -1,0 +1,9 @@
+// Copyright 2020, Intel Corporation
+
+#pragma once
+
+namespace pmlc::target::intel_gen_ocl_spirv {
+
+void registerPassPipeline();
+
+} // namespace pmlc::target::intel_gen_ocl_spirv

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -1,0 +1,101 @@
+// Copyright 2020, Intel Corporation
+
+#include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h"
+#include "mlir/Conversion/GPUToVulkan/ConvertGPUToVulkanPass.h"
+#include "mlir/Conversion/SCFToGPU/SCFToGPUPass.h"
+#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
+#include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h"
+#include "mlir/Dialect/GPU/Passes.h"
+#include "mlir/Dialect/SPIRV/Passes.h"
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#include "pmlc/compiler/registry.h"
+
+#include "pmlc/conversion/SCFToGPU/SCFToGPUPass.h"
+#include "pmlc/conversion/comp/passes.h"
+#include "pmlc/conversion/gpu/lowering.h"
+#include "pmlc/conversion/pxa_to_affine/passes.h"
+#include "pmlc/conversion/tile_to_pxa/passes.h"
+#include "pmlc/dialect/comp/transforms/passes.h"
+#include "pmlc/dialect/stdx/transforms/passes.h"
+#include "pmlc/dialect/tile/transforms/passes.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+namespace pmlc::target::intel_gen_ocl_spirv {
+
+namespace {
+
+void addToPipeline(OpPassManager &pm) {
+  // llvm::DebugFlag = true;
+  pm.addPass(dialect::tile::createComputeBoundsPass());
+  // pm.addPass(dialect::tile::createPadPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  pm.addPass(conversion::tile_to_pxa::createLowerTileToPXAPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  // TODO: do optimizations here
+
+  // pm.addPass(std::make_unique<UpdateWorkGroupSizePass>(workGroupSize));
+  // pm.addPass(std::make_unique<IREETileLinalgPass>());
+  // pm.addPass(createConvertLinalgToLoopsPass());
+  pm.addPass(conversion::pxa_to_affine::createLowerPXAToAffinePass());
+  pm.addPass(createLowerAffinePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  pm.addPass(dialect::stdx::createI1StorageToI32Pass());
+
+  pm.addPass(pmlc::conversion::scf_to_gpu::createSimpleSCFToGPUPass(1, 0));
+  pm.addPass(createCanonicalizerPass());
+  {
+    auto outliningPass = conversion::gpu::createGpuKernelOutliningPass();
+    outliningPass->initializeOptions("ocl-capabilities=true");
+    pm.addPass(std::move(outliningPass));
+  }
+
+  {
+    auto convertPass = conversion::comp::createConvertGpuToCompPass();
+    convertPass->initializeOptions(
+        "comp-execenv-runtime=1 comp-execenv-memory-space=11");
+    pm.addPass(std::move(convertPass));
+  }
+  pm.addPass(dialect::comp::createExecEnvCoalescingPass());
+
+  // GPU to SPIR-V.
+  pm.addPass(createLegalizeStdOpsForSPIRVLoweringPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(createConvertGPUToSPIRVPass());
+
+  // SPIR-V passes for lowering attributes.
+  pm.addPass(spirv::createLowerABIAttributesPass());
+  pm.addPass(spirv::createUpdateVersionCapabilityExtensionPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  // GPU to OpenCL SPIRV.
+  pm.addPass(conversion::comp::createConvertCompToOpenClPass());
+  pm.addPass(conversion::gpu::createLLVMLoweringPass());
+}
+
+} // namespace
+
+void registerPassPipeline() {
+  static PassPipelineRegistration<> passPipelineReg(
+      "target-intel_gen_ocl_spirv",
+      "Target pipeline for Intel GEN iGPUs with OpenCL SPIRV backend",
+      addToPipeline);
+  static compiler::TargetRegistration targetReg("intel_gen_ocl_spirv",
+                                                addToPipeline);
+}
+
+} // namespace pmlc::target::intel_gen_ocl_spirv

--- a/pmlc/target/intel_gen_ocl_spirv/tests/BUILD
+++ b/pmlc/target/intel_gen_ocl_spirv/tests/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2020 Intel Corporation
+
+package(default_visibility = ["//visibility:public"])
+
+load("//pmlc:lit.bzl", "glob_lit_tests")
+
+glob_lit_tests(
+    data = ["//pmlc/rt/opencl:clprobe"],
+)

--- a/pmlc/target/intel_gen_ocl_spirv/tests/dotf.mlir
+++ b/pmlc/target/intel_gen_ocl_spirv/tests/dotf.mlir
@@ -1,0 +1,16 @@
+// RUN: pmlc-opt --target-intel_gen_ocl_spirv %s | FileCheck %s
+
+#map0 = affine_map<() -> (0, 0, 0)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<() -> (2, 2, 2)>
+
+func @dot(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %cst = "eltwise.sconst"() {value = 0.000000e+00 : f64} : () -> tensor<f32>
+  %0 = tile.contract add, mul, %cst, %arg1, %arg0 {idxs = ["i", "j", "k"], lowerBounds = #map0, sink = #map1, srcs = [#map2, #map3], upperBounds = #map4} : tensor<f32>, tensor<3x3xf32>, tensor<3x3xf32> -> tensor<3x3xf32>
+  return %0 : tensor<3x3xf32>
+}
+
+// CHECK: llvm.call @oclInit
+// CHECK: llvm.call @oclDeinit

--- a/pmlc/util/all_dialects.h
+++ b/pmlc/util/all_dialects.h
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/IR/Dialect.h"
 
+#include "pmlc/dialect/comp/ir/dialect.h"
 #include "pmlc/dialect/eltwise/ir/ops.h"
 #include "pmlc/dialect/pxa/ir/ops.h"
 #include "pmlc/dialect/stdx/ir/ops.h"
@@ -38,6 +39,7 @@ inline void registerAllDialects() {
     registerDialect<StandardOpsDialect>();
     registerDialect<vector::VectorDialect>();
     // PMLC
+    registerDialect<pmlc::dialect::comp::COMPDialect>();
     registerDialect<pmlc::dialect::eltwise::EltwiseDialect>();
     registerDialect<pmlc::dialect::pxa::PXADialect>();
     registerDialect<pmlc::dialect::stdx::StdXDialect>();

--- a/pmlc/util/all_passes.h
+++ b/pmlc/util/all_passes.h
@@ -35,9 +35,11 @@
 #include "mlir/Transforms/ViewOpGraph.h"
 #include "mlir/Transforms/ViewRegionGraph.h"
 
+#include "pmlc/conversion/comp/passes.h"
 #include "pmlc/conversion/pxa_to_affine/passes.h"
 #include "pmlc/conversion/stdx_to_llvm/passes.h"
 #include "pmlc/conversion/tile_to_pxa/passes.h"
+#include "pmlc/dialect/comp/transforms/passes.h"
 #include "pmlc/dialect/pxa/transforms/passes.h"
 #include "pmlc/dialect/stdx/transforms/passes.h"
 #include "pmlc/dialect/tile/transforms/passes.h"
@@ -98,6 +100,10 @@ inline void registerAllPasses() {
   // PMLC
   //
 
+  // Conversion: gpu_to_comp
+#define GEN_PASS_REGISTRATION
+#include "pmlc/conversion/comp/passes.h.inc"
+
   // Conversion: pxa_to_affine
 #define GEN_PASS_REGISTRATION
 #include "pmlc/conversion/pxa_to_affine/passes.h.inc"
@@ -109,6 +115,10 @@ inline void registerAllPasses() {
   // Conversion: tile_to_pxa
 #define GEN_PASS_REGISTRATION
 #include "pmlc/conversion/tile_to_pxa/passes.h.inc"
+
+  // Dialect: comp
+#define GEN_PASS_REGISTRATION
+#include "pmlc/dialect/comp/transforms/passes.h.inc"
 
   // Dialect: pxa
 #define GEN_PASS_REGISTRATION

--- a/pmlc/util/all_passes.h
+++ b/pmlc/util/all_passes.h
@@ -44,6 +44,7 @@
 #include "pmlc/dialect/stdx/transforms/passes.h"
 #include "pmlc/dialect/tile/transforms/passes.h"
 #include "pmlc/target/intel_gen/passes.h"
+#include "pmlc/target/intel_gen_ocl_spirv/passes.h"
 #include "pmlc/target/x86/passes.h"
 
 namespace mlir {
@@ -138,6 +139,7 @@ inline void registerAllPasses() {
 
   // Pass pipelines
   pmlc::target::intel_gen::registerPassPipeline();
+  pmlc::target::intel_gen_ocl_spirv::registerPassPipeline();
   pmlc::target::x86::registerPassPipeline();
 }
 

--- a/vendor/opencl_headers/opencl_headers.BUILD
+++ b/vendor/opencl_headers/opencl_headers.BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "opencl_headers",
+    includes = ["."],
+    textual_hdrs = glob(["CL/*.h"]),
+)

--- a/vendor/opencl_hpp_headers/opencl_hpp_headers.BUILD
+++ b/vendor/opencl_hpp_headers/opencl_hpp_headers.BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "opencl_hpp_headers",
+    includes = ["include"],
+    textual_hdrs = glob(["include/CL/*.hpp"]),
+    deps = ["@opencl_headers"],
+)

--- a/vendor/opencl_icd_loader/opencl_icd_loader.BUILD
+++ b/vendor/opencl_icd_loader/opencl_icd_loader.BUILD
@@ -1,0 +1,50 @@
+package(default_visibility = ["//visibility:public"])
+
+opencl_icd_loader_srcs = glob([
+    "loader/*.c",
+    "loader/*.h",
+])
+
+opencl_icd_loader_win_srcs = glob([
+    "loader/windows/*.c",
+    "loader/windows/*.cpp",
+    "loader/windows/*.h",
+])
+
+opencl_icd_loader_win_hdrs = [
+    "loader/windows/OpenCL.rc",
+]
+
+opencl_icd_loader_lnx_srcs = glob([
+    "loader/linux/*.c",
+])
+
+opencl_icd_loader_lnx_hdrs = [
+    "loader/linux/icd_exports.map.in",
+]
+
+opencl_icd_loader_srcs += select({
+    "@bazel_tools//src/conditions:windows": opencl_icd_loader_win_srcs,
+    "//conditions:default": opencl_icd_loader_lnx_srcs,
+})
+
+opencl_icd_loader_hdrs = select({
+    "@bazel_tools//src/conditions:windows": opencl_icd_loader_win_hdrs,
+    "//conditions:default": opencl_icd_loader_lnx_hdrs,
+})
+
+opencl_icd_loader_lnks = [
+    "cfgmgr32.lib",
+    "runtimeobject.lib",
+    "Advapi32.lib",
+    "ole32.lib",
+]
+
+cc_library(
+    name = "opencl_icd_loader",
+    srcs = opencl_icd_loader_srcs,
+    hdrs = opencl_icd_loader_hdrs,
+    includes = ["loader"],
+    linkopts = opencl_icd_loader_lnks,
+    deps = ["@opencl_headers"],
+)


### PR DESCRIPTION
### How to run:
1. Currently branched from commit: f171a54279040e3a2d5fedb88508604a9ce1d55e, merge at this point
2. Manually apply LLVM [patch](https://github.com/kdobros/plaidml/blob/ocl_spirv/llvm_unified_diff.patch)
3. On Linux you will most likely need to fix libraries to link in vendor/opencl_icd_loader/opencl_icd_loader.BUILD

### Most interesting changes:
273d08c - Add comp dialect - host-device modeling
0377848 - LLVM patch
0d1343a - Fixes for existing gpu pipeline

### Current status:
- EdslCpp tests - 16/17 pass
- networks/oplib/resnet50 - able to execute with removed softmax layer, conformance not verified

### TODO:
- upstream existing llvm changes
- make sure linux build works correctly - especially opencl icd
- remove debug cout's
- add traces support
- add support for extended OCL/SPIRV operations, needed for resnet's softmax
