### PR TITLE
Fix gtest_filter with skip_test_file on intel_gen target.

### DIFF
--- a/pmlc/testing/gtest_main.cc
+++ b/pmlc/testing/gtest_main.cc
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
       sep = ':';
     }
 
-    testing::FLAGS_gtest_filter = ss.str();
+    testing::FLAGS_gtest_filter += ss.str();
   }
 
   try {


### PR DESCRIPTION
Signed-off-by: xin1.wang <xin1.wang@intel.com>