### PR TITLE
Pick float vs int comparison for contractions based on type of comparands, not result

### DIFF
--- a/plaidml/bridge/keras/backend_test.py
+++ b/plaidml/bridge/keras/backend_test.py
@@ -855,7 +855,6 @@ class TestBackendOps(unittest.TestCase):
         return [b.categorical_crossentropy(x, y, from_logits=True)]
 
     @opTest([[m(3, 3, 10)]], skip_theano=True, tol=0.01)
-    @unittest.skip("'std.cmpi' op operand #0 must be signless-integer-like, but got 'f32'")
     def testSparseCategoricalCrossentropy(self, b, x):
         smax = b.softmax(x)
         sbest = b.variable(np.array([[7, 8, 5], [9, 3, 8], [0, 7, 6]]))
@@ -865,7 +864,6 @@ class TestBackendOps(unittest.TestCase):
         ]
 
     @opTest([[m(1, 3, 10)]], skip_theano=True, tol=0.01)
-    @unittest.skip("'std.cmpi' op operand #0 must be signless-integer-like, but got 'f32'")
     def testSparseCategoricalCrossentropyUnbalanced(self, b, x):
         smax = b.softmax(x)
         sbest = b.variable(np.array([[7, 8, 5]]))
@@ -875,7 +873,6 @@ class TestBackendOps(unittest.TestCase):
         ]
 
     @opTest([[m(3, 10)]], skip_theano=True, tol=0.001)
-    @unittest.skip("'std.cmpi' op operand #0 must be signless-integer-like, but got 'f32'")
     def testSparseCategoricalCrossentropyShort(self, b, x):
         smax = b.softmax(x)
         sbest = b.variable(np.array([7, 8, 5]))
@@ -885,7 +882,6 @@ class TestBackendOps(unittest.TestCase):
         ]
 
     @opTest([[m(3, 3, 2, 10)]], skip_theano=True, tol=0.01)
-    @unittest.skip("'std.cmpi' op operand #0 must be signless-integer-like, but got 'f32'")
     def testSparseCategoricalCrossentropyLong(self, b, x):
         smax = b.softmax(x)
         sbest = b.variable(
@@ -897,7 +893,6 @@ class TestBackendOps(unittest.TestCase):
         ]
 
     @opTest([[m(3, 3, 2, 1, 10)]], skip_theano=True, tol=0.01)
-    @unittest.skip("'std.cmpi' op operand #0 must be signless-integer-like, but got 'f32'")
     def testSparseCategoricalCrossentropyXLong(self, b, x):
         smax = b.softmax(x)
         sbest = b.variable(


### PR DESCRIPTION
This was the issue blocking the sparse categorical crossentropy backend tests. Related to #1249. 