### PR TITLE
Define --//plaidml:device and --//plaidml:target

### DIFF
--- a/bzl/bazel.rc
+++ b/bzl/bazel.rc
@@ -29,9 +29,6 @@ build --define=version=0.0.0.dev0
 test --test_timeout_filters=-eternal
 #test --test_output=streamed
 test --test_env=HOME
-test --test_env=PLAIDML_DEVICE
-test --test_env=PLAIDML_TARGET
-test --test_env=PLAIDML_SETTINGS
 test --test_sharding_strategy=disabled
 run --test_env=HOME
 run --test_env=PLAIDML_DEVICE

--- a/bzl/plaidml.bzl
+++ b/bzl/plaidml.bzl
@@ -1,5 +1,7 @@
 # Copyright 2020 Intel Corporation.
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
 PLAIDML_COPTS = select({
     "@com_intel_plaidml//:msvc": [
         "/std:c++17",  # This MUST match all other compilation units
@@ -121,3 +123,21 @@ def plaidml_cc_shlib(
         srcs = select(names),
         visibility = visibility,
     )
+
+
+def _plaidml_settings_impl(ctx):
+    return [
+        platform_common.TemplateVariableInfo({
+            "plaidml_device": ctx.attr._device[BuildSettingInfo].value,
+            "plaidml_target": ctx.attr._target[BuildSettingInfo].value,
+        }),
+    ]
+
+
+plaidml_settings = rule(
+    attrs = {
+        "_device": attr.label(default="//plaidml:device"),
+        "_target": attr.label(default="//plaidml:target"),
+    },
+    implementation = _plaidml_settings_impl,
+)

--- a/plaidml/BUILD
+++ b/plaidml/BUILD
@@ -2,9 +2,10 @@
 
 load("//tools/py_cffi:build_defs.bzl", "py_cffi")
 load("//tools/py_setup:build_defs.bzl", "py_setup")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_shlib")
+load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_shlib", "plaidml_settings")
 
 plaidml_cc_library(
     name = "plaidml",
@@ -150,6 +151,7 @@ plaidml_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":plaidml",
+        "@gflags",
         "@gmock//:gtest",
     ],
     alwayslink = 1,
@@ -165,4 +167,20 @@ py_binary(
         "//plaidml/exec:py",
         "//plaidml/op:py",
     ],
+)
+
+string_flag(
+    name = "device",
+    build_setting_default = "llvm_cpu.0",
+)
+
+string_flag(
+    name = "target",
+    values = ["llvm_cpu", "foo"],
+    build_setting_default = "llvm_cpu",
+)
+
+plaidml_settings(
+    name = "settings",
+    visibility = ["//visibility:public"],
 )

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1,5 +1,5 @@
 // Copyright 2020 Intel Corporation
-// RUN: cc_test | FileCheck %s
+// RUN: cc_test --plaidml_device=%plaidml_device --plaidml_target=%plaidml_target | FileCheck %s
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/plaidml/testenv.cc
+++ b/plaidml/testenv.cc
@@ -1,10 +1,14 @@
 // Copyright 2019, Intel Corp.
 
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 
 #include "plaidml/edsl/edsl.h"
 #include "plaidml/exec/exec.h"
 #include "plaidml/op/op.h"
+
+DEFINE_string(plaidml_device, "llvm_cpu.0", "The device to run tests on");
+DEFINE_string(plaidml_target, "llvm_cpu", "The compilation target");
 
 namespace {
 
@@ -14,8 +18,8 @@ class Environment : public ::testing::Environment {
     plaidml::edsl::init();
     plaidml::op::init();
     plaidml::exec::init();
-    plaidml::Settings::set("PLAIDML_DEVICE", "llvm_cpu.0");
-    plaidml::Settings::set("PLAIDML_TARGET", "llvm_cpu");
+    plaidml::Settings::set("PLAIDML_DEVICE", FLAGS_plaidml_device);
+    plaidml::Settings::set("PLAIDML_TARGET", FLAGS_plaidml_target);
   }
 };
 

--- a/pmlc/lit.bzl
+++ b/pmlc/lit.bzl
@@ -45,7 +45,12 @@ def _run_lit_test(name, data, size, tags, features):
         name = name,
         srcs = ["@llvm-project//llvm:lit"],
         tags = tags,
-        args = ["pmlc", "-v"] + features,
+        args = [
+            "pmlc",
+            "-v",
+            "-Dplaidml_device=$(plaidml_device)",
+            "-Dplaidml_target=$(plaidml_target)",
+        ] + features,
         data = data + [
             "//pmlc/tools/pmlc-jit",
             "//pmlc/tools/pmlc-opt",
@@ -58,6 +63,7 @@ def _run_lit_test(name, data, size, tags, features):
         ],
         size = size,
         main = "lit.py",
+        toolchains = ["//plaidml:settings"],
     )
 
 def glob_lit_tests(

--- a/pmlc/lit.cfg.py
+++ b/pmlc/lit.cfg.py
@@ -52,3 +52,6 @@ tool_names = [
 ]
 tools = [ToolSubst(s, unresolved='ignore') for s in tool_names]
 llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+config.substitutions.append(('%plaidml_device', lit_config.params.get('plaidml_device', 'llvm_cpu.0')))
+config.substitutions.append(('%plaidml_target', lit_config.params.get('plaidml_target', 'llvm_cpu')))


### PR DESCRIPTION
This commit adds two Bazel command line flags:
 --//plaidml:device=&lt;device&gt; -- sets the test execution device
 --//plaidml:target=&lt;target&gt; -- sets the test compilation target

For now, the device defaults to 'llvm_cpu.0', and the target must be
'llvm_cpu'.