### PR TITLE
Update to latest LLVM/MLIR

### DIFF
--- a/bzl/workspace.bzl
+++ b/bzl/workspace.bzl
@@ -91,8 +91,8 @@ def plaidml_workspace():
         strip_prefix = "jsonnet-0.13.0",
     )
 
-    LLVM_COMMIT = "7e56550ed070913036d0681aae66833312fabdd0"
-    LLVM_SHA256 = "41a7e62f985a33d09097c101cd9a469ae82412b3db27437b7b849b5bace1243c"
+    LLVM_COMMIT = "10d7e2d83cc8b2c605af9346913c1b56a5a317bc"
+    LLVM_SHA256 = "ef8fb8575ca85f594c3c72834078b14aab73f8b6720350ae307091a3abd0ac6f"
     LLVM_URL = "https://github.com/plaidml/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)
     http_archive(
         name = "llvm-project",

--- a/plaidml/exec/ffi.cc
+++ b/plaidml/exec/ffi.cc
@@ -115,7 +115,7 @@ plaidml_executable* plaidml_jit(  //
       auto view = args[i].buffer->MapCurrent();
       bufptrs[i] = view->data();
     }
-    EngineKind kind = EngineKind::MCJIT;
+    EngineKind kind = EngineKind::OrcJIT;
     auto jit = pmlc::util::getEnvVar("LLVM_JIT");
     if (jit == "ORC") {
       kind = EngineKind::OrcJIT;

--- a/pmlc/BUILD
+++ b/pmlc/BUILD
@@ -38,11 +38,20 @@ plaidml_cc_test(
 )
 
 plaidml_cc_library(
+    name = "hdrs",
+    hdrs = [
+        "all_dialects.h",
+        "all_passes.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+plaidml_cc_library(
     name = "all_passes_and_dialects",
     srcs = ["all_dialects.cc"],
-    hdrs = ["all_passes.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":hdrs",
         "//pmlc/conversion/gpu",
         "//pmlc/conversion/pxa_to_affine",
         "//pmlc/conversion/stdx_to_llvm",
@@ -57,7 +66,6 @@ plaidml_cc_library(
         "//pmlc/target/x86",
         "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
     ],
-    alwayslink = 1,
 )
 
 # The following rules are helpers to make it quicker and easier to launch the

--- a/pmlc/all_dialects.cc
+++ b/pmlc/all_dialects.cc
@@ -1,5 +1,7 @@
 // Copyright 2020 Intel Corporation
 
+#include "pmlc/all_dialects.h"
+
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -20,31 +22,28 @@
 
 using namespace mlir; // NOLINT [build/namespaces]
 
-namespace {
+// Add all the MLIR dialects to the provided registry.
+void registerAllDialects(DialectRegistry &registry) {
+  registry.insert<AffineDialect,                          //
+                  gpu::GPUDialect,                        //
+                  LLVM::LLVMDialect,                      //
+                  linalg::LinalgDialect,                  //
+                  scf::SCFDialect,                        //
+                  omp::OpenMPDialect,                     //
+                  spirv::SPIRVDialect,                    //
+                  StandardOpsDialect,                     //
+                  vector::VectorDialect,                  //
+                  pmlc::dialect::eltwise::EltwiseDialect, //
+                  pmlc::dialect::pxa::PXADialect,         //
+                  pmlc::dialect::stdx::StdXDialect,       //
+                  pmlc::dialect::tile::TileDialect,       //
+                  pmlc::dialect::xsmm::XSMMDialect>();
+}
 
-struct DialectRegistration {
-  DialectRegistration() {
-    // MLIR core
-    registerDialect<AffineDialect>();
-    registerDialect<gpu::GPUDialect>();
-    registerDialect<LLVM::LLVMDialect>();
-    registerDialect<linalg::LinalgDialect>();
-    registerDialect<omp::OpenMPDialect>();
-    registerDialect<quant::QuantizationDialect>();
-    registerDialect<scf::SCFDialect>();
-    registerDialect<spirv::SPIRVDialect>();
-    registerDialect<StandardOpsDialect>();
-    registerDialect<vector::VectorDialect>();
-
-    // PMLC
-    registerDialect<pmlc::dialect::eltwise::EltwiseDialect>();
-    registerDialect<pmlc::dialect::pxa::PXADialect>();
-    registerDialect<pmlc::dialect::stdx::StdXDialect>();
-    registerDialect<pmlc::dialect::tile::TileDialect>();
-    registerDialect<pmlc::dialect::xsmm::XSMMDialect>();
-  }
-};
-
-static DialectRegistration allDialects;
-
-} // namespace
+// This function should be called before creating any MLIRContext if one expect
+// all the possible dialects to be made available to the context automatically.
+void registerAllDialects() {
+  static bool initOnce =
+      ([]() { registerAllDialects(getGlobalDialectRegistry()); }(), true);
+  (void)initOnce;
+}

--- a/pmlc/all_dialects.h
+++ b/pmlc/all_dialects.h
@@ -1,0 +1,12 @@
+// Copyright 2020 Intel Corporation
+
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+
+// Add all the MLIR dialects to the provided registry.
+void registerAllDialects(mlir::DialectRegistry &registry);
+
+// This function should be called before creating any MLIRContext if one expect
+// all the possible dialects to be made available to the context automatically.
+void registerAllDialects();

--- a/pmlc/all_passes.h
+++ b/pmlc/all_passes.h
@@ -2,49 +2,24 @@
 
 #pragma once
 
-#include <cstdlib>
-
-#include "mlir/Conversion/AVX512ToLLVM/ConvertAVX512ToLLVM.h"
-#include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
-#include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
-#include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
-#include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h"
-#include "mlir/Conversion/GPUToVulkan/ConvertGPUToVulkanPass.h"
-#include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
-#include "mlir/Conversion/LinalgToSPIRV/LinalgToSPIRVPass.h"
-#include "mlir/Conversion/LinalgToStandard/LinalgToStandard.h"
-#include "mlir/Conversion/SCFToGPU/SCFToGPUPass.h"
-#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
-#include "mlir/Conversion/SPIRVToLLVM/ConvertSPIRVToLLVMPass.h"
-#include "mlir/Conversion/ShapeToSCF/ShapeToSCF.h"
-#include "mlir/Conversion/ShapeToStandard/ShapeToStandard.h"
-#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
-#include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
-#include "mlir/Conversion/VectorToROCDL/VectorToROCDL.h"
-#include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
+#include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/GPU/Passes.h"
-#include "mlir/Dialect/LLVMIR/Transforms/LegalizeForExport.h"
+#include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
-#include "mlir/Dialect/Quant/Passes.h"
 #include "mlir/Dialect/SCF/Passes.h"
 #include "mlir/Dialect/SPIRV/Passes.h"
-#include "mlir/Transforms/LocationSnapshot.h"
+#include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Transforms/ViewOpGraph.h"
-#include "mlir/Transforms/ViewRegionGraph.h"
 
+#include "pmlc/conversion/SCFToGPU/Passes.h"
 #include "pmlc/conversion/pxa_to_affine/passes.h"
 #include "pmlc/conversion/stdx_to_llvm/passes.h"
 #include "pmlc/conversion/tile_to_pxa/passes.h"
 #include "pmlc/dialect/pxa/transforms/passes.h"
 #include "pmlc/dialect/stdx/transforms/passes.h"
 #include "pmlc/dialect/tile/transforms/passes.h"
-#include "pmlc/target/intel_gen/passes.h"
 #include "pmlc/target/x86/passes.h"
-
-namespace mlir {
 
 // This function may be called to register the MLIR passes with the
 // global registry.
@@ -58,73 +33,36 @@ inline void registerAllPasses() {
   // MLIR Core
   //
 
-  // Init general passes
-#define GEN_PASS_REGISTRATION
-#include "mlir/Transforms/Passes.h.inc"
+  // General passes
+  mlir::registerTransformsPasses();
 
   // Conversion passes
-#define GEN_PASS_REGISTRATION
-#include "mlir/Conversion/Passes.h.inc"
+  mlir::registerConversionPasses();
 
-  // Affine
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/Affine/Passes.h.inc"
-
-  // GPU
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/GPU/Passes.h.inc"
-
-  // Linalg
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/Linalg/Passes.h.inc"
-
-  // LLVM
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/LLVMIR/Transforms/Passes.h.inc"
-
-  // Quant
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/Quant/Passes.h.inc"
-
-  // SCF
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/SCF/Passes.h.inc"
-
-  // SPIR-V
-#define GEN_PASS_REGISTRATION
-#include "mlir/Dialect/SPIRV/Passes.h.inc"
+  // Dialect passes
+  mlir::registerAffinePasses();
+  mlir::registerGPUPasses();
+  mlir::registerLinalgPasses();
+  mlir::LLVM::registerLLVMPasses();
+  mlir::registerSCFPasses();
+  mlir::spirv::registerSPIRVPasses();
+  mlir::registerStandardPasses();
 
   //
   // PMLC
   //
 
-  // Conversion: pxa_to_affine
-#define GEN_PASS_REGISTRATION
-#include "pmlc/conversion/pxa_to_affine/passes.h.inc"
+  // Conversion passes
+  pmlc::conversion::pxa_to_affine::registerPasses();
+  pmlc::conversion::scf_to_gpu::registerPasses();
+  pmlc::conversion::stdx_to_llvm::registerPasses();
+  pmlc::conversion::tile_to_pxa::registerPasses();
 
-  // Conversion: stdx_to_llvm
-#define GEN_PASS_REGISTRATION
-#include "pmlc/conversion/stdx_to_llvm/passes.h.inc"
+  // Dialect passes
+  pmlc::dialect::pxa::registerPasses();
+  pmlc::dialect::stdx::registerPasses();
+  pmlc::dialect::tile::registerPasses();
 
-  // Conversion: tile_to_pxa
-#define GEN_PASS_REGISTRATION
-#include "pmlc/conversion/tile_to_pxa/passes.h.inc"
-
-  // Dialect: pxa
-#define GEN_PASS_REGISTRATION
-#include "pmlc/dialect/pxa/transforms/passes.h.inc"
-
-  // Dialect: stdx
-#define GEN_PASS_REGISTRATION
-#include "pmlc/dialect/stdx/transforms/passes.h.inc"
-
-  // Dialect: tile
-#define GEN_PASS_REGISTRATION
-#include "pmlc/dialect/tile/transforms/passes.h.inc"
-
-  // Target: x86
-#define GEN_PASS_REGISTRATION
-#include "pmlc/target/x86/passes.h.inc"
+  // Target passes
+  pmlc::target::x86::registerPasses();
 }
-
-} // namespace mlir

--- a/pmlc/compiler/BUILD
+++ b/pmlc/compiler/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "compiler",
@@ -18,5 +18,6 @@ plaidml_cc_library(
         "@llvm-project//llvm:X86CodeGen",
         "@llvm-project//mlir:ExecutionEngineUtils",
         "@llvm-project//mlir:TargetLLVMIR",
+        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/pmlc/compiler/executable.h
+++ b/pmlc/compiler/executable.h
@@ -19,7 +19,7 @@ class Executable {
 public:
   Executable(const std::shared_ptr<Program> &program,
              mlir::ArrayRef<void *> bufptrs,
-             EngineKind kind = EngineKind::MCJIT);
+             EngineKind kind = EngineKind::OrcJIT);
   ~Executable();
 
   void invoke();

--- a/pmlc/conversion/SCFToGPU/BUILD
+++ b/pmlc/conversion/SCFToGPU/BUILD
@@ -13,6 +13,7 @@ gentbl(
             "Passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "Passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/conversion/SCFToGPU/Passes.h
+++ b/pmlc/conversion/SCFToGPU/Passes.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "pmlc/conversion/SCFToGPU/SCFToGPUPass.h"
+
+namespace pmlc::conversion::scf_to_gpu {
+
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/conversion/SCFToGPU/Passes.h.inc"
+
+} // namespace pmlc::conversion::scf_to_gpu

--- a/pmlc/conversion/SCFToGPU/Passes.td
+++ b/pmlc/conversion/SCFToGPU/Passes.td
@@ -17,7 +17,8 @@ include "mlir/Pass/PassBase.td"
 
 def ConvertSimpleSCFToGPU : FunctionPass<"convert-scf-to-gpu"> {
   let summary = "Convert top-level loops to GPU kernels";
-  let constructor = "mlir::createSimpleSCFToGPUPass()";
+  let constructor = "createSimpleSCFToGPUPass()";
+  let dependentDialects = ["mlir::gpu::GPUDialect"];
   let options = [
     Option<"numBlockDims", "gpu-block-dims", "unsigned", /*default=*/"1u",
            "Number of GPU block dimensions for mapping">,

--- a/pmlc/conversion/gpu/BUILD
+++ b/pmlc/conversion/gpu/BUILD
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/conversion/gpu/gpu_to_vulkan.cc
+++ b/pmlc/conversion/gpu/gpu_to_vulkan.cc
@@ -103,11 +103,10 @@ private:
   void declareVulkanFunctions(Location loc);
 
   void getCachedTypes() {
-    llvmDialect = getContext().getRegisteredDialect<LLVM::LLVMDialect>();
-    llvmVoidType = LLVM::LLVMType::getVoidTy(llvmDialect);
-    llvmPointerType = LLVM::LLVMType::getInt8PtrTy(llvmDialect);
-    llvmInt32Type = LLVM::LLVMType::getInt32Ty(llvmDialect);
-    llvmInt64Type = LLVM::LLVMType::getInt64Ty(llvmDialect);
+    llvmVoidType = LLVM::LLVMType::getVoidTy(&getContext());
+    llvmPointerType = LLVM::LLVMType::getInt8PtrTy(&getContext());
+    llvmInt32Type = LLVM::LLVMType::getInt32Ty(&getContext());
+    llvmInt64Type = LLVM::LLVMType::getInt64Ty(&getContext());
 
     OpBuilder builder(getOperation());
     mlirIndexType = builder.getIndexType();
@@ -146,7 +145,6 @@ private:
     return nullptr;
   }
 
-  LLVM::LLVMDialect *getLLVMDialect() { return llvmDialect; }
   LLVM::LLVMType getLLVMVoidType() { return llvmVoidType; }
   LLVM::LLVMType getLLVMPointerType() { return llvmPointerType; }
   LLVM::LLVMType getLLVMInt32Type() { return llvmInt32Type; }
@@ -155,7 +153,6 @@ private:
   mlir::Type getMLIRFloat32Type() { return mlirFloat32Type; }
   mlir::Type getMLIRIndexType() { return mlirIndexType; }
 
-  LLVM::LLVMDialect *llvmDialect;
   LLVM::LLVMType llvmVoidType;
   LLVM::LLVMType llvmPointerType;
   LLVM::LLVMType llvmInt32Type;
@@ -215,8 +212,7 @@ Value ConvertGpuLaunchFuncToVulkanCalls::createEntryPointNameConstant(
   std::string entryPointGlobalName =
       (name + "_spv_entry_point_name" + std::to_string(lauchFuncIndex)).str();
   return LLVM::createGlobalString(loc, builder, entryPointGlobalName,
-                                  shaderName, LLVM::Linkage::Internal,
-                                  getLLVMDialect());
+                                  shaderName, LLVM::Linkage::Internal);
 }
 
 LogicalResult
@@ -420,8 +416,7 @@ void ConvertGpuLaunchFuncToVulkanCalls::convertGpuLaunchFunc(
   // that data to runtime call.
   Value ptrToSPIRVBinary = LLVM::createGlobalString(
       loc, builder, kSPIRVBinary + std::to_string(lauchFuncIndex),
-      {binary.data(), binary.size()}, LLVM::Linkage::Internal,
-      getLLVMDialect());
+      {binary.data(), binary.size()}, LLVM::Linkage::Internal);
 
   // Create LLVM constant for the size of SPIR-V binary shader.
   Value binarySize = builder.create<LLVM::ConstantOp>(

--- a/pmlc/conversion/pxa_to_affine/BUILD
+++ b/pmlc/conversion/pxa_to_affine/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 gentbl(
     name = "gen-pass",
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/conversion/pxa_to_affine/pass_detail.h
+++ b/pmlc/conversion/pxa_to_affine/pass_detail.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace pmlc::conversion::pxa_to_affine {

--- a/pmlc/conversion/pxa_to_affine/passes.h
+++ b/pmlc/conversion/pxa_to_affine/passes.h
@@ -22,4 +22,8 @@ void populatePXAToAffineConversionPatterns(
 
 std::unique_ptr<mlir::Pass> createLowerPXAToAffinePass();
 
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/conversion/pxa_to_affine/passes.h.inc"
+
 } // namespace pmlc::conversion::pxa_to_affine

--- a/pmlc/conversion/pxa_to_affine/passes.td
+++ b/pmlc/conversion/pxa_to_affine/passes.td
@@ -6,6 +6,7 @@ include "mlir/Pass/PassBase.td"
 def LowerPXAToAffine : Pass<"convert-pxa-to-affine", "mlir::ModuleOp"> {
   let summary = "Convert PXA dialect to Affine dialect";
   let constructor = "pmlc::conversion::pxa_to_affine::createLowerPXAToAffinePass()";
+  let dependentDialects = ["mlir::AffineDialect"];
 }
 
 #endif // __PMLC_CONVERSION_PXA_TO_AFFINE_PASSES__

--- a/pmlc/conversion/pxa_to_affine/tests/contract.mlir
+++ b/pmlc/conversion/pxa_to_affine/tests/contract.mlir
@@ -1,5 +1,6 @@
-// RUN: pmlc-opt -tile-compute-bounds -convert-tile-to-pxa -canonicalize \
-// RUN:          -convert-pxa-to-affine -canonicalize -cse %s | FileCheck %s
+// RUN: pmlc-opt -tile-compute-bounds -convert-tile-to-pxa -pxa-normalize \
+// RUN:          -canonicalize -convert-pxa-to-affine -canonicalize -cse %s | \
+// RUN: FileCheck %s
 
 #src  = affine_map<(i, j) -> (i, j)>
 #sink = affine_map<(i, j) -> (j, i)>

--- a/pmlc/conversion/stdx_to_llvm/BUILD
+++ b/pmlc/conversion/stdx_to_llvm/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 gentbl(
     name = "gen-pass",
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/conversion/stdx_to_llvm/pass_detail.h
+++ b/pmlc/conversion/stdx_to_llvm/pass_detail.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace pmlc::conversion::stdx_to_llvm {

--- a/pmlc/conversion/stdx_to_llvm/passes.h
+++ b/pmlc/conversion/stdx_to_llvm/passes.h
@@ -18,4 +18,8 @@ void populateStdXToLLVMConversionPatterns(
 
 std::unique_ptr<mlir::Pass> createLowerToLLVMPass();
 
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/conversion/stdx_to_llvm/passes.h.inc"
+
 } // namespace pmlc::conversion::stdx_to_llvm

--- a/pmlc/conversion/stdx_to_llvm/passes.td
+++ b/pmlc/conversion/stdx_to_llvm/passes.td
@@ -6,6 +6,7 @@ include "mlir/Pass/PassBase.td"
 def LowerToLLVM : Pass<"convert-stdx-to-llvm", "mlir::ModuleOp"> {
   let summary = "Convert stdx to the LLVM dialect";
   let constructor = "pmlc::conversion::stdx_to_llvm::createLowerToLLVMPass()";
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
 #endif // __PMLC_CONVERSION_STDX_TO_LLVM_PASSES__

--- a/pmlc/conversion/stdx_to_llvm/tests/reshape.mlir
+++ b/pmlc/conversion/stdx_to_llvm/tests/reshape.mlir
@@ -8,12 +8,12 @@ module {
 }
 
 // CHECK-LABEL: func @reshaper0
-// CHECK: undef : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">
+// CHECK: undef : !llvm.struct<(ptr<float>, ptr<float>, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK: %[[index0:.*]] = llvm.mlir.constant(60 : index)
 // CHECK: insertvalue %[[index0]], %{{.*}}[3, 0]
 // CHECK: %[[index1:.*]] = llvm.mlir.constant(1 : index)
 // CHECK: insertvalue %[[index1]], %{{.*}}[4, 0]
-// CHECK: return %{{.*}} : !llvm<"{ float*, float*, i64, [1 x i64], [1 x i64] }">
+// CHECK: return %{{.*}} : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
 
 // -----
 
@@ -25,7 +25,7 @@ module {
 }
 
 // CHECK-LABEL: func @reshaper1
-// CHECK: undef : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">
+// CHECK: undef : !llvm.struct<(ptr<float>, ptr<float>, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK: %[[index0:.*]] = llvm.mlir.constant(2 : index)
 // CHECK: insertvalue %[[index0]], %{{.*}}[3, 0]
 // CHECK: %[[index1:.*]] = llvm.mlir.constant(20 : index)
@@ -33,7 +33,7 @@ module {
 // CHECK: insertvalue %[[index1]], %{{.*}}[4, 0]
 // CHECK: %[[index2:.*]] = llvm.mlir.constant(1 : index)
 // CHECK: insertvalue %[[index2]], %{{.*}}[4, 1]
-// CHECK: return %{{.*}} : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
+// CHECK: return %{{.*}} : !llvm.struct<(ptr<float>, ptr<float>, i64, array<2 x i64>, array<2 x i64>)>
 
 // -----
 
@@ -45,7 +45,7 @@ module {
 }
 
 // CHECK-LABEL: func @reshaper2
-// CHECK: undef : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">
+// CHECK: undef : !llvm.struct<(ptr<float>, ptr<float>, i64, array<3 x i64>, array<3 x i64>)>
 // CHECK: %[[index0:.*]] = llvm.mlir.constant(5 : index)
 // CHECK: insertvalue %[[index0]], %{{.*}}[3, 0]
 // CHECK: %[[index1:.*]] = llvm.mlir.constant(6 : index)
@@ -53,7 +53,7 @@ module {
 // CHECK: insertvalue %[[index1]], %{{.*}}[4, 0]
 // CHECK: %[[index2:.*]] = llvm.mlir.constant(1 : index)
 // CHECK: insertvalue %[[index2]], %{{.*}}[4, 1]
-// CHECK: return %{{.*}} : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
+// CHECK: return %{{.*}} : !llvm.struct<(ptr<float>, ptr<float>, i64, array<2 x i64>, array<2 x i64>)>
 
 
 // -----
@@ -66,7 +66,7 @@ module {
 }
 
 // CHECK-LABEL: func @squeeze
-// CHECK: undef : !llvm<"{ float*, float*, i64, [5 x i64], [5 x i64] }">
+// CHECK: undef : !llvm.struct<(ptr<float>, ptr<float>, i64, array<5 x i64>, array<5 x i64>)>
 // CHECK: %[[index0:.*]] = llvm.mlir.constant(4 : index)
 // CHECK: insertvalue %[[index0]], %{{.*}}[3, 0]
 // CHECK: %[[index1:.*]] = llvm.mlir.constant(2 : index)
@@ -81,5 +81,5 @@ module {
 // CHECK: insertvalue %[[index1]], %{{.*}}[4, 2]
 // CHECK: %[[index5:.*]] = llvm.mlir.constant(1 : index)
 // CHECK: insertvalue %[[index5]], %{{.*}}[4, 3]
-// CHECK: return %{{.*}} : !llvm<"{ float*, float*, i64, [4 x i64], [4 x i64] }">
+// CHECK: return %{{.*}} : !llvm.struct<(ptr<float>, ptr<float>, i64, array<4 x i64>, array<4 x i64>)>
 

--- a/pmlc/conversion/tile_to_pxa/BUILD
+++ b/pmlc/conversion/tile_to_pxa/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 gentbl(
     name = "gen-pass",
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/conversion/tile_to_pxa/pass_detail.h
+++ b/pmlc/conversion/tile_to_pxa/pass_detail.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Pass/Pass.h"
+
+#include "pmlc/dialect/pxa/ir/ops.h"
+#include "pmlc/dialect/stdx/ir/ops.h"
 
 namespace pmlc::conversion::tile_to_pxa {
 

--- a/pmlc/conversion/tile_to_pxa/passes.h
+++ b/pmlc/conversion/tile_to_pxa/passes.h
@@ -12,4 +12,8 @@ namespace pmlc::conversion::tile_to_pxa {
 
 std::unique_ptr<mlir::Pass> createLowerTileToPXAPass();
 
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/conversion/tile_to_pxa/passes.h.inc"
+
 } // namespace pmlc::conversion::tile_to_pxa

--- a/pmlc/conversion/tile_to_pxa/passes.td
+++ b/pmlc/conversion/tile_to_pxa/passes.td
@@ -6,6 +6,11 @@ include "mlir/Pass/PassBase.td"
 def LowerTileToPXA : Pass<"convert-tile-to-pxa", "mlir::ModuleOp"> {
   let summary = "Convert Tile dialect to PXA dialect";
   let constructor = "pmlc::conversion::tile_to_pxa::createLowerTileToPXAPass()";
+  let dependentDialects = [
+    "dialect::pxa::PXADialect",
+    "dialect::stdx::StdXDialect",
+    "mlir::AffineDialect"
+  ];
 }
 
 #endif // __PMLC_CONVERSION_TILE_TO_PXA_PASSES__

--- a/pmlc/conversion/tile_to_pxa/tests/cast.mlir
+++ b/pmlc/conversion/tile_to_pxa/tests/cast.mlir
@@ -29,7 +29,7 @@ func @cast_f32_u16(%arg0: tensor<f32>) -> tensor<ui16> {
   %0 = "eltwise.cast"(%arg0) : (tensor<f32>) -> tensor<ui16>
   // CHECK: alloc
   // CHECK: pxa.load
-  // CHECK: stdx.fptoui
+  // CHECK: fptoui
   // CHECK: pxa.reduce assign
   return %0 : tensor<ui16>
 }
@@ -53,7 +53,7 @@ func @cast_u16_f32(%arg0: tensor<ui16>) -> tensor<f32> {
   %0 = "eltwise.cast"(%arg0) : (tensor<ui16>) -> tensor<f32>
   // CHECK: alloc
   // CHECK: pxa.load
-  // CHECK: stdx.uitofp
+  // CHECK: uitofp
   // CHECK: pxa.reduce assign
   return %0 : tensor<f32>
 }

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -175,7 +175,7 @@ static Value createCastOp(OpBuilder &builder, Location loc, Value from,
         return builder.create<mlir::SIToFPOp>(loc, from, intoType).getResult();
       } else {
         // UIToFPOp: IntegerType -> FloatType
-        return builder.create<stdx::UIToFPOp>(loc, intoType, from).getResult();
+        return builder.create<mlir::UIToFPOp>(loc, intoType, from).getResult();
       }
     }
     if (auto fromIndexType = fromType.dyn_cast<IndexType>()) {
@@ -206,7 +206,7 @@ static Value createCastOp(OpBuilder &builder, Location loc, Value from,
         return builder.create<mlir::FPToSIOp>(loc, from, intoType).getResult();
       } else {
         // FPToUIOp: FloatType -> unsigned IntegerType
-        return builder.create<stdx::FPToUIOp>(loc, from, intoType).getResult();
+        return builder.create<mlir::FPToUIOp>(loc, from, intoType).getResult();
       }
     }
     if (auto fromIndexType = fromType.dyn_cast<IndexType>()) {

--- a/pmlc/dialect/eltwise/BUILD
+++ b/pmlc/dialect/eltwise/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "eltwise",

--- a/pmlc/dialect/eltwise/ir/BUILD
+++ b/pmlc/dialect/eltwise/ir/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2019 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "td_files",
@@ -27,6 +27,7 @@ gentbl(
             "interfaces.cc.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "interfaces.td",
     td_srcs = [":td_files"],
 )
@@ -47,6 +48,7 @@ gentbl(
             "dialect.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ops.td",
     td_srcs = [":td_files"],
 )

--- a/pmlc/dialect/eltwise/ir/dialect.cc
+++ b/pmlc/dialect/eltwise/ir/dialect.cc
@@ -44,8 +44,7 @@ struct OpAsmInterface : public mlir::OpAsmDialectInterface {
 
 } // namespace
 
-EltwiseDialect::EltwiseDialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+void EltwiseDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "pmlc/dialect/eltwise/ir/ops.cc.inc"

--- a/pmlc/dialect/pxa/BUILD
+++ b/pmlc/dialect/pxa/BUILD
@@ -1,14 +1,14 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "pxa",
     deps = [
-        "//pmlc/dialect/pxa/ir",
         "//pmlc/dialect/pxa/analysis",
+        "//pmlc/dialect/pxa/ir",
         "//pmlc/dialect/pxa/transforms",
     ],
 )

--- a/pmlc/dialect/pxa/ir/BUILD
+++ b/pmlc/dialect/pxa/ir/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "td_files",
@@ -29,6 +29,7 @@ gentbl(
             "dialect.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ops.td",
     td_srcs = [":td_files"],
 )

--- a/pmlc/dialect/pxa/ir/ops.cc
+++ b/pmlc/dialect/pxa/ir/ops.cc
@@ -520,8 +520,7 @@ OpFoldResult PxaVectorReduceOp::fold(ArrayRef<Attribute> cstOperands) {
 #define GET_OP_CLASSES
 #include "pmlc/dialect/pxa/ir/ops.cc.inc"
 
-PXADialect::PXADialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+void PXADialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "pmlc/dialect/pxa/ir/ops.cc.inc" // NOLINT

--- a/pmlc/dialect/pxa/tests/fusion.mlir
+++ b/pmlc/dialect/pxa/tests/fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: pmlc-opt -canonicalize -pxa-fusion -canonicalize %s | FileCheck %s
+// RUN: pmlc-opt -pxa-normalize -canonicalize -pxa-fusion -pxa-normalize -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: func @simple_fusion
 func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32>, %D: memref<2x3xf32>) {

--- a/pmlc/dialect/pxa/tests/grn.mlir
+++ b/pmlc/dialect/pxa/tests/grn.mlir
@@ -1,14 +1,16 @@
 // RUN: pmlc-opt \
 // RUN:   -tile-compute-bounds \
 // RUN:   -convert-tile-to-pxa \
+// RUN:   -pxa-normalize \
 // RUN:   -canonicalize \
 // RUN:   -pxa-fusion \
+// RUN:   -pxa-normalize \
 // RUN:   -canonicalize \
 // RUN:   -pxa-dataflow-opt \
 // RUN:   -canonicalize \
 // RUN:   -pxa-localize \
 // RUN:   -pxa-resize-tmps \
-// RUN:   --canonicalize \
+// RUN:   -canonicalize \
 // RUN:   %s | FileCheck %s
 
 #map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>

--- a/pmlc/dialect/pxa/tests/vectorize.mlir
+++ b/pmlc/dialect/pxa/tests/vectorize.mlir
@@ -5,12 +5,13 @@ func @vectorize_gemm(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) -> (mem
   %a = alloc() : memref<64x64xf32>
   %b = alloc() : memref<64xf32>
   %r1, %r2 = affine.parallel (%i, %j, %k) = (0, 0, 0) to (64, 64, 64) reduce ("assign", "assign") -> (memref<64x64xf32>, memref<64xf32>) {
-  // We must vectorize on j since it is the only stride one output
-  // CHECK: step (1, 8, 1)
+    // We must vectorize on j since it is the only stride one output
+    // CHECK: step (1, 8, 1)
+
     %0 = pxa.load %arg1[%i, %k] : memref<64x64xf32>
     // This load doesn't vectorize (since it's stride 0 to j)
     // CHECK: pxa.load %{{.*}} : memref<64x64xf32>
-    
+
     %1 = pxa.load %arg0[%k, %j] : memref<64x64xf32>
     // This load *does* vectorize (stride 1 on j)
     // CHECK: pxa.vector_load %{{.*}} : memref<64x64xf32>, vector<8xf32>
@@ -30,9 +31,9 @@ func @vectorize_gemm(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>) -> (mem
     // CHECK: pxa.vector_reduce addf %{{.*}}, %{{.*}} : memref<64x64xf32>, vector<8xf32>
 
     %red2 = pxa.reduce addf %3, %b[%i] : memref<64xf32>
-    // This reduce doesn't vectorize 
+    // This reduce doesn't vectorize
     // CHECK: pxa.reduce addf %{{.*}}, %{{.*}} : memref<64xf32>
-   
+
     affine.yield %red1, %red2 : memref<64x64xf32>, memref<64xf32>
   }
   return %r1, %r2 : memref<64x64xf32>, memref<64xf32>
@@ -44,7 +45,7 @@ func @vector_set(%val: f32) -> (memref<64xf32>) {
   %o = affine.parallel (%i) = (0) to (64) reduce ("assign") -> (memref<64xf32>) {
   // CHECK: affine.parallel (%{{.*}}) = (0) to (64) step (8) reduce ("assign") -> (memref<64xf32>)
     %0 = pxa.reduce assign %val, %a[%i] : memref<64xf32>
-    /// The reduce should get vectorized, including a broadcast of the scalar 
+    /// The reduce should get vectorized, including a broadcast of the scalar
     // %[[.*:vec]] = vector.broadcast %{{.*}} : f32 to vector<8xf32>
     // pxa.vector_reduce assign %[[vec]], %{{.*}} : memref<64xf32>, vector<8xf32>
     affine.yield %0 : memref<64xf32>

--- a/pmlc/dialect/pxa/transforms/BUILD
+++ b/pmlc/dialect/pxa/transforms/BUILD
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",
@@ -29,6 +30,7 @@ plaidml_cc_library(
         "fusion.cc",
         "localize.cc",
         "nest_loops.cc",
+        "normalize.cc",
         "pass_detail.h",
         "resize_tmps.cc",
         "stencil.cc",

--- a/pmlc/dialect/pxa/transforms/normalize.cc
+++ b/pmlc/dialect/pxa/transforms/normalize.cc
@@ -1,0 +1,99 @@
+// Copyright 2020 Intel Corporation
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/dialect/pxa/transforms/passes.h"
+
+using namespace mlir; // NOLINT
+
+// TODO: fix upstream
+void normalizeAffineParallel(AffineParallelOp op);
+
+namespace pmlc::dialect::pxa {
+
+/// Promotes the loop body of an affine.parallel to its containing block if no
+/// induction variables are present.
+void promoteIfEmptyIVs(AffineParallelOp op) {
+  // Nothing to do when there are induction variables.
+  if (op.getNumDims())
+    return;
+
+  // Replace yielded loop results.
+  auto *body = op.getBody();
+  auto yield = cast<AffineYieldOp>(body->back());
+  op.replaceAllUsesWith(yield.operands());
+
+  // Move the loop body operations, except for its terminator, to the loop's
+  // containing block.
+  yield.erase();
+  auto &parentOps = op.getOperation()->getBlock()->getOperations();
+  parentOps.splice(Block::iterator(op), body->getOperations());
+  op.erase();
+}
+
+void elideSingleIterationIndexes(AffineParallelOp op) {
+  AffineValueMap ranges = op.getRangesValueMap();
+  Block *body = op.getBody();
+  SmallVector<AffineExpr, 6> newLowerBounds;
+  SmallVector<AffineExpr, 6> newUpperBounds;
+  SmallVector<int64_t, 6> newSteps;
+  SmallVector<BlockArgument, 6> argsToRemove;
+  auto steps = op.getSteps();
+  for (unsigned i = 0, e = body->getNumArguments(); i < e; i++) {
+    // Is the range a constant value matching the step size?
+    auto constExpr = ranges.getResult(i).dyn_cast<AffineConstantExpr>();
+    int64_t step = steps[i];
+    if (constExpr && constExpr.getValue() == step) {
+      // Mark argument for removal and replacement with 0.
+      argsToRemove.push_back(body->getArgument(i));
+    } else {
+      // Keep argument
+      newLowerBounds.push_back(op.lowerBoundsMap().getResult(i));
+      newUpperBounds.push_back(op.upperBoundsMap().getResult(i));
+      newSteps.push_back(step);
+    }
+  }
+
+  // Return if no arguments need removal.
+  if (argsToRemove.empty())
+    return;
+
+  auto builder = OpBuilder::atBlockBegin(body);
+  for (auto arg : argsToRemove) {
+    auto argNumber = arg.getArgNumber();
+    auto lowerBoundValue = builder.create<AffineApplyOp>(
+        op.getLoc(), op.lowerBoundsMap().getSubMap({argNumber}),
+        op.getLowerBoundsOperands());
+    arg.replaceAllUsesWith(lowerBoundValue);
+    body->eraseArgument(argNumber);
+  }
+
+  // Update attributes and return success
+  auto newLower = AffineMap::get(op.lowerBoundsMap().getNumDims(),
+                                 op.lowerBoundsMap().getNumSymbols(),
+                                 newLowerBounds, op.getContext());
+  auto newUpper = AffineMap::get(op.upperBoundsMap().getNumDims(),
+                                 op.upperBoundsMap().getNumSymbols(),
+                                 newUpperBounds, op.getContext());
+  op.lowerBoundsMapAttr(AffineMapAttr::get(newLower));
+  op.upperBoundsMapAttr(AffineMapAttr::get(newUpper));
+  op.setSteps(newSteps);
+}
+
+struct AffineNormalizePass : public AffineNormalizeBase<AffineNormalizePass> {
+  void runOnFunction() override {
+    getFunction().walk(::normalizeAffineParallel);
+    getFunction().walk(elideSingleIterationIndexes);
+    getFunction().walk(promoteIfEmptyIVs);
+  }
+};
+
+std::unique_ptr<Pass> createAffineNormalizePass() {
+  return std::make_unique<AffineNormalizePass>();
+}
+
+} // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/transforms/pass_detail.h
+++ b/pmlc/dialect/pxa/transforms/pass_detail.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace pmlc::dialect::pxa {

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -5,19 +5,21 @@
 #include <functional>
 #include <memory>
 
+#include "mlir/Pass/Pass.h"
 #include "llvm/ADT/ArrayRef.h"
-
-namespace mlir {
-class Pass;
-} // namespace mlir
 
 namespace pmlc::dialect::pxa {
 
+struct StencilCost {
+  double throughput;
+  unsigned startupCost;
+};
+
+using StencilCostFunction = std::function<StencilCost(llvm::ArrayRef<int64_t>)>;
+
+std::unique_ptr<mlir::Pass> createAffineNormalizePass();
+
 std::unique_ptr<mlir::Pass> createAutoTileExamplePass();
-
-std::unique_ptr<mlir::Pass> createTileAccumulatePass();
-
-std::unique_ptr<mlir::Pass> createVectorizeExamplePass();
 
 std::unique_ptr<mlir::Pass> createBufferPlacementPass();
 
@@ -28,16 +30,16 @@ std::unique_ptr<mlir::Pass> createLocalizePass();
 
 std::unique_ptr<mlir::Pass> createMemRefDataFlowOptPass();
 
+std::unique_ptr<mlir::Pass> createNestLoopsPass();
+
+std::unique_ptr<mlir::Pass> createNestLoopsPass(unsigned minLoopIVs);
+
 std::unique_ptr<mlir::Pass> createResizeTmpsPass();
 
+std::unique_ptr<mlir::Pass> createStencilGEMMPass(unsigned numThreads,
+                                                  StencilCostFunction costFn);
+
 std::unique_ptr<mlir::Pass> createSubgroupsPass();
-
-struct StencilCost {
-  double throughput;
-  unsigned startupCost;
-};
-
-using StencilCostFunction = std::function<StencilCost(llvm::ArrayRef<int64_t>)>;
 
 std::unique_ptr<mlir::Pass> createTestStrideInfoPass();
 
@@ -45,10 +47,12 @@ std::unique_ptr<mlir::Pass> createTestIndirectUsesIteratorPass();
 
 std::unique_ptr<mlir::Pass> createTestIndirectValuesIteratorPass();
 
-std::unique_ptr<mlir::Pass> createStencilGEMMPass(unsigned numThreads,
-                                                  StencilCostFunction costFn);
+std::unique_ptr<mlir::Pass> createTileAccumulatePass();
 
-std::unique_ptr<mlir::Pass> createNestLoopsPass();
-std::unique_ptr<mlir::Pass> createNestLoopsPass(unsigned minLoopIVs);
+std::unique_ptr<mlir::Pass> createVectorizeExamplePass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/dialect/pxa/transforms/passes.h.inc"
 
 } // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -3,29 +3,14 @@
 
 include "mlir/Pass/PassBase.td"
 
+def AffineNormalize : FunctionPass<"pxa-normalize"> {
+  let summary = "Normalize affine ops";
+  let constructor = "pmlc::dialect::pxa::createAffineNormalizePass()";
+}
+
 def AutoTileExample : FunctionPass<"pxa-autotile-example"> {
   let summary = "Tile all dimensions by 10";
   let constructor = "pmlc::dialect::pxa::createAutoTileExamplePass()";
-}
-
-def TileAccumulate : FunctionPass<"pxa-tile-accumulate"> {
-  let summary = "Tile accumulation indexes into an inner block to avoid "
-    "possible race conditions";
-  let constructor = "pmlc::dialect::pxa::createTileAccumulatePass()";
-}
-
-def NestLoops : FunctionPass<"pxa-nest-loops"> {
-  let summary = "Nests outermost loops to a minimum IV count";
-  let constructor = "pmlc::dialect::pxa::createNestLoopsPass()";
-  let options = [
-    Option<"minLoopIVs", "ivs", "unsigned", /*default=*/"2",
-           "Set minimum required IV's">
-  ];
-}
-
-def VectorizeExample : FunctionPass<"pxa-vectorize-example"> {
-  let summary = "Vectorizes with vector register of 8 elements";
-  let constructor = "pmlc::dialect::pxa::createVectorizeExamplePass()";
 }
 
 def BufferPlacement : FunctionPass<"pxa-buffer-placement"> {
@@ -54,6 +39,15 @@ def MemRefDataFlowOpt : FunctionPass<"pxa-dataflow-opt"> {
   let constructor = "pmlc::dialect::pxa::createMemRefDataFlowOptPass()";
 }
 
+def NestLoops : FunctionPass<"pxa-nest-loops"> {
+  let summary = "Nests outermost loops to a minimum IV count";
+  let constructor = "pmlc::dialect::pxa::createNestLoopsPass()";
+  let options = [
+    Option<"minLoopIVs", "ivs", "unsigned", /*default=*/"2",
+           "Set minimum required IV's">
+  ];
+}
+
 def ResizeTmps : FunctionPass<"pxa-resize-tmps"> {
   let summary = "Resize temporary buffers to minimal sizes";
   let constructor = "pmlc::dialect::pxa::createResizeTmpsPass()";
@@ -77,6 +71,18 @@ def TestIndirectValuesIterator : Pass<"pxa-test-indirect-values-iterator"> {
 def TestStrideInfo : Pass<"pxa-stride-info"> {
   let summary = "Report stride data for all loads/stores for unit tests";
   let constructor = "pmlc::dialect::pxa::createTestStrideInfoPass()";
+}
+
+def TileAccumulate : FunctionPass<"pxa-tile-accumulate"> {
+  let summary = "Tile accumulation indexes into an inner block to avoid "
+    "possible race conditions";
+  let constructor = "pmlc::dialect::pxa::createTileAccumulatePass()";
+}
+
+def VectorizeExample : FunctionPass<"pxa-vectorize-example"> {
+  let summary = "Vectorizes with vector register of 8 elements";
+  let constructor = "pmlc::dialect::pxa::createVectorizeExamplePass()";
+  let dependentDialects = ["mlir::vector::VectorDialect"];
 }
 
 #endif // __PMLC_DIALECT_PXA_PASSES__

--- a/pmlc/dialect/pxa/transforms/tile_accumulate.cc
+++ b/pmlc/dialect/pxa/transforms/tile_accumulate.cc
@@ -8,18 +8,17 @@
 #include <vector>
 
 #include "mlir/Analysis/AffineStructures.h"
-#include "mlir/Pass/Pass.h"
-#include "pmlc/dialect/pxa/ir/ops.h"
-#include "pmlc/dialect/pxa/transforms/pass_detail.h"
-
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "pmlc/dialect/pxa/transforms/tile.h"
-
+#include "mlir/Pass/Pass.h"
 #include "mlir/Support/DebugStringHelper.h"
+
 #include "pmlc/dialect/pxa/analysis/strides.h"
 #include "pmlc/dialect/pxa/analysis/uses.h"
+#include "pmlc/dialect/pxa/ir/ops.h"
+#include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/dialect/pxa/transforms/tile.h"
 #include "pmlc/util/logging.h"
 
 using namespace mlir; // NOLINT

--- a/pmlc/dialect/stdx/BUILD
+++ b/pmlc/dialect/stdx/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "stdx",

--- a/pmlc/dialect/stdx/ir/BUILD
+++ b/pmlc/dialect/stdx/ir/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "td_files",
@@ -29,6 +29,7 @@ gentbl(
             "dialect.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ops.td",
     td_srcs = [":td_files"],
 )

--- a/pmlc/dialect/stdx/ir/ops.cc
+++ b/pmlc/dialect/stdx/ir/ops.cc
@@ -7,86 +7,7 @@
 namespace pmlc::dialect::stdx {
 
 using mlir::failure;
-using mlir::FunctionType;
 using mlir::success;
-
-namespace {
-
-// ---- FPToUIOp ----
-
-void printFPToUIOp(OpAsmPrinter &p, FPToUIOp op) {
-  p << op.getOperation()->getName() << ' ' << op.getOperand() << " : "
-    << op.getOperand().getType() << " to "
-    << op.getOperation()->getResult(0).getType();
-}
-
-ParseResult parseFPToUIOp(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::OperandType srcInfo;
-  Type srcType, dstType;
-  return failure(parser.parseOperand(srcInfo) ||
-                 parser.parseOptionalAttrDict(result.attributes) ||
-                 parser.parseColonType(srcType) ||
-                 parser.resolveOperand(srcInfo, srcType, result.operands) ||
-                 parser.parseKeywordType("to", dstType) ||
-                 parser.addTypeToList(dstType, result.types));
-}
-
-LogicalResult verifyFPToUIOp(FPToUIOp op) {
-  auto opType = op.getOperand().getType();
-  auto resType = op.getOperation()->getResult(0).getType();
-  if (auto fromFloatType = opType.dyn_cast<mlir::FloatType>()) {
-    if (auto intoIntType = resType.dyn_cast<mlir::IntegerType>()) {
-      return success();
-    }
-  }
-  return op.emitError("operand type ") << opType << " and result type "
-                                       << resType << " are cast incompatible";
-}
-
-static void buildFPToUIOp(OpBuilder &builder, OperationState &result,
-                          Value source, Type destType) {
-  result.addOperands(source);
-  result.addTypes(destType);
-}
-
-// ---- UIToFPOp ----
-
-void printUIToFPOp(OpAsmPrinter &p, UIToFPOp op) {
-  p << op.getOperation()->getName() << ' ' << op.getOperand() << " : "
-    << op.getOperand().getType() << " to "
-    << op.getOperation()->getResult(0).getType();
-}
-
-ParseResult parseUIToFPOp(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::OperandType srcInfo;
-  Type srcType, dstType;
-  return failure(parser.parseOperand(srcInfo) ||
-                 parser.parseOptionalAttrDict(result.attributes) ||
-                 parser.parseColonType(srcType) ||
-                 parser.resolveOperand(srcInfo, srcType, result.operands) ||
-                 parser.parseKeywordType("to", dstType) ||
-                 parser.addTypeToList(dstType, result.types));
-}
-
-LogicalResult verifyUIToFPOp(UIToFPOp op) {
-  auto opType = op.getOperand().getType();
-  auto resType = op.getOperation()->getResult(0).getType();
-  if (auto fromIntType = opType.dyn_cast<mlir::IntegerType>()) {
-    if (auto intoFloatType = resType.dyn_cast<mlir::FloatType>()) {
-      return success();
-    }
-  }
-  return op.emitError("operand type ") << opType << " and result type "
-                                       << resType << " are cast incompatible";
-}
-
-static void buildUIToFPOp(OpBuilder &builder, OperationState &result,
-                          Value source, Type destType) {
-  result.addOperands(source);
-  result.addTypes(destType);
-}
-
-} // namespace
 
 // ---- ReshapeOp ----
 
@@ -95,8 +16,7 @@ Value ReshapeOp::getViewSource() { return tensor(); }
 #define GET_OP_CLASSES
 #include "pmlc/dialect/stdx/ir/ops.cc.inc"
 
-StdXDialect::StdXDialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+void StdXDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "pmlc/dialect/stdx/ir/ops.cc.inc" // NOLINT

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -25,26 +25,6 @@ class StdX_Op<string mnemonic, list<OpTrait> traits = []> :
   let verifier = [{ return verify$cppClass(*this); }];
 }
 
-def FPToUIOp : StdX_Op<"fptoui", [NoSideEffect]> {
-  let summary = "cast from floating-point to unsigned integer type";
-  let arguments = (ins AnyType:$result);
-  let results = (outs AnyType);
-  let builders = [OpBuilder<
-    "OpBuilder &builder, OperationState &result, Value source, Type destType",
-    [{ buildFPToUIOp(builder, result, source, destType); }]
-  >];
-}
-
-def UIToFPOp : StdX_Op<"uitofp", [NoSideEffect]> {
-  let summary = "cast from unsigned integer to floating-point type";
-  let arguments = (ins AnyType:$result);
-  let results = (outs AnyType);
-  let builders = [OpBuilder<
-    "OpBuilder &builder, OperationState &result, Value source, Type destType",
-    [{ buildUIToFPOp(builder, result, source, destType); }]
-  >];
-}
-
 def ReshapeOp : StdX_Op<"reshape",
   [DeclareOpInterfaceMethods<ViewLikeOpInterface>]> {
   let summary = "tensor reshape operation";

--- a/pmlc/dialect/stdx/transforms/BUILD
+++ b/pmlc/dialect/stdx/transforms/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 gentbl(
     name = "gen-pass",
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",
@@ -24,20 +25,20 @@ plaidml_cc_library(
     srcs = [
         "boundscheck.cc",
         "i1_to_i32.cc",
-        "subgroup_broadcast.cc",
         "pass_detail.h",
+        "subgroup_broadcast.cc",
     ],
     hdrs = [
         "passes.h",
     ],
     deps = [
         ":gen-pass",
-        "@llvm-project//mlir:SCFDialect",
-        "@llvm-project//mlir:VectorOps",
-        "//pmlc/dialect/stdx/ir",
         "//pmlc/dialect/eltwise/ir",
         "//pmlc/dialect/pxa/analysis",
         "//pmlc/dialect/pxa/ir",
+        "//pmlc/dialect/stdx/ir",
         "//pmlc/dialect/tile/ir",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:VectorOps",
     ],
 )

--- a/pmlc/dialect/stdx/transforms/pass_detail.h
+++ b/pmlc/dialect/stdx/transforms/pass_detail.h
@@ -2,6 +2,8 @@
 
 #include "mlir/Pass/Pass.h"
 
+#include "pmlc/dialect/stdx/ir/ops.h"
+
 namespace pmlc::dialect::stdx {
 
 #define GEN_PASS_CLASSES

--- a/pmlc/dialect/stdx/transforms/passes.h
+++ b/pmlc/dialect/stdx/transforms/passes.h
@@ -5,14 +5,18 @@
 #include <functional>
 #include <memory>
 
-namespace mlir {
-class Pass;
-} // namespace mlir
+#include "mlir/Pass/Pass.h"
 
 namespace pmlc::dialect::stdx {
 
 std::unique_ptr<mlir::Pass> createBoundsCheckPass();
+
 std::unique_ptr<mlir::Pass> createI1StorageToI32Pass();
+
 std::unique_ptr<mlir::Pass> createSubgroupBroadcastPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/dialect/stdx/transforms/passes.h.inc"
 
 } // namespace pmlc::dialect::stdx

--- a/pmlc/dialect/stdx/transforms/passes.td
+++ b/pmlc/dialect/stdx/transforms/passes.td
@@ -16,6 +16,7 @@ def I1StorageToI32 : FunctionPass<"stdx-i1-storage-to-i32"> {
 def SubgroupBroadcast : FunctionPass<"stdx-subgroup-broadcast"> {
   let summary = "Perform unvectorization for subgroups broadcast usage";
   let constructor = "pmlc::dialect::stdx::createSubgroupBroadcastPass()";
+  let dependentDialects = ["StdXDialect"];
 }
 
 #endif // __PMLC_DIALECT_STDX_PASSES__

--- a/pmlc/dialect/tile/BUILD
+++ b/pmlc/dialect/tile/BUILD
@@ -23,6 +23,7 @@ plaidml_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/pmlc/dialect/tile/ir/BUILD
+++ b/pmlc/dialect/tile/ir/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2019 Intel Corporation.
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "td_files",
@@ -28,6 +28,7 @@ gentbl(
             "interfaces.cc.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "interfaces.td",
     td_srcs = [":td_files"],
 )
@@ -48,6 +49,7 @@ gentbl(
             "dialect.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ops.td",
     td_srcs = [":td_files"],
 )

--- a/pmlc/dialect/tile/ir/dialect.cc
+++ b/pmlc/dialect/tile/ir/dialect.cc
@@ -43,8 +43,7 @@ struct OpAsmInterface : public mlir::OpAsmDialectInterface {
 
 } // namespace
 
-TileDialect::TileDialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+void TileDialect::initialize() {
   addTypes<AffineMapType, AffineConstraintsType, AffineTensorMapType,
            StringType>();
   addOperations<

--- a/pmlc/dialect/tile/ir/types.cc
+++ b/pmlc/dialect/tile/ir/types.cc
@@ -5,19 +5,19 @@
 namespace pmlc::dialect::tile {
 
 AffineMapType AffineMapType::get(mlir::MLIRContext *context) {
-  return Base::get(context, TypeKinds::AffineMap);
+  return Base::get(context);
 }
 
 AffineTensorMapType AffineTensorMapType::get(mlir::MLIRContext *context) {
-  return Base::get(context, TypeKinds::AffineTensorMap);
+  return Base::get(context);
 }
 
 AffineConstraintsType AffineConstraintsType::get(mlir::MLIRContext *context) {
-  return Base::get(context, TypeKinds::AffineConstraints);
+  return Base::get(context);
 }
 
 StringType StringType::get(mlir::MLIRContext *context) {
-  return Base::get(context, TypeKinds::String);
+  return Base::get(context);
 }
 
 } // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/ir/types.h
+++ b/pmlc/dialect/tile/ir/types.h
@@ -6,24 +6,12 @@
 
 namespace pmlc::dialect::tile {
 
-namespace TypeKinds {
-enum Kind {
-  AffineMap = mlir::Type::Kind::FIRST_PRIVATE_EXPERIMENTAL_2_TYPE,
-  AffineTensorMap,
-  AffineConstraints,
-  String,
-};
-}
-
 class AffineTensorMapType
     : public mlir::Type::TypeBase<AffineTensorMapType, mlir::Type,
                                   mlir::TypeStorage> {
 public:
   using Base::Base;
   static AffineTensorMapType get(mlir::MLIRContext *context);
-  static bool kindof(unsigned kind) {
-    return kind == TypeKinds::AffineTensorMap;
-  }
 };
 
 class AffineMapType : public mlir::Type::TypeBase<AffineMapType, mlir::Type,
@@ -31,7 +19,6 @@ class AffineMapType : public mlir::Type::TypeBase<AffineMapType, mlir::Type,
 public:
   using Base::Base;
   static AffineMapType get(mlir::MLIRContext *context);
-  static bool kindof(unsigned kind) { return kind == TypeKinds::AffineMap; }
 };
 
 class AffineConstraintsType
@@ -40,9 +27,6 @@ class AffineConstraintsType
 public:
   using Base::Base;
   static AffineConstraintsType get(mlir::MLIRContext *context);
-  static bool kindof(unsigned kind) {
-    return kind == TypeKinds::AffineConstraints;
-  }
 };
 
 class StringType
@@ -50,7 +34,6 @@ class StringType
 public:
   using Base::Base;
   static StringType get(mlir::MLIRContext *context);
-  static bool kindof(unsigned kind) { return kind == TypeKinds::String; }
 };
 
 } // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/transforms/BUILD
+++ b/pmlc/dialect/tile/transforms/BUILD
@@ -13,6 +13,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",

--- a/pmlc/dialect/tile/transforms/passes.h
+++ b/pmlc/dialect/tile/transforms/passes.h
@@ -25,4 +25,8 @@ std::unique_ptr<mlir::Pass> createMakeProgramPass();
 
 std::unique_ptr<mlir::Pass> createPadPass();
 
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/dialect/tile/transforms/passes.h.inc"
+
 } // namespace pmlc::dialect::tile

--- a/pmlc/dialect/xsmm/BUILD
+++ b/pmlc/dialect/xsmm/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "xsmm",

--- a/pmlc/dialect/xsmm/ir/BUILD
+++ b/pmlc/dialect/xsmm/ir/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
-load("//bzl:plaidml.bzl", "plaidml_cc_library", "plaidml_cc_test")
+load("//bzl:plaidml.bzl", "plaidml_cc_library")
 load("//vendor/mlir:tblgen.bzl", "gentbl")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "td_files",
@@ -29,6 +29,7 @@ gentbl(
             "dialect.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ops.td",
     td_srcs = [":td_files"],
 )

--- a/pmlc/dialect/xsmm/ir/ops.cc
+++ b/pmlc/dialect/xsmm/ir/ops.cc
@@ -13,8 +13,7 @@ using mlir::failure;
 using mlir::FunctionType;
 using mlir::success;
 
-XSMMDialect::XSMMDialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+void XSMMDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "pmlc/dialect/xsmm/ir/ops.cc.inc"

--- a/pmlc/rt/tests/boundscheck-rt.mlir
+++ b/pmlc/rt/tests/boundscheck-rt.mlir
@@ -1,4 +1,4 @@
-// RUN: pmlc-opt -stdx-check-bounds -convert-std-to-llvm='emit-c-wrappers=1' %s | pmlc-jit | FileCheck %s
+// RUN: pmlc-opt -stdx-check-bounds -convert-std-to-llvm='emit-c-wrappers' %s | pmlc-jit | FileCheck %s
 
 func @main() {
   %c0 = constant 0 : index

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -40,11 +40,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCSEPass());
   pm.addPass(pmlc::dialect::pxa::createTileAccumulatePass());
 
-  // TODO: do optimizations here
-
-  // pm.addPass(std::make_unique<UpdateWorkGroupSizePass>(workGroupSize));
-  // pm.addPass(std::make_unique<IREETileLinalgPass>());
-  // pm.addPass(createConvertLinalgToLoopsPass());
   pm.addPass(conversion::pxa_to_affine::createLowerPXAToAffinePass());
   pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());
@@ -59,7 +54,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
   pm.addPass(createConvertGPUToSPIRVPass());
-  // pm.addPass(std::make_unique<IREEGPUToSPIRVPass>());
 
   // SPIR-V passes for lowering attributes.
   pm.addPass(spirv::createLowerABIAttributesPass());

--- a/pmlc/target/intel_gen/tests/BUILD
+++ b/pmlc/target/intel_gen/tests/BUILD
@@ -1,9 +1,10 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//pmlc:lit.bzl", "glob_lit_tests")
+
+package(default_visibility = ["//visibility:public"])
 
 glob_lit_tests(
     data = ["//pmlc/rt/vulkan:vkprobe"],
+    default_tags = ["manual"],
 )

--- a/pmlc/target/x86/BUILD
+++ b/pmlc/target/x86/BUILD
@@ -21,6 +21,7 @@ gentbl(
             "passes.h.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "passes.td",
     td_srcs = [
         "@llvm-project//mlir:PassBaseTdFiles",
@@ -55,6 +56,7 @@ plaidml_cc_library(
         "//pmlc/dialect/xsmm",
         "//pmlc/rt",
         "@llvm-project//mlir:AffineToStandardTransforms",
+        "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:LLVMTransforms",
         "@llvm-project//mlir:SCFToStandard",
         "@llvm-project//mlir:StandardOpsTransforms",

--- a/pmlc/target/x86/pass_detail.h
+++ b/pmlc/target/x86/pass_detail.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
+
+#include "pmlc/dialect/xsmm/ir/ops.h"
 
 namespace pmlc::target::x86 {
 

--- a/pmlc/target/x86/passes.h
+++ b/pmlc/target/x86/passes.h
@@ -2,13 +2,14 @@
 
 #include <memory>
 
+#include "mlir/Pass/Pass.h"
+
 namespace mlir {
 class LLVMTypeConverter;
 class LowerToLLVMOptions;
 class MLIRContext;
 class OpPassManager;
 class OwningRewritePatternList;
-class Pass;
 } // namespace mlir
 
 namespace pmlc::target::x86 {
@@ -34,5 +35,9 @@ void populateXSMMToLLVMConversionPatterns(
     mlir::OwningRewritePatternList &patterns);
 
 void pipelineBuilder(mlir::OpPassManager &pm);
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "pmlc/target/x86/passes.h.inc"
 
 } // namespace pmlc::target::x86

--- a/pmlc/target/x86/passes.td
+++ b/pmlc/target/x86/passes.td
@@ -6,11 +6,16 @@ include "mlir/Pass/PassBase.td"
 def ConvertPXAToAffine : Pass<"x86-convert-pxa-to-affine", "mlir::ModuleOp"> {
   let summary = "Convert PXA dialect to Affine dialect";
   let constructor = "pmlc::target::x86::createLowerPXAToAffinePass()";
+  let dependentDialects = [
+    "dialect::xsmm::XSMMDialect",
+    "mlir::AffineDialect"
+  ];
 }
 
 def ConvertStandardToLLVM : Pass<"x86-convert-std-to-llvm", "mlir::ModuleOp"> {
   let summary = "Convert StandardX + XSMM dialects to LLVM dialect";
   let constructor = "pmlc::target::x86::createLowerToLLVMPass()";
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
 def TraceLinking : Pass<"x86-trace-linking", "mlir::ModuleOp"> {

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -126,6 +126,7 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(pxa::createLocalizePass());
   pm.addPass(pxa::createResizeTmpsPass());
   pm.addPass(pxa::createBufferPlacementPass());
+  pm.addPass(pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/pmlc/target/x86/tests/trace.mlir
+++ b/pmlc/target/x86/tests/trace.mlir
@@ -8,7 +8,7 @@ func @main() {
 }
 
 // CHECK-DAG:  llvm.mlir.global internal constant @__trace_msg{{.*}}("msg\00")
-// CHECK-DAG:  llvm.func @plaidml_rt_trace(!llvm<"i8*">)
+// CHECK-DAG:  llvm.func @plaidml_rt_trace(!llvm.ptr<i8>)
 // CHECK:      llvm.func @__trace{{.*}}()
 // CHECK:        llvm.mlir.addressof @{{.*}}
 // CHECK:        llvm.mlir.constant

--- a/pmlc/target/x86/tests/xsmm_call.mlir
+++ b/pmlc/target/x86/tests/xsmm_call.mlir
@@ -13,8 +13,8 @@
 !O_memref = type memref<1x6x5x11xf32>
 
 func @print_memref_f32(memref<*xf32>)
-llvm.func @plaidml_rt_xsmm_gemm_invoke_f32(!llvm<"i8*">, !llvm<"float*">, !llvm<"float*">, !llvm<"float*">)
-llvm.func @plaidml_rt_xsmm_gemm_dispatch_f32(!llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32) -> !llvm<"i8*">
+llvm.func @plaidml_rt_xsmm_gemm_invoke_f32(!llvm.ptr<i8>, !llvm.ptr<float>, !llvm.ptr<float>, !llvm.ptr<float>)
+llvm.func @plaidml_rt_xsmm_gemm_dispatch_f32(!llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
 
 func @baseline() {
   %dot = constant @dot : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()

--- a/pmlc/target/x86/trace_linking.cc
+++ b/pmlc/target/x86/trace_linking.cc
@@ -27,19 +27,18 @@ struct TraceLinkingPass : public TraceLinkingBase<TraceLinkingPass> {
         return;
       }
       auto loc = op.getLoc();
-      auto context = op.getContext();
+      auto *context = op.getContext();
       OpBuilder builder(context);
-      auto llvmDialect = context->getRegisteredDialect<LLVM::LLVMDialect>();
       auto module = op.getParentOfType<ModuleOp>();
-      auto traceRef = getOrInsertTrace(loc, builder, module, llvmDialect);
+      auto traceRef = getOrInsertTrace(loc, builder, module);
       auto block = op.addEntryBlock();
       builder.setInsertionPointToStart(block);
       auto id = op.getAttrOfType<IntegerAttr>("id").getValue().getZExtValue();
       auto msgStr = op.getAttrOfType<StringAttr>("msg").getValue().str();
       auto msg = StringRef(msgStr.c_str(), msgStr.size() + 1);
       auto msgSymbol = llvm::formatv("__trace_msg_{0}", id).str();
-      auto msgValue = getOrCreateGlobalString(loc, builder, msgSymbol, msg,
-                                              module, llvmDialect);
+      auto msgValue =
+          getOrCreateGlobalString(loc, builder, msgSymbol, msg, module);
       builder.create<LLVM::CallOp>(loc, ArrayRef<Type>{}, traceRef,
                                    ArrayRef<Value>{msgValue});
       builder.create<LLVM::ReturnOp>(loc, ArrayRef<Value>{});
@@ -53,15 +52,14 @@ struct TraceLinkingPass : public TraceLinkingBase<TraceLinkingPass> {
   /// name, creating the string if necessary.
   static Value getOrCreateGlobalString(Location loc, OpBuilder &builder,
                                        StringRef name, StringRef value,
-                                       ModuleOp module,
-                                       LLVM::LLVMDialect *llvmDialect) {
+                                       ModuleOp module) {
     // Create the global at the entry of the module.
     LLVM::GlobalOp global;
     if (!(global = module.lookupSymbol<LLVM::GlobalOp>(name))) {
       OpBuilder::InsertionGuard insertGuard(builder);
       builder.setInsertionPointToStart(module.getBody());
       auto type = LLVM::LLVMType::getArrayTy(
-          LLVM::LLVMType::getInt8Ty(llvmDialect), value.size());
+          LLVM::LLVMType::getInt8Ty(builder.getContext()), value.size());
       global = builder.create<LLVM::GlobalOp>(loc, type, /*isConstant=*/true,
                                               LLVM::Linkage::Internal, name,
                                               builder.getStringAttr(value));
@@ -70,25 +68,24 @@ struct TraceLinkingPass : public TraceLinkingBase<TraceLinkingPass> {
     // Get the pointer to the first character in the global string.
     Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, global);
     Value cst0 = builder.create<LLVM::ConstantOp>(
-        loc, LLVM::LLVMType::getInt64Ty(llvmDialect),
+        loc, LLVM::LLVMType::getInt64Ty(builder.getContext()),
         builder.getIntegerAttr(builder.getIndexType(), 0));
     return builder.create<LLVM::GEPOp>(
-        loc, LLVM::LLVMType::getInt8PtrTy(llvmDialect), globalPtr,
+        loc, LLVM::LLVMType::getInt8PtrTy(builder.getContext()), globalPtr,
         ArrayRef<Value>({cst0, cst0}));
   }
 
   static FlatSymbolRefAttr getOrInsertTrace(Location loc, OpBuilder &builder,
-                                            ModuleOp module,
-                                            LLVM::LLVMDialect *llvmDialect) {
+                                            ModuleOp module) {
     const char *symbol = "plaidml_rt_trace";
-    auto context = module.getContext();
+    auto *context = module.getContext();
     if (module.lookupSymbol(symbol)) {
       return SymbolRefAttr::get(symbol, context);
     }
     OpBuilder::InsertionGuard insertGuard(builder);
     builder.setInsertionPointToStart(module.getBody());
-    auto voidTy = LLVM::LLVMType::getVoidTy(llvmDialect);
-    auto msgTy = LLVM::LLVMType::getInt8PtrTy(llvmDialect);
+    auto voidTy = LLVM::LLVMType::getVoidTy(context);
+    auto msgTy = LLVM::LLVMType::getInt8PtrTy(context);
     auto funcType = LLVM::LLVMType::getFunctionTy(voidTy, {msgTy}, false);
     builder.create<LLVM::LLVMFuncOp>(loc, symbol, funcType);
     return SymbolRefAttr::get(symbol, context);

--- a/pmlc/tools/pmlc-opt/pmlc-opt.cc
+++ b/pmlc/tools/pmlc-opt/pmlc-opt.cc
@@ -1,55 +1,17 @@
 // Copyright 2020 Intel Corporation
 
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/PrettyStackTrace.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/Process.h"
 
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/MlirOptMain.h"
 
+#include "pmlc/all_dialects.h"
 #include "pmlc/all_passes.h"
-#include "pmlc/util/env.h"
 #include "pmlc/util/logging.h"
 
-using namespace llvm; // NOLINT(build/namespaces)
-using namespace mlir; // NOLINT(build/namespaces)
-
-static cl::opt<std::string>
-    inputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));
-
-static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
-                                           cl::value_desc("filename"),
-                                           cl::init("-"));
-
-static cl::opt<bool> splitInputFile(
-    "split-input-file",
-    cl::desc("Split the input file into pieces and process each chunk "
-             "independently"),
-    cl::init(false));
-
-static cl::opt<bool> verifyDiagnostics(
-    "verify-diagnostics",
-    cl::desc("Check that emitted diagnostics match expected-* lines on the "
-             "corresponding line"),
-    cl::init(false));
-
-static cl::opt<bool>
-    verifyPasses("verify-each",
-                 cl::desc("Run the verifier after each transformation pass"),
-                 cl::init(true));
-
-static cl::opt<bool> allowUnregisteredDialects(
-    "allow-unregistered-dialect",
-    cl::desc("Allow operation with no registered dialects"), cl::init(false));
-
 int main(int argc, char **argv) {
-  auto level_str = pmlc::util::getEnvVar("PLAIDML_VERBOSE");
-  if (level_str.size()) {
-    auto level = std::atoi(level_str.c_str());
+  auto verboseEnv = llvm::sys::Process::GetEnv("PLAIDML_VERBOSE");
+  if (verboseEnv) {
+    auto level = std::atoi(verboseEnv->c_str());
     if (level) {
       el::Loggers::setVerboseLevel(level);
     }
@@ -57,38 +19,10 @@ int main(int argc, char **argv) {
   }
 
   registerAllPasses();
-  // registerTestPasses();
-  InitLLVM y(argc, argv);
 
-  // Register any pass manager command line options.
-  registerPassManagerCLOptions();
-  PassPipelineCLParser passPipeline("", "Compiler passes to run");
-
-  // Parse pass names in main to ensure static initialization completed.
-  cl::ParseCommandLineOptions(argc, argv, "pmlc modular optimizer driver\n");
-
-  // Set up the input file.
-  std::string errorMessage;
-  auto file = openInputFile(inputFilename, &errorMessage);
-  if (!file) {
-    llvm::errs() << errorMessage << "\n";
-    return 1;
-  }
-
-  auto output = openOutputFile(outputFilename, &errorMessage);
-  if (!output) {
-    llvm::errs() << errorMessage << "\n";
-    exit(1);
-  }
-
-  auto ret = failed(MlirOptMain(output->os(), std::move(file), passPipeline,
-                                splitInputFile, verifyDiagnostics, verifyPasses,
-                                allowUnregisteredDialects));
-  llvm::outs() << "\n";
-  if (ret) {
-    return 1;
-  }
-  // Keep the output file if the invocation of MlirOptMain was successful.
-  output->keep();
-  return 0;
+  mlir::DialectRegistry registry;
+  registerAllDialects(registry);
+  return failed(mlir::MlirOptMain(argc, argv, "PMLC modular optimizer driver\n",
+                                  registry,
+                                  /*preloadDialectsInContext=*/false));
 }

--- a/pmlc/tools/pmlc-tblgen/BUILD
+++ b/pmlc/tools/pmlc-tblgen/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "model",

--- a/pmlc/tools/pmlc-translate/BUILD
+++ b/pmlc/tools/pmlc-translate/BUILD
@@ -1,8 +1,8 @@
 # Copyright 2020 Intel Corporation
 
-package(default_visibility = ["//visibility:public"])
-
 load("//bzl:plaidml.bzl", "plaidml_cc_binary", "plaidml_cc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 plaidml_cc_library(
     name = "lib",

--- a/pmlc/tools/pmlc-vulkan-runner/pmlc-vulkan-runner.cc
+++ b/pmlc/tools/pmlc-vulkan-runner/pmlc-vulkan-runner.cc
@@ -24,12 +24,13 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/TargetSelect.h"
 
+#include "pmlc/all_dialects.h"
 #include "pmlc/compiler/executable.h"
 #include "pmlc/compiler/program.h"
 #include "pmlc/conversion/gpu/lowering.h"
-#include "pmlc/util/env.h"
 #include "pmlc/util/logging.h"
 
 using namespace mlir; // NOLINT[build/namespaces]
@@ -96,9 +97,9 @@ int JitRunnerMain(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
-  auto level_str = pmlc::util::getEnvVar("PLAIDML_VERBOSE");
-  if (level_str.size()) {
-    auto level = std::atoi(level_str.c_str());
+  auto verboseEnv = llvm::sys::Process::GetEnv("PLAIDML_VERBOSE");
+  if (verboseEnv) {
+    auto level = std::atoi(verboseEnv->c_str());
     if (level) {
       el::Loggers::setVerboseLevel(level);
     }
@@ -108,6 +109,7 @@ int main(int argc, char **argv) {
   llvm::llvm_shutdown_obj x;
   registerPassManagerCLOptions();
 
+  registerAllDialects();
   llvm::InitLLVM y(argc, argv);
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();

--- a/pmlc/util/BUILD
+++ b/pmlc/util/BUILD
@@ -35,6 +35,7 @@ gentbl(
             "interfaces.cc.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "interfaces.td",
     td_srcs = ["@llvm-project//mlir:OpBaseTdFiles"],
 )
@@ -51,6 +52,7 @@ gentbl(
             "enums.cc.inc",
         ),
     ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "enums.td",
     td_srcs = ["@llvm-project//mlir:OpBaseTdFiles"],
 )

--- a/vendor/llvm/llvm.BUILD
+++ b/vendor/llvm/llvm.BUILD
@@ -685,26 +685,36 @@ cc_library(
     ],
 )
 
-gentbl(
-    name = "omp_gen",
-    tbl_outs = [("--gen-directive-decl", "include/llvm/Frontend/OpenMP/OMP.h.inc")],
-    tblgen = ":llvm-tblgen",
-    td_file = "include/llvm/Frontend/OpenMP/OMP.td",
-    td_srcs = glob([
+exports_files([
+    "include/llvm/Frontend/OpenMP/OMP.td",
+])
+
+filegroup(
+    name = "omp_td_files",
+    srcs = glob([
         "include/llvm/Frontend/OpenMP/*.td",
         "include/llvm/Frontend/Directive/*.td",
     ]),
 )
 
 gentbl(
-    name = "omp_gen_impl",
-    tbl_outs = [("--gen-directive-impl", "include/llvm/Frontend/OpenMP/OMP.cpp.inc")],
+    name = "omp_gen",
+    tbl_outs = [("--gen-directive-decl", "include/llvm/Frontend/OpenMP/OMP.h.inc")],
     tblgen = ":llvm-tblgen",
     td_file = "include/llvm/Frontend/OpenMP/OMP.td",
-    td_srcs = glob([
-        "include/llvm/Frontend/OpenMP/*.td",
-        "include/llvm/Frontend/Directive/*.td",
-    ]),
+    td_srcs = [
+        ":omp_td_files",
+    ],
+)
+
+gentbl(
+    name = "omp_gen_impl",
+    tbl_outs = [("--gen-directive-impl", "include/llvm/Frontend/OpenMP/OMP.cpp")],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/Frontend/OpenMP/OMP.td",
+    td_srcs = [
+        ":omp_td_files",
+    ],
 )
 
 # TODO(b/159809163): autogenerate this after enabling release-mode ML
@@ -1556,7 +1566,9 @@ cc_library(
         ":BPFInfo",
         ":CodeGen",
         ":Core",
+        ":IPO",
         ":MC",
+        ":Scalar",
         ":SelectionDAG",
         ":Support",
         ":Target",
@@ -2092,7 +2104,7 @@ cc_library(
         "lib/Frontend/OpenMP/*.cpp",
         "lib/Frontend/OpenMP/*.inc",
         "lib/Frontend/OpenMP/*.h",
-    ]),
+    ]) + ["include/llvm/Frontend/OpenMP/OMP.cpp"],
     hdrs = glob([
         "include/llvm/Frontend/OpenMP/*.h",
         "include/llvm/Frontend/OpenMP/*.def",
@@ -2395,6 +2407,27 @@ cc_library(
         ":ProfileData",
         ":Support",
         ":TransformUtils",
+        ":config",
+    ],
+)
+
+cc_library(
+    name = "InterfaceStub",
+    srcs = glob([
+        "lib/InterfaceStub/*.c",
+        "lib/InterfaceStub/*.cpp",
+        "lib/InterfaceStub/*.inc",
+        "lib/InterfaceStub/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/InterfaceStub/*.h",
+        "include/llvm/InterfaceStub/*.def",
+        "include/llvm/InterfaceStub/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":Object",
+        ":Support",
         ":config",
     ],
 )
@@ -4082,8 +4115,6 @@ cc_library(
         "include/llvm/TextAPI/*.def",
         "include/llvm/TextAPI/*.inc",
     ]) + [
-        "include/llvm/TextAPI/ELF/TBEHandler.h",
-        "include/llvm/TextAPI/ELF/ELFStub.h",
         "include/llvm/TextAPI/MachO/Architecture.def",
         "include/llvm/TextAPI/MachO/PackedVersion.h",
         "include/llvm/TextAPI/MachO/InterfaceFile.h",

--- a/vendor/mlir/tblgen.bzl
+++ b/vendor/mlir/tblgen.bzl
@@ -7,15 +7,7 @@ COPTS = select({
     "//conditions:default": [],
 })
 
-def gentbl(
-        name,
-        td_file,
-        tbl_outs,
-        td_srcs = [],
-        td_includes = [],
-        strip_include_prefix = None,
-        test = False,
-        tblgen = "@llvm-project//mlir:mlir-tblgen"):
+def gentbl(name, tblgen, td_file, tbl_outs, td_srcs = [], td_includes = [], td_relative_includes = [], strip_include_prefix = None, test = False):
     """gentbl() generates tabular code from a table definition file.
 
     Args:
@@ -26,7 +18,8 @@ def gentbl(
         options passed to tblgen, and the out is the corresponding output file
         produced.
       td_srcs: A list of table definition files included transitively.
-      td_includes: A list of include paths for relative includes.
+      td_includes: A list of include paths for relative includes, provided as build targets.
+      td_relative_includes: A list of include paths for relative includes, provided as relative path.
       strip_include_prefix: attribute to pass through to cc_library.
       test: whether to create a test to invoke the tool too.
     """
@@ -41,7 +34,16 @@ def gentbl(
         "-I external/com_intel_plaidml",
     ]
     for td_include in td_includes:
-        td_includes_cmd += ["-I%s" % td_include]
+        td_includes_cmd += [
+            "-I%s" % td_include,
+            "-I$(GENDIR)/%s" % td_include,
+        ]
+    for td_include in td_relative_includes:
+        td_includes_cmd += [
+            "-I%s/%s -Iexternal/com_intel_plaidml/%s/%s" % (native.package_name(), td_include, native.package_name(), td_include),
+            "-I$(GENDIR)/%s/%s" % (native.package_name(), td_include),
+        ]
+
     local_inc = "-I $$(dirname $(location %s))" % td_file
 
     if test:
@@ -63,7 +65,8 @@ def gentbl(
             "$(location %s)" % td_file,
             "-I$(GENDIR)",
         ] + td_includes_cmd
-        rule_suffix = "_".join(opts.replace("-", "_").replace("=", "_").split(" "))
+        first_opt = opts.split(" ", 1)[0]
+        rule_suffix = "_{}_{}".format(first_opt.replace("-", "_").replace("=", "_"), str(hash(opts)))
 
         # Rule to generate code using generated shell script.
         native.genrule(
@@ -76,12 +79,15 @@ def gentbl(
         )
 
         # Optionally generate rule to test tblgen invocation.
+        # Disable these on windows, because $(location ...) does not seem to
+        # work as expected on windows.
         if test:
             native.sh_test(
                 name = "%s_%s_genrule_test" % (name, rule_suffix),
                 srcs = ["%s.gen.sh" % name],
                 args = base_args,
                 data = srcs + [tblgen],
+                tags = ["no_windows"],
             )
 
     # List of opts that do not generate cc files.

--- a/vendor/mlir/test.BUILD
+++ b/vendor/mlir/test.BUILD
@@ -181,10 +181,13 @@ cc_library(
         "@llvm-project//mlir:GPUToGPURuntimeTransforms",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:LLVMTransforms",
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SPIRVDialect",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
         "@llvm-project//mlir:Support",
@@ -228,5 +231,17 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SPIRVDialect",
         "@llvm-project//mlir:SPIRVLowering",
+    ],
+)
+
+cc_library(
+    name = "TestTypeDialect",
+    srcs = glob([
+        "lib/Dialect/LLVMIR/*.cpp",
+    ]),
+    deps = [
+        ":TestDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
     ],
 )


### PR DESCRIPTION
Note that the intel_gen tests are disabled due to the following error now appearing:

```
error: module must have 'vce_triple' attribute to be serializeable
```

This occurs during the serialization to SPIR-V.
