### PR TITLE
Fix bazel buildkite farm

### DIFF
--- a/bzl/bazel.rc
+++ b/bzl/bazel.rc
@@ -29,6 +29,9 @@ build --define=version=0.0.0.dev0
 test --test_timeout_filters=-eternal
 #test --test_output=streamed
 test --test_env=HOME
+test --test_env=PLAIDML_DEVICE
+test --test_env=PLAIDML_TARGET
+test --test_env=PLAIDML_SETTINGS
 test --test_sharding_strategy=disabled
 run --test_env=HOME
 run --test_env=PLAIDML_DEVICE


### PR DESCRIPTION
Currently the OpenVINO tests use `plaidml::Settings` to determine which device/target to run on. Therefore, we need to have these env vars included so that CI will work. A PR that will use command line args instead to make things more hermetic is very welcome!

@tzerrell Is it possible to use `//plaidml:device` and `//plaidml:target` command line arguments?