### PR TITLE
Use AffineVectorLoadOp/AffineVectorStoreOp builders

### DIFF
--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -91,13 +91,13 @@ def plaidml_workspace():
         strip_prefix = "jsonnet-0.13.0",
     )
 
-    LLVM_COMMIT = "ae1b53a07c63e03deafdcd4152a03c625161adcb"
+    LLVM_COMMIT = "911c314a6c762906aee28df54844c87f1643bab5"
     LLVM_SHA256 = "eca41b349e99db0cde1e510cd28ea48b6ac09d4257dc7f9d7668342f0d46ddf0"
     LLVM_URL = "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)
     http_archive(
         name = "llvm-project",
         url = LLVM_URL,
-        sha256 = LLVM_SHA256,
+        # sha256 = LLVM_SHA256,
         strip_prefix = "llvm-project-" + LLVM_COMMIT,
         link_files = {
             clean_dep("//vendor/llvm:llvm.BUILD"): "llvm/BUILD.bazel",

--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -92,12 +92,12 @@ def plaidml_workspace():
     )
 
     LLVM_COMMIT = "911c314a6c762906aee28df54844c87f1643bab5"
-    LLVM_SHA256 = "eca41b349e99db0cde1e510cd28ea48b6ac09d4257dc7f9d7668342f0d46ddf0"
+    LLVM_SHA256 = "dc17c0e6d0d1ddef2617e276d6751b6f3712e126c2019011c0cc2c0ed9361462"
     LLVM_URL = "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)
     http_archive(
         name = "llvm-project",
         url = LLVM_URL,
-        # sha256 = LLVM_SHA256,
+        sha256 = LLVM_SHA256,
         strip_prefix = "llvm-project-" + LLVM_COMMIT,
         link_files = {
             clean_dep("//vendor/llvm:llvm.BUILD"): "llvm/BUILD.bazel",

--- a/pmlc/conversion/pxa_to_affine/tests/vector.mlir
+++ b/pmlc/conversion/pxa_to_affine/tests/vector.mlir
@@ -1,0 +1,23 @@
+// RUN: pmlc-opt %s -convert-pxa-to-affine | FileCheck %s
+
+func @eltwise_sum(%arg0: memref<1x256x256x16xf16>, %arg1: memref<1x256x256x16xf16>) -> memref<1x256x256x16xf16> {
+  %0 = alloc() : memref<1x256x256x16xf16>
+  %1 = affine.parallel (%arg2, %arg3, %arg4) = (0, 0, 0) to (256, 256, 2) reduce ("assign") -> (memref<1x256x256x16xf16>) {
+    %2 = pxa.vector_load %arg1[0, %arg2, %arg3, %arg4 * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+    %3 = pxa.vector_load %arg0[0, %arg2, %arg3, %arg4 * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+    %4 = addf %2, %3 : vector<8xf16>
+    %5 = pxa.vector_reduce assign %4, %0[0, %arg2, %arg3, %arg4 * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+    affine.yield %5 : memref<1x256x256x16xf16>
+  }
+  return %1 : memref<1x256x256x16xf16>
+}
+
+// CHECK-LABEL: func @eltwise_sum
+// CHECK: affine.for %{{.*}} = 0 to 256
+// CHECK:   affine.for %{{.*}} = 0 to 256
+// CHECK:     affine.for %{{.*}} = 0 to 2
+// CHECK:       affine.vector_load %{{.*}}[0, %{{.*}}, %{{.*}}, %{{.*}} * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+// CHECK:       affine.vector_load %{{.*}}[0, %{{.*}}, %{{.*}}, %{{.*}} * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+// CHECK:       addf %{{.*}}, %{{.*}} : vector<8xf16>
+// CHECK:       affine.vector_load %{{.*}}[0, %{{.*}}, %{{.*}}, %{{.*}} * 8] : memref<1x256x256x16xf16>, vector<8xf16>
+// CHECK:       affine.vector_store %{{.*}}, %{{.*}}[0, %{{.*}}, %{{.*}}, %{{.*}} * 8] : memref<1x256x256x16xf16>, vector<8xf16>


### PR DESCRIPTION
This relies on: https://github.com/plaidml/llvm-project/pull/24

Without the custom builder, `affine.vector_load` op verification was failing. It's unclear how to fix this without having a custom builder.
