### PR TITLE
Support for 3rd party compilers

### DIFF
--- a/plaidml/BUILD
+++ b/plaidml/BUILD
@@ -3,18 +3,38 @@
 load("//tools/py_cffi:build_defs.bzl", "py_cffi")
 load("//tools/py_setup:build_defs.bzl", "py_setup")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")
 load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_shlib", "plaidml_settings")
 
 plaidml_cc_library(
-    name = "plaidml",
+    name = "api",
     visibility = ["//visibility:public"],
     deps = [
         "//plaidml/core",
         "//plaidml/edsl",
         "//plaidml/exec",
         "//plaidml/op",
+    ],
+)
+
+plaidml_cc_library(
+    name = "plaidml",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":api",
+        ":targets",
+    ],
+)
+
+plaidml_cc_library(
+    name = "targets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pmlc:all_passes_and_dialects",
+        "//pmlc/target/demo",
+        "//pmlc/target/intel_gen",
+        "//pmlc/target/x86",
     ],
 )
 
@@ -176,7 +196,6 @@ string_flag(
 
 string_flag(
     name = "target",
-    values = ["llvm_cpu", "foo"],
     build_setting_default = "llvm_cpu",
 )
 

--- a/plaidml/bridge/openvino/BUILD
+++ b/plaidml/bridge/openvino/BUILD
@@ -20,7 +20,7 @@ plaidml_cc_library(
     includes = ["src/plaidml_plugin"],
     tags = TAGS,
     deps = [
-        "//plaidml",
+        "//plaidml:api",
         "@openvino//:inference_engine",
     ],
     alwayslink = 1,
@@ -31,7 +31,10 @@ cc_binary(
     linkopts = PLAIDML_LINKOPTS,
     linkshared = 1,
     tags = TAGS,
-    deps = [":lib"],
+    deps = [
+        ":lib",
+        "//plaidml:targets",
+    ],
 )
 
 write_file(

--- a/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_executable_network.cpp
+++ b/plaidml/bridge/openvino/src/plaidml_plugin/plaidml_executable_network.cpp
@@ -33,7 +33,7 @@ InferRequestInternal::Ptr PlaidMLExecutableNetwork::CreateInferRequestImpl(Input
     IVLOG(2, "output: " << kvp.first);
     outputs.push_back(tensorIOMap_.at(kvp.first));
   }
-  auto program = edsl::ProgramBuilder("ie", outputs).target("llvm_cpu").compile();
+  auto program = edsl::ProgramBuilder("ie", outputs).compile();
   return std::make_shared<PlaidMLInferRequest>(networkInputs, networkOutputs, program, tensorIOMap_);
 }
 

--- a/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
+++ b/plaidml/bridge/openvino/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/BUILD
@@ -1,10 +1,30 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bzl:plaidml.bzl", "PLAIDML_LINKOPTS")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_test(
-    name = "single_layer_tests",
+TAGS = [
+    "skip_macos",
+    "skip_windows",
+]
+
+DATA = [
+    "//plaidml/bridge/openvino:libplaidml-plugin.so",
+    "//plaidml/bridge/openvino:plugins",
+]
+
+DEPS = [
+    "//pmlc/util:logging",
+    "@gflags",
+    "@gmock//:gtest_main",
+    "@openvino//:common_test_utils",
+    "@openvino//:helpers",
+    "@openvino//:inference_engine",
+    "@openvino//:shared_plugin_tests",
+]
+
+cc_library(
+    name = "lib",
     srcs = glob(
         ["*.cpp"],
         exclude = [
@@ -14,77 +34,60 @@ cc_test(
         ],
     ),
     copts = ["-Wno-deprecated-declarations"],
-    data = [
-        "//plaidml/bridge/openvino:libplaidml-plugin.so",
-        "//plaidml/bridge/openvino:plugins",
-    ],
+    tags = TAGS,
+    deps = DEPS,
+)
+
+cc_library(
+    name = "smoke_lib",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = [
+            "convert_like.cpp",  # Known errors
+            "convolution.cpp",  # Long
+            "convolution_backprop_data.cpp",  # Long
+            "cum_sum.cpp",  # Doesn't compile
+            "equal.cpp",  # Known errors
+            "extract_image_patches.cpp",  # Doesn't compile
+            "fake_quantize.cpp",  # Known errors (intermittent)
+            "floor_mod.cpp",  # Known errors
+            "greater.cpp",  # Known errors
+            "greater_equal.cpp",  # Known errors
+            "group_convolution_backprop_data.cpp",  # Long
+            "less.cpp",  # Known errors
+            "less_equal.cpp",  # Known errors
+            "logical_and.cpp",  # Known errors
+            "logical_not.cpp",  # Known errors
+            "logical_or.cpp",  # Known errors
+            "logical_xor.cpp",  # Known errors
+            "not_equal.cpp",  # Known errors
+            "reduce_logical_and.cpp",  # Known errors
+            "reduce_logical_or.cpp",  # Known errors
+            "pooling.cpp",  # Long, known errors
+            "select.cpp",  # Known errors
+            "split.cpp",  # Known errors
+            "space_to_batch.cpp",  # Doesn't compile
+            "tile.cpp",  # Known errors
+        ],
+    ),
+    copts = ["-Wno-deprecated-declarations"],
+    tags = TAGS,
+    deps = DEPS,
+)
+
+cc_test(
+    name = "single_layer_tests",
+    data = DATA,
     linkopts = PLAIDML_LINKOPTS,
-    tags = [
-        "manual",
-        "skip_macos",
-        "skip_windows",
-    ],
-    deps = [
-        "//pmlc/util:logging",
-        "@gflags",
-        "@gmock//:gtest_main",
-        "@openvino//:helpers",
-        "@openvino//:inference_engine",
-        "@openvino//:common_test_utils",
-        "@openvino//:shared_plugin_tests",
-    ],
+    tags = TAGS + ["manual"],
+    deps = [":lib"],
 )
 
 # Tests suitable for CI, skips flakey, broken, and long tests
 cc_test(
     name = "smoke",
-    srcs = glob(
-        ["*.cpp"],
-        exclude = [
-            "convert_like.cpp",                     # Known errors
-            "convolution.cpp",                      # Long
-            "convolution_backprop_data.cpp",        # Long
-            "cum_sum.cpp",                          # Doesn't compile
-            "equal.cpp",                            # Known errors
-            "extract_image_patches.cpp",            # Doesn't compile
-            "fake_quantize.cpp",                    # Known errors (intermittent)
-            "floor_mod.cpp",                        # Known errors
-            "greater.cpp",                          # Known errors
-            "greater_equal.cpp",                    # Known errors
-            "group_convolution_backprop_data.cpp",  # Long
-            "less.cpp",                             # Known errors
-            "less_equal.cpp",                       # Known errors
-            "logical_and.cpp",                      # Known errors
-            "logical_not.cpp",                      # Known errors
-            "logical_or.cpp",                       # Known errors
-            "logical_xor.cpp",                      # Known errors
-            "not_equal.cpp",                        # Known errors
-            "reduce_logical_and.cpp",               # Known errors
-            "reduce_logical_or.cpp",                # Known errors
-            "pooling.cpp",                          # Long, known errors
-            "select.cpp",                           # Known errors
-            "split.cpp",                            # Known errors
-            "space_to_batch.cpp",                   # Doesn't compile
-            "tile.cpp",                             # Known errors
-        ],
-    ),
-    copts = ["-Wno-deprecated-declarations"],
-    data = [
-        "//plaidml/bridge/openvino:libplaidml-plugin.so",
-        "//plaidml/bridge/openvino:plugins",
-    ],
+    data = DATA,
     linkopts = PLAIDML_LINKOPTS,
-    tags = [
-        "skip_macos",
-        "skip_windows",
-    ],
-    deps = [
-        "//pmlc/util:logging",
-        "@gflags",
-        "@gmock//:gtest_main",
-        "@openvino//:helpers",
-        "@openvino//:inference_engine",
-        "@openvino//:common_test_utils",
-        "@openvino//:shared_plugin_tests",
-    ],
+    tags = TAGS,
+    deps = [":smoke_lib"],
 )

--- a/plaidml/bridge/pytorch/BUILD
+++ b/plaidml/bridge/pytorch/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2019, Intel Corporation.
 
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
 
 # NOTE: We can't statically link against anything unless it was built with _GLIBCXX_USE_CXX11_ABI=0.

--- a/plaidml/core/BUILD
+++ b/plaidml/core/BUILD
@@ -56,7 +56,6 @@ plaidml_cc_library(
         "//pmlc/util",
         "@llvm-project//llvm:Support",
     ],
-    alwayslink = 1,
 )
 
 py_library(

--- a/plaidml/edsl/BUILD
+++ b/plaidml/edsl/BUILD
@@ -1,8 +1,7 @@
 # Copyright 2020 Intel Corporation
 
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
-load("//pmlc:lit.bzl", "lit_test")
 
 SDK_HDRS = [
     "autodiff.h",
@@ -41,12 +40,10 @@ plaidml_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//plaidml/core",
-        "//pmlc:all_passes_and_dialects_no_registration",
         "//pmlc/dialect/tile",
         "//pmlc/util",
         "@llvm-project//llvm:Support",
     ],
-    alwayslink = 1,
 )
 
 py_library(

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -20,8 +20,6 @@
 #include "pmlc/compiler/registry.h"
 #include "pmlc/dialect/tile/gradient.h"
 #include "pmlc/dialect/tile/ir/ops.h"
-#include "pmlc/util/all_dialects.h"
-#include "pmlc/util/all_passes.h"
 #include "pmlc/util/enums.h"
 #include "pmlc/util/env.h"
 
@@ -114,8 +112,6 @@ void plaidml_edsl_init(  //
   ffi_wrap_void(err, [&] {
     std::call_once(is_initialized, []() {
       IVLOG(1, "plaidml_edsl_init");
-      registerAllDialects();
-      registerAllPasses();
       plaidml::edsl::RegisterDerivs();
     });
   });

--- a/plaidml/edsl/tests/BUILD
+++ b/plaidml/edsl/tests/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 
 load("@rules_python//python:defs.bzl", "py_test")
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_test")
 load("//pmlc:lit.bzl", "lit_test")
 
 plaidml_cc_test(

--- a/plaidml/exec/BUILD
+++ b/plaidml/exec/BUILD
@@ -1,6 +1,7 @@
 # Copyright 2019 Intel Corporation.
 
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 
 SDK_HDRS = [
     "exec.h",
@@ -33,9 +34,6 @@ plaidml_cc_library(
     deps = [
         "//plaidml/core",
         "//pmlc/compiler",
-        "//pmlc/target/demo",
-        "//pmlc/target/intel_gen",
-        "//pmlc/target/x86",
         "//pmlc/util",
     ],
     alwayslink = 1,

--- a/plaidml/op/BUILD
+++ b/plaidml/op/BUILD
@@ -1,7 +1,6 @@
 # Copyright 2019 Intel Corporation.
 
-load("@rules_python//python:defs.bzl", "py_test")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_python//python:defs.bzl", "py_library")
 load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
 
 SDK_HDRS = [

--- a/pmlc/BUILD
+++ b/pmlc/BUILD
@@ -38,7 +38,9 @@ plaidml_cc_test(
 )
 
 plaidml_cc_library(
-    name = "all_passes_and_dialects_no_registration",
+    name = "all_passes_and_dialects",
+    srcs = ["all_dialects.cc"],
+    hdrs = ["all_passes.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//pmlc/conversion/gpu",
@@ -50,16 +52,11 @@ plaidml_cc_library(
         "//pmlc/dialect/stdx",
         "//pmlc/dialect/tile",
         "//pmlc/dialect/xsmm",
+        "//pmlc/target/demo",
         "//pmlc/target/intel_gen",
         "//pmlc/target/x86",
         "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
     ],
-)
-
-plaidml_cc_library(
-    name = "all_passes_and_dialects",
-    visibility = ["//visibility:public"],
-    deps = [":all_passes_and_dialects_no_registration"],
     alwayslink = 1,
 )
 

--- a/pmlc/all_dialects.cc
+++ b/pmlc/all_dialects.cc
@@ -1,7 +1,5 @@
 // Copyright 2020 Intel Corporation
 
-#pragma once
-
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -22,10 +20,10 @@
 
 using namespace mlir; // NOLINT [build/namespaces]
 
-// This function should be called before creating any MLIRContext if one expect
-// all the possible dialects to be made available to the context automatically.
-inline void registerAllDialects() {
-  static bool init_once = []() {
+namespace {
+
+struct DialectRegistration {
+  DialectRegistration() {
     // MLIR core
     registerDialect<AffineDialect>();
     registerDialect<gpu::GPUDialect>();
@@ -37,13 +35,16 @@ inline void registerAllDialects() {
     registerDialect<spirv::SPIRVDialect>();
     registerDialect<StandardOpsDialect>();
     registerDialect<vector::VectorDialect>();
+
     // PMLC
     registerDialect<pmlc::dialect::eltwise::EltwiseDialect>();
     registerDialect<pmlc::dialect::pxa::PXADialect>();
     registerDialect<pmlc::dialect::stdx::StdXDialect>();
     registerDialect<pmlc::dialect::tile::TileDialect>();
     registerDialect<pmlc::dialect::xsmm::XSMMDialect>();
-    return true;
-  }();
-  (void)init_once;
-}
+  }
+};
+
+static DialectRegistration allDialects;
+
+} // namespace

--- a/pmlc/all_passes.h
+++ b/pmlc/all_passes.h
@@ -125,10 +125,6 @@ inline void registerAllPasses() {
   // Target: x86
 #define GEN_PASS_REGISTRATION
 #include "pmlc/target/x86/passes.h.inc"
-
-  // Pass pipelines
-  pmlc::target::intel_gen::registerPassPipeline();
-  pmlc::target::x86::registerPassPipeline();
 }
 
 } // namespace mlir

--- a/pmlc/rt/vulkan/tests/BUILD
+++ b/pmlc/rt/vulkan/tests/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//pmlc:lit.bzl", "glob_lit_tests", "lit_test")
-load("//bzl:plaidml.bzl", "plaidml_cc_test","plaidml_cc_library")
+load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+
+package(default_visibility = ["//visibility:public"])
 
 glob_lit_tests(
     data = ["//pmlc/rt/vulkan:vkprobe"],
@@ -25,6 +25,7 @@ plaidml_cc_library(
 plaidml_cc_test(
     name = "cc_test_gpu",
     srcs = ["edsl_test_gpu.cc"],
+    linkstatic = 1,
     tags = ["manual"],  # the `edsl_test.cc.test` rule will run this test via lit
     deps = [
         ":testenv",
@@ -32,14 +33,13 @@ plaidml_cc_test(
         "//plaidml/exec",
         "//pmlc/rt/vulkan",
     ],
-    linkstatic = 1,
 )
 
 lit_test(
-	name="edsl_test_gpu.cc",
+    name = "edsl_test_gpu.cc",
     data = [
-    	":cc_test_gpu",
-    	"lit.local.cfg",
-    	"//pmlc/rt/vulkan:vkprobe",
+        "lit.local.cfg",
+        ":cc_test_gpu",
+        "//pmlc/rt/vulkan:vkprobe",
     ],
 )

--- a/pmlc/target/demo/BUILD
+++ b/pmlc/target/demo/BUILD
@@ -16,5 +16,4 @@ plaidml_cc_library(
         "@llvm-project//mlir:AffineToStandardTransforms",
         "@llvm-project//mlir:LLVMTransforms",
     ],
-    alwayslink = 1,
 )

--- a/pmlc/target/intel_gen/passes.h
+++ b/pmlc/target/intel_gen/passes.h
@@ -1,7 +1,11 @@
 #pragma once
 
+namespace mlir {
+class OpPassManager;
+} // namespace mlir
+
 namespace pmlc::target::intel_gen {
 
-void registerPassPipeline();
+void pipelineBuilder(mlir::OpPassManager &pm);
 
 } // namespace pmlc::target::intel_gen

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -28,7 +28,7 @@ namespace pmlc::target::intel_gen {
 
 namespace {
 
-void addToPipeline(OpPassManager &pm) {
+void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(dialect::tile::createComputeBoundsPass());
   // pm.addPass(dialect::tile::createPadPass());
   pm.addPass(createCanonicalizerPass());
@@ -78,10 +78,9 @@ void addToPipeline(OpPassManager &pm) {
 
 } // namespace
 
-void registerPassPipeline() {
-  static PassPipelineRegistration<> passPipelineReg(
-      "target-intel_gen", "Target pipeline for Intel GEN iGPUs", addToPipeline);
-  static compiler::TargetRegistration targetReg("intel_gen", addToPipeline);
-}
+static PassPipelineRegistration<>
+    passPipelineReg("target-intel_gen", "Target pipeline for Intel GEN iGPUs",
+                    pipelineBuilder);
+static compiler::TargetRegistration targetReg("intel_gen", pipelineBuilder);
 
 } // namespace pmlc::target::intel_gen

--- a/pmlc/target/x86/BUILD
+++ b/pmlc/target/x86/BUILD
@@ -28,7 +28,7 @@ gentbl(
 )
 
 plaidml_cc_library(
-    name = "x86",
+    name = "lib",
     srcs = [
         "heatmap.h",
         "heatmap_impl.cc",
@@ -55,7 +55,14 @@ plaidml_cc_library(
         "//pmlc/rt",
         "@llvm-project//mlir:AffineToStandardTransforms",
         "@llvm-project//mlir:LLVMTransforms",
+        "@llvm-project//mlir:SCFToStandard",
         "@llvm-project//mlir:StandardOpsTransforms",
     ],
+)
+
+plaidml_cc_library(
+    name = "x86",
+    srcs = ["register.cc"],
+    deps = [":lib"],
     alwayslink = 1,
 )

--- a/pmlc/target/x86/passes.h
+++ b/pmlc/target/x86/passes.h
@@ -6,6 +6,7 @@ namespace mlir {
 class LLVMTypeConverter;
 class LowerToLLVMOptions;
 class MLIRContext;
+class OpPassManager;
 class OwningRewritePatternList;
 class Pass;
 } // namespace mlir
@@ -29,6 +30,6 @@ void populateXSMMToLLVMConversionPatterns(
     mlir::LLVMTypeConverter &converter,
     mlir::OwningRewritePatternList &patterns);
 
-void registerPassPipeline();
+void pipelineBuilder(mlir::OpPassManager &pm);
 
 } // namespace pmlc::target::x86

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -5,8 +5,6 @@
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/Affine/Passes.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Pass/Pass.h"
@@ -106,7 +104,7 @@ std::unique_ptr<Pass> createLowerToLLVMPass() {
   return std::make_unique<ConvertToLLVMPass>();
 }
 
-static void addToPipeline(OpPassManager &pm) {
+void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(pmlc::dialect::tile::createComputeBoundsPass());
   pm.addPass(pmlc::dialect::tile::createPadPass());
   pm.addPass(createCanonicalizerPass());
@@ -148,12 +146,6 @@ static void addToPipeline(OpPassManager &pm) {
 
   pm.addPass(createLowerToLLVMPass());
   pm.addPass(createTraceLinkingPass());
-}
-
-void registerPassPipeline() {
-  static PassPipelineRegistration<> passPipelineReg(
-      "target-cpu", "Target pipeline for CPU", addToPipeline);
-  static compiler::TargetRegistration targetReg("llvm_cpu", addToPipeline);
 }
 
 } // namespace pmlc::target::x86

--- a/pmlc/target/x86/register.cc
+++ b/pmlc/target/x86/register.cc
@@ -1,0 +1,16 @@
+#include "pmlc/target/x86/passes.h"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "pmlc/compiler/registry.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+namespace pmlc::target::x86 {
+
+static PassPipelineRegistration<>
+    passPipelineReg("target-cpu", "Target pipeline for CPU", pipelineBuilder);
+static compiler::TargetRegistration targetReg("llvm_cpu", pipelineBuilder);
+
+} // namespace pmlc::target::x86

--- a/pmlc/tools/pmlc-jit/BUILD
+++ b/pmlc/tools/pmlc-jit/BUILD
@@ -1,14 +1,14 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "lib",
     srcs = ["pmlc-jit.cc"],
     deps = [
-        "//pmlc:all_passes_and_dialects_no_registration",
+        "//pmlc:all_passes_and_dialects",
         "//pmlc/compiler",
         "//pmlc/rt",
         "//pmlc/rt/vulkan",

--- a/pmlc/tools/pmlc-jit/pmlc-jit.cc
+++ b/pmlc/tools/pmlc-jit/pmlc-jit.cc
@@ -16,17 +16,17 @@
 
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/Support/FileUtilities.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "pmlc/compiler/executable.h"
 #include "pmlc/compiler/program.h"
-#include "pmlc/util/all_dialects.h"
-#include "pmlc/util/all_passes.h"
 #include "pmlc/util/env.h"
 #include "pmlc/util/logging.h"
 
+using namespace mlir; // NOLINT
 using llvm::Error;
 using pmlc::compiler::EngineKind;
 using pmlc::compiler::Executable;
@@ -85,7 +85,6 @@ int main(int argc, char **argv) {
     IVLOG(level, "PLAIDML_VERBOSE=" << level);
   }
 
-  registerAllDialects();
   llvm::InitLLVM y(argc, argv);
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();

--- a/pmlc/tools/pmlc-opt/BUILD
+++ b/pmlc/tools/pmlc-opt/BUILD
@@ -1,14 +1,14 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "lib",
     srcs = ["pmlc-opt.cc"],
     deps = [
-        "//pmlc:all_passes_and_dialects_no_registration",
+        "//pmlc:all_passes_and_dialects",
         "//pmlc/util",
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:Parser",

--- a/pmlc/tools/pmlc-opt/pmlc-opt.cc
+++ b/pmlc/tools/pmlc-opt/pmlc-opt.cc
@@ -11,8 +11,7 @@
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/MlirOptMain.h"
 
-#include "pmlc/util/all_dialects.h"
-#include "pmlc/util/all_passes.h"
+#include "pmlc/all_passes.h"
 #include "pmlc/util/env.h"
 #include "pmlc/util/logging.h"
 
@@ -57,7 +56,6 @@ int main(int argc, char **argv) {
     IVLOG(level, "PLAIDML_VERBOSE=" << level);
   }
 
-  registerAllDialects();
   registerAllPasses();
   // registerTestPasses();
   InitLLVM y(argc, argv);

--- a/pmlc/tools/pmlc-vulkan-runner/BUILD
+++ b/pmlc/tools/pmlc-vulkan-runner/BUILD
@@ -8,7 +8,7 @@ plaidml_cc_library(
     name = "lib",
     srcs = ["pmlc-vulkan-runner.cc"],
     deps = [
-        "//pmlc:all_passes_and_dialects_no_registration",
+        "//pmlc:all_passes_and_dialects",
         "//pmlc/rt/vulkan",
         "@llvm-project//mlir:MlirJitRunner",
     ],

--- a/pmlc/tools/pmlc-vulkan-runner/pmlc-vulkan-runner.cc
+++ b/pmlc/tools/pmlc-vulkan-runner/pmlc-vulkan-runner.cc
@@ -29,8 +29,6 @@
 #include "pmlc/compiler/executable.h"
 #include "pmlc/compiler/program.h"
 #include "pmlc/conversion/gpu/lowering.h"
-#include "pmlc/util/all_dialects.h"
-#include "pmlc/util/all_passes.h"
 #include "pmlc/util/env.h"
 #include "pmlc/util/logging.h"
 
@@ -110,7 +108,6 @@ int main(int argc, char **argv) {
   llvm::llvm_shutdown_obj x;
   registerPassManagerCLOptions();
 
-  registerAllDialects();
   llvm::InitLLVM y(argc, argv);
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();


### PR DESCRIPTION
* Provide support for allowing external compilers to decide which targets to include.
* Decouple lib and test in openvino bridge.
* All dialects must be registered, until this lands: https://reviews.llvm.org/D85622
* A target is registered via a static initializer.
* OpenVINO tests no longer hard-code the target, instead use the PLAIDML_TARGET env var.