### PR TITLE
add stdx.uitofp operation with lowering to llvm and use for casting

### DIFF
--- a/pmlc/conversion/tile_to_pxa/tests/cast.mlir
+++ b/pmlc/conversion/tile_to_pxa/tests/cast.mlir
@@ -33,3 +33,27 @@ func @cast_f32_u16(%arg0: tensor<f32>) -> tensor<ui16> {
   // CHECK: pxa.reduce assign
   return %0 : tensor<ui16>
 }
+
+// -----
+
+// CHECK-LABEL: func @cast_i16_f32
+func @cast_i16_f32(%arg0: tensor<si16>) -> tensor<f32> {
+  %0 = "eltwise.cast"(%arg0) : (tensor<si16>) -> tensor<f32>
+  // CHECK: alloc
+  // CHECK: affine.load
+  // CHECK: sitofp
+  // CHECK: pxa.reduce assign
+  return %0 : tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL: func @cast_u16_f32
+func @cast_u16_f32(%arg0: tensor<ui16>) -> tensor<f32> {
+  %0 = "eltwise.cast"(%arg0) : (tensor<ui16>) -> tensor<f32>
+  // CHECK: alloc
+  // CHECK: affine.load
+  // CHECK: stdx.uitofp
+  // CHECK: pxa.reduce assign
+  return %0 : tensor<f32>
+}

--- a/pmlc/dialect/stdx/ir/ops.cc
+++ b/pmlc/dialect/stdx/ir/ops.cc
@@ -49,6 +49,43 @@ static void buildFPToUIOp(OpBuilder &builder, OperationState &result,
   result.addTypes(destType);
 }
 
+// ---- UIToFPOp ----
+
+void printUIToFPOp(OpAsmPrinter &p, UIToFPOp op) {
+  p << op.getOperation()->getName() << ' ' << op.getOperand() << " : "
+    << op.getOperand().getType() << " to "
+    << op.getOperation()->getResult(0).getType();
+}
+
+ParseResult parseUIToFPOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::OperandType srcInfo;
+  Type srcType, dstType;
+  return failure(parser.parseOperand(srcInfo) ||
+                 parser.parseOptionalAttrDict(result.attributes) ||
+                 parser.parseColonType(srcType) ||
+                 parser.resolveOperand(srcInfo, srcType, result.operands) ||
+                 parser.parseKeywordType("to", dstType) ||
+                 parser.addTypeToList(dstType, result.types));
+}
+
+LogicalResult verifyUIToFPOp(UIToFPOp op) {
+  auto opType = op.getOperand().getType();
+  auto resType = op.getOperation()->getResult(0).getType();
+  if (auto fromIntType = opType.dyn_cast<mlir::IntegerType>()) {
+    if (auto intoFloatType = resType.dyn_cast<mlir::FloatType>()) {
+      return success();
+    }
+  }
+  return op.emitError("operand type ") << opType << " and result type "
+                                       << resType << " are cast incompatible";
+}
+
+static void buildUIToFPOp(OpBuilder &builder, OperationState &result,
+                          Value source, Type destType) {
+  result.addOperands(source);
+  result.addTypes(destType);
+}
+
 } // namespace
 
 #define GET_OP_CLASSES

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -33,6 +33,17 @@ def FPToUIOp :
   >];
 }
 
+def UIToFPOp :
+    StdX_Op<"uitofp", [NoSideEffect]> {
+  let summary = "cast from unsigned integer to floating-point type";
+  let arguments = (ins AnyType:$result);
+  let results = (outs AnyType);
+  let builders = [OpBuilder<
+    "OpBuilder &builder, OperationState &result, Value source, Type destType",
+    [{ buildUIToFPOp(builder, result, source, destType); }]
+  >];
+}
+
 class StdX_Plain_Op<string mnemonic, list<OpTrait> traits = []> :
     Op<StdX_Dialect, mnemonic, traits> {
 }


### PR DESCRIPTION
Tile to PXA lowering has been converting all ints to float using sitofp, since MLIR std dialect does not include uitofp. Add a stdx.uitofp which lowers to llvm.uitofp so createCastOp can generate appropriately signed conversions.
Fixes #1256 