### PR TITLE
Changes to StrideInfo and some fixes to tiling and resize

### DIFF
--- a/pmlc/dialect/pxa/analysis/BUILD
+++ b/pmlc/dialect/pxa/analysis/BUILD
@@ -7,10 +7,12 @@ package(default_visibility = ["//visibility:public"])
 plaidml_cc_library(
     name = "analysis",
     srcs = [
+        "affine_expr.cc",
         "strides.cc",
         "uses.cc",
     ],
     hdrs = [
+        "affine_expr.h",
         "strides.h",
         "uses.h",
     ],

--- a/pmlc/dialect/pxa/analysis/affine_expr.cc
+++ b/pmlc/dialect/pxa/analysis/affine_expr.cc
@@ -1,0 +1,97 @@
+#include "pmlc/dialect/pxa/analysis/affine_expr.h"
+
+namespace mlir {
+
+AffineValueExpr::AffineValueExpr(AffineExpr expr, ValueRange operands)
+    : expr(expr), operands(operands.begin(), operands.end()) {}
+
+AffineValueExpr::AffineValueExpr(MLIRContext *ctx, int64_t v) {
+  expr = getAffineConstantExpr(v, ctx);
+}
+
+AffineValueExpr::AffineValueExpr(Value v) {
+  operands.push_back(v);
+  expr = getAffineDimExpr(0, v.getContext());
+}
+
+AffineValueExpr::AffineValueExpr(AffineValueMap map, unsigned idx)
+    : expr(map.getResult(idx)),
+      operands(map.getOperands().begin(), map.getOperands().end()) {}
+
+AffineValueExpr AffineValueExpr::operator*(const AffineValueExpr &rhs) const {
+  return AffineValueExpr(AffineExprKind::Mul, *this, rhs);
+}
+
+AffineValueExpr AffineValueExpr::operator*(int64_t rhs) const {
+  auto cst = AffineValueExpr(expr.getContext(), rhs);
+  return AffineValueExpr(AffineExprKind::Mul, *this, cst);
+}
+
+AffineValueExpr AffineValueExpr::operator+(const AffineValueExpr &rhs) const {
+  return AffineValueExpr(AffineExprKind::Add, *this, rhs);
+}
+
+AffineValueExpr AffineValueExpr::operator+(int64_t rhs) const {
+  auto cst = AffineValueExpr(expr.getContext(), rhs);
+  return AffineValueExpr(AffineExprKind::Add, *this, cst);
+}
+
+AffineValueExpr AffineValueExpr::operator-(const AffineValueExpr &rhs) const {
+  return *this + (rhs * -1);
+}
+
+AffineValueExpr AffineValueExpr::operator-(int64_t rhs) const {
+  return *this - rhs;
+}
+
+AffineExpr AffineValueExpr::getExpr() const { return expr; }
+
+ArrayRef<Value> AffineValueExpr::getOperands() const { return operands; }
+
+AffineValueExpr::AffineValueExpr(AffineExprKind kind, AffineValueExpr a,
+                                 AffineValueExpr b)
+    : operands(a.operands.begin(), a.operands.end()) {
+  SmallVector<AffineExpr, 4> repl_b;
+  for (auto v : b.operands) {
+    auto it = std::find(operands.begin(), operands.end(), v);
+    unsigned idx;
+    if (it == operands.end()) {
+      idx = operands.size();
+      operands.push_back(v);
+    } else {
+      idx = it - operands.begin();
+    }
+    repl_b.push_back(getAffineDimExpr(idx, a.expr.getContext()));
+  }
+  auto new_b = b.expr.replaceDimsAndSymbols(repl_b, {});
+  expr = getAffineBinaryOpExpr(kind, a.expr, new_b);
+}
+
+AffineValueMap jointValueMap(MLIRContext *ctx,
+                             ArrayRef<AffineValueExpr> exprs) {
+  DenseMap<Value, unsigned> jointSpace;
+  for (const auto &expr : exprs) {
+    for (Value v : expr.getOperands()) {
+      if (!jointSpace.count(v)) {
+        unsigned idx = jointSpace.size();
+        jointSpace[v] = idx;
+      }
+    }
+  }
+  SmallVector<AffineExpr, 4> jointExprs;
+  for (const auto &expr : exprs) {
+    SmallVector<AffineExpr, 4> repl;
+    for (Value v : expr.getOperands()) {
+      repl.push_back(getAffineDimExpr(jointSpace[v], ctx));
+    }
+    jointExprs.push_back(expr.getExpr().replaceDimsAndSymbols(repl, {}));
+  }
+  SmallVector<Value, 4> jointOperands(jointSpace.size());
+  for (const auto &kvp : jointSpace) {
+    jointOperands[kvp.second] = kvp.first;
+  }
+  auto map = AffineMap::get(jointSpace.size(), 0, jointExprs, ctx);
+  return AffineValueMap(map, jointOperands);
+}
+
+} // End namespace mlir

--- a/pmlc/dialect/pxa/analysis/affine_expr.cc
+++ b/pmlc/dialect/pxa/analysis/affine_expr.cc
@@ -41,7 +41,7 @@ AffineValueExpr AffineValueExpr::operator-(const AffineValueExpr &rhs) const {
 }
 
 AffineValueExpr AffineValueExpr::operator-(int64_t rhs) const {
-  return *this - rhs;
+  return *this - AffineValueExpr(expr.getContext(), rhs);
 }
 
 AffineExpr AffineValueExpr::getExpr() const { return expr; }

--- a/pmlc/dialect/pxa/analysis/affine_expr.h
+++ b/pmlc/dialect/pxa/analysis/affine_expr.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Intel Corporation
+
+#pragma once
+
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+
+namespace mlir {
+
+class AffineValueExpr {
+public:
+  AffineValueExpr(AffineExpr expr, ValueRange operands);
+  AffineValueExpr(MLIRContext *ctx, int64_t v);
+  explicit AffineValueExpr(Value v);
+  AffineValueExpr(AffineValueMap map, unsigned idx);
+  AffineValueExpr operator*(const AffineValueExpr &rhs) const;
+  AffineValueExpr operator*(int64_t rhs) const;
+  AffineValueExpr operator+(const AffineValueExpr &rhs) const;
+  AffineValueExpr operator+(int64_t rhs) const;
+  AffineValueExpr operator-(const AffineValueExpr &rhs) const;
+  AffineValueExpr operator-(int64_t rhs) const;
+  AffineExpr getExpr() const;
+  ArrayRef<Value> getOperands() const;
+
+private:
+  AffineValueExpr(AffineExprKind kind, AffineValueExpr a, AffineValueExpr b);
+  AffineExpr expr;
+  SmallVector<Value, 4> operands;
+};
+
+AffineValueMap jointValueMap(MLIRContext *ctx, ArrayRef<AffineValueExpr> exprs);
+
+} // End namespace mlir

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -30,7 +30,7 @@ static std::string getUniqueName(Block *ref, BlockArgument arg) {
 }
 
 // Generally useful helper function
-int64_t GetIVStep(BlockArgument arg) {
+int64_t getIVStep(BlockArgument arg) {
   // Check the kind of loop we are part of, and dispatch.
   Operation *baseOp = arg.getOwner()->getParentOp();
 
@@ -186,7 +186,7 @@ AffineValueExpr StrideInfo::toValueExpr(MLIRContext *ctx) const {
     } else {
       llvm_unreachable("Invalid op type in toValueMap");
     }
-    int64_t step = GetIVStep(kvp.first);
+    int64_t step = getIVStep(kvp.first);
     assert(kvp.second % step == 0 && "Stride not divisible by step");
     tot = tot + idx * (kvp.second / step);
   }

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -11,6 +11,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
 #include "mlir/Support/DebugStringHelper.h"
+#include "pmlc/dialect/pxa/analysis/affine_expr.h"
 #include "pmlc/util/logging.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -28,27 +29,44 @@ static std::string getUniqueName(Block *ref, BlockArgument arg) {
       .str();
 }
 
+// Generally useful helper function
+int64_t GetIVStep(BlockArgument arg) {
+  // Check the kind of loop we are part of, and dispatch.
+  Operation *baseOp = arg.getOwner()->getParentOp();
+
+  size_t idx = arg.getArgNumber();
+  if (auto op = dyn_cast<AffineParallelOp>(baseOp)) {
+    auto stepAttr = op.steps().getValue()[idx];
+    return stepAttr.cast<IntegerAttr>().getInt();
+  }
+  if (auto op = dyn_cast<AffineForOp>(baseOp)) {
+    return op.getStep();
+  }
+  llvm_unreachable("Get IV Step on non-IV");
+}
+
 StrideRange::StrideRange(BlockArgument arg)
     : valid(false), minVal(0), maxVal(0), stride(0) {
   if (auto ap =
           mlir::dyn_cast<AffineParallelOp>(arg.getOwner()->getParentOp())) {
-    auto low_expr = ap.getLowerBoundsValueMap().getResult(arg.getArgNumber());
-    auto high_expr = ap.getUpperBoundsValueMap().getResult(arg.getArgNumber());
-    auto low_cst = low_expr.dyn_cast<AffineConstantExpr>();
-    auto high_cst = high_expr.dyn_cast<AffineConstantExpr>();
-    if (!low_cst || !high_cst) {
+    auto range_expr = ap.getRangesValueMap().getResult(arg.getArgNumber());
+    auto range_cst = range_expr.dyn_cast<AffineConstantExpr>();
+    if (!range_cst) {
+      return;
+    }
+    int64_t range = range_cst.getValue();
+    if (range < 1) {
       return;
     }
     int64_t step = ap.steps()[arg.getArgNumber()].cast<IntegerAttr>().getInt();
-    if (step <= 0 || ((maxVal - minVal) % step) != 0) {
+    if (step <= 0) {
       return;
     }
     stride = 1;
-    minVal = low_cst.getValue();
+    minVal = 0;
     // This is a correction to deal with the fact that strides are measured
     // relative to loop iterations not indexes.
-    maxVal = low_cst.getValue() +
-             (high_cst.getValue() - low_cst.getValue()) / step - 1;
+    maxVal = (range - 1) / step;
     valid = true;
     if (minVal == maxVal) {
       stride = 0;
@@ -84,8 +102,12 @@ void StrideRange::unionEquals(const StrideRange &rhs) {
 // Multiply the offset and all strides by a constant.
 StrideInfo &StrideInfo::operator*=(int64_t factor) {
   offset *= factor;
-  for (auto &kvp : strides) {
-    kvp.second *= factor;
+  if (factor == 0) {
+    strides.clear();
+  } else {
+    for (auto &kvp : strides) {
+      kvp.second *= factor;
+    }
   }
   return *this;
 }
@@ -95,6 +117,13 @@ StrideInfo &StrideInfo::operator+=(const StrideInfo &rhs) {
   offset += rhs.offset;
   for (const auto &kvp : rhs.strides) {
     strides[kvp.first] += kvp.second;
+  }
+  // Remove entries with 0 for stride
+  for (auto &kvp : llvm::make_early_inc_range(strides)) {
+    if (kvp.second == 0) {
+      // DenseMap never resizes during erase, so iterators stay valid.
+      strides.erase(kvp.first);
+    }
   }
   return *this;
 }
@@ -143,20 +172,25 @@ StrideRange StrideInfo::range() const {
   return ret;
 }
 
-AffineExpr StrideInfo::toExpr(MLIRContext *ctx, ValueRange operands) const {
-  DenseMap<Value, unsigned> opIdx;
-  for (unsigned i = 0; i < operands.size(); i++) {
-    opIdx[operands[i]] = i;
-  }
-  AffineExpr ret = getAffineConstantExpr(offset, ctx);
+AffineValueExpr StrideInfo::toValueExpr(MLIRContext *ctx) const {
+  auto tot = AffineValueExpr(ctx, offset);
   for (const auto &kvp : strides) {
-    auto it = opIdx.find(kvp.first);
-    assert(it != opIdx.end() &&
-           "toMap requires all values needed to be passed in as operands");
-    ret = ret + getAffineDimExpr(it->second, ctx) *
-                    getAffineConstantExpr(kvp.second, ctx);
+    Operation *baseOp = kvp.first.getOwner()->getParentOp();
+    AffineValueExpr idx(kvp.first);
+    if (auto op = dyn_cast<AffineParallelOp>(baseOp)) {
+      idx = idx - AffineValueExpr(op.getLowerBoundsValueMap(),
+                                  kvp.first.getArgNumber());
+    } else if (auto op = dyn_cast<AffineForOp>(baseOp)) {
+      auto map = op.getLowerBoundMap();
+      idx = idx - AffineValueExpr(map.getResult(0), op.getLowerBoundOperands());
+    } else {
+      llvm_unreachable("Invalid op type in toValueMap");
+    }
+    int64_t step = GetIVStep(kvp.first);
+    assert(kvp.second % step == 0 && "Stride not divisible by step");
+    tot = tot + idx * (kvp.second / step);
   }
-  return ret;
+  return tot;
 }
 
 void StrideInfo::print(raw_ostream &os, Block *relative) const {
@@ -179,6 +213,14 @@ void StrideInfo::print(raw_ostream &os, Block *relative) const {
     os << item.value().first << "=" << item.value().second;
   }
   os << ']';
+}
+
+AffineValueMap StridesToValueMap(MLIRContext *ctx, ArrayRef<StrideInfo> dims) {
+  SmallVector<AffineValueExpr, 4> exprs;
+  for (const auto &si : dims) {
+    exprs.push_back(si.toValueExpr(ctx));
+  }
+  return jointValueMap(ctx, exprs);
 }
 
 static Optional<StrideInfo> computeStrideInfo(AffineParallelOp op,

--- a/pmlc/dialect/pxa/analysis/strides.h
+++ b/pmlc/dialect/pxa/analysis/strides.h
@@ -11,8 +11,9 @@
 
 namespace mlir {
 
-// Generally useful helper function
-int64_t GetIVStep(BlockArgument arg);
+// Get the step for a block argument as an IV of an affine.for or
+// affine.parallel
+int64_t getIVStep(BlockArgument arg);
 
 struct StrideRange {
   bool valid;

--- a/pmlc/dialect/pxa/analysis/strides.h
+++ b/pmlc/dialect/pxa/analysis/strides.h
@@ -6,9 +6,13 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 
+#include "pmlc/dialect/pxa/analysis/affine_expr.h"
 #include "pmlc/dialect/pxa/ir/ops.h"
 
 namespace mlir {
+
+// Generally useful helper function
+int64_t GetIVStep(BlockArgument arg);
 
 struct StrideRange {
   bool valid;
@@ -35,6 +39,16 @@ struct StrideRange {
     return ret;
   }
 
+  int64_t count() {
+    if (!valid) {
+      return 0;
+    }
+    if (stride == 0) {
+      return 1;
+    }
+    return (maxVal - minVal) / stride + 1;
+  }
+
   void unionEquals(const StrideRange &rhs);
 };
 
@@ -46,6 +60,7 @@ struct StrideInfo {
   int64_t offset;
   DenseMap<BlockArgument, int64_t> strides;
 
+  explicit StrideInfo(BlockArgument arg) : offset(0), strides({{arg, 1}}) {}
   explicit StrideInfo(int64_t offset = 0) : offset(offset) {}
 
   bool operator==(const StrideInfo &rhs) const {
@@ -53,6 +68,11 @@ struct StrideInfo {
   }
   StrideInfo &operator*=(int64_t factor);
   StrideInfo &operator+=(const StrideInfo &rhs);
+  StrideInfo operator+(const StrideInfo &rhs) {
+    StrideInfo r = *this;
+    r += rhs;
+    return r;
+  }
 
   // Compute the outer and inner portion of stride info with respect to a given
   // block.
@@ -62,10 +82,14 @@ struct StrideInfo {
   // Return the range of a given stride info if it's computable
   StrideRange range() const;
 
-  AffineExpr toExpr(MLIRContext *ctx, ValueRange operands) const;
+  // Convert a StrideInfo back into an affine expression
+  AffineValueExpr toValueExpr(MLIRContext *ctx) const;
 
   void print(raw_ostream &os, Block *relative = nullptr) const;
 };
+
+// Convert a vector of StrideInfo's into a value map
+AffineValueMap StridesToValueMap(MLIRContext *ctx, ArrayRef<StrideInfo> dims);
 
 // Compute stride info for a given affine value (such an an induction variable
 // or the result of an affine.apply). Return None if the expression is not a

--- a/pmlc/dialect/pxa/tests/autotile.mlir
+++ b/pmlc/dialect/pxa/tests/autotile.mlir
@@ -25,7 +25,7 @@ func @dot0(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> memref<100
 func @dot1(%arg0: memref<100x100xf32>, %arg1: memref<100x100xf32>) -> memref<100x100xf32> {
   %obuf = alloc() : memref<100x100xf32>
   // CHECK: %[[obuf:.*]] = alloc() : memref<100x100xf32>
-  // CHECK: affine.parallel (%[[arg2:.*]], %[[arg3:.*]], %[[arg4:.*]]) = (0, 0, 0) to (200, 200, 200) step (50, 50, 50)
+  // CHECK: affine.parallel (%[[arg2:.*]], %[[arg3:.*]], %[[arg4:.*]]) = (0, 0, 0) to (200, 200, 200) step (10, 10, 10)
   %out = affine.parallel (%arg2, %arg3, %arg4) = (0, 0, 0) to (200, 200, 200) step (5, 5, 5) reduce ("assign") -> (memref<100x100xf32>) {
     // CHECK: affine.parallel (%[[arg5:.*]], %[[arg6:.*]], %[[arg7:.*]]) = (%[[arg2]], %[[arg3]], %[[arg4]]) to (%[[arg2]] + 10, %[[arg3]] + 10, %[[arg4]] + 10) 
     // CHECK: affine.parallel (%[[arg8:.*]], %[[arg9:.*]], %[[arg10:.*]]) = (%[[arg5]], %[[arg6]], %[[arg7]]) to (%[[arg5]] + 5, %[[arg6]] + 5, %[[arg7]] + 5)

--- a/pmlc/dialect/pxa/tests/grn.mlir
+++ b/pmlc/dialect/pxa/tests/grn.mlir
@@ -8,6 +8,7 @@
 // RUN:   -canonicalize \
 // RUN:   -pxa-localize \
 // RUN:   -pxa-resize-tmps \
+// RUN:   --canonicalize \
 // RUN:   %s | FileCheck %s
 
 #map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>

--- a/pmlc/dialect/pxa/transforms/resize_tmps.cc
+++ b/pmlc/dialect/pxa/transforms/resize_tmps.cc
@@ -23,15 +23,16 @@ struct ResizeTmpsPass : public ResizeTmpsBase<ResizeTmpsPass> {
     func.walk([&](AllocOp op) { runOnAlloc(op); });
   }
 
-  AffineMap computeInnerMap(AffineMap orig, ValueRange operands, Block *block) {
+  AffineValueMap computeInnerValueMap(AffineMap orig, ValueRange operands,
+                                      Block *block) {
     auto strides = computeStrideInfo(orig, operands);
     assert(strides && "Could not compute stride info");
-    SmallVector<AffineExpr, 4> newExprs;
+    SmallVector<StrideInfo, 4> inner;
     for (size_t i = 0; i < strides->size(); i++) {
-      auto innerStrides = (*strides)[i].inner(block);
-      newExprs.push_back(innerStrides.toExpr(orig.getContext(), operands));
+      auto innerStride = (*strides)[i].inner(block);
+      inner.push_back(innerStride);
     }
-    return AffineMap::get(operands.size(), 0, newExprs, orig.getContext());
+    return StridesToValueMap(orig.getContext(), inner);
   }
 
   void runOnAlloc(AllocOp op) {
@@ -148,16 +149,33 @@ struct ResizeTmpsPass : public ResizeTmpsBase<ResizeTmpsPass> {
       value.setType(newType);
     }
     // Update all of the access maps
+    // Get ops first and then replace since we modify use-def chain during
+    // mutation.
+    SmallVector<Operation *, 4> ops;
     for (auto &use : getIndirectAccessUses(op.getResult())) {
-      if (auto rop = dyn_cast<AffineReduceOp>(use.getOwner())) {
-        auto map =
-            computeInnerMap(rop.getAffineMap(), rop.getMapOperands(), opBlock);
-        rop.setAttr(AffineReduceOp::getMapAttrName(), AffineMapAttr::get(map));
+      ops.push_back(use.getOwner());
+    }
+    // Now do the actual changes.  Note, we don't bother erasing the original
+    // instructions, but they get cleaned up via canonicalization
+    for (Operation *op : ops) {
+      if (auto rop = dyn_cast<AffineReduceOp>(op)) {
+        // TODO: This probably should move into some sort of utility transform,
+        // but I need another example or two to generalize from
+        auto vm = computeInnerValueMap(rop.getAffineMap(), rop.getMapOperands(),
+                                       opBlock);
+        OpBuilder replace(rop);
+        auto nrop = replace.create<AffineReduceOp>(
+            rop.getLoc(), rop.agg(), rop.val(), rop.getMemRef(),
+            vm.getAffineMap(), vm.getOperands());
+        rop.replaceAllUsesWith(nrop.result());
       }
-      if (auto lop = dyn_cast<AffineLoadOp>(use.getOwner())) {
-        auto map =
-            computeInnerMap(lop.getAffineMap(), lop.getMapOperands(), opBlock);
-        lop.setAttr(AffineLoadOp::getMapAttrName(), AffineMapAttr::get(map));
+      if (auto lop = dyn_cast<AffineLoadOp>(op)) {
+        auto vm = computeInnerValueMap(lop.getAffineMap(), lop.getMapOperands(),
+                                       opBlock);
+        OpBuilder replace(lop);
+        auto nlop = replace.create<AffineLoadOp>(
+            lop.getLoc(), lop.getMemRef(), vm.getAffineMap(), vm.getOperands());
+        lop.replaceAllUsesWith(nlop.result());
       }
     }
   }


### PR DESCRIPTION
Updates to StrideInfo, Tiling and ResizeTmps so that they work on non-canonical affine loops.