### PR TITLE
Improvements to utilities

### DIFF
--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -169,13 +169,13 @@ struct PxaReduceOpConversion : public OpConversionPattern<pxa::PxaReduceOp> {
   LogicalResult
   matchAndRewrite(pxa::PxaReduceOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    auto source = rewriter.create<AffineLoadOp>(op.getLoc(), op.mem(), op.map(),
-                                                op.idxs());
+    auto source = rewriter.create<AffineLoadOp>(op.getLoc(), op.memref(),
+                                                op.map(), op.idxs());
     auto reduce =
         createReduction(rewriter, op.getLoc(), op.agg(), source, op.val());
-    rewriter.create<AffineStoreOp>(op.getLoc(), reduce, op.mem(), op.map(),
+    rewriter.create<AffineStoreOp>(op.getLoc(), reduce, op.memref(), op.map(),
                                    op.idxs());
-    op.replaceAllUsesWith(op.mem());
+    op.replaceAllUsesWith(op.memref());
     rewriter.eraseOp(op);
     return success();
   }
@@ -189,13 +189,13 @@ struct PxaVectorReduceOpConversion
   matchAndRewrite(pxa::PxaVectorReduceOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
     auto source = rewriter.create<AffineVectorLoadOp>(
-        op.getLoc(), op.getVectorType(), op.mem(), op.getAffineMap(),
+        op.getLoc(), op.getVectorType(), op.memref(), op.getAffineMap(),
         op.idxs());
     auto reduce =
         createReduction(rewriter, op.getLoc(), op.agg(), source, op.vector());
-    rewriter.create<AffineVectorStoreOp>(op.getLoc(), reduce, op.mem(),
+    rewriter.create<AffineVectorStoreOp>(op.getLoc(), reduce, op.memref(),
                                          op.getAffineMap(), op.idxs());
-    op.replaceAllUsesWith(op.mem());
+    op.replaceAllUsesWith(op.memref());
     rewriter.eraseOp(op);
     return success();
   }

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -17,9 +17,10 @@
 #include "pmlc/dialect/pxa/analysis/affine_expr.h"
 #include "pmlc/util/logging.h"
 
-namespace mlir {
+using namespace mlir; // NOLINT
 
-namespace pxa = pmlc::dialect::pxa;
+namespace pmlc::dialect::pxa {
+
 const char *kBlockAndArgFormat = "^bb{0}:%arg{1}";
 
 static std::string getUniqueName(Block *ref, BlockArgument arg) {
@@ -48,24 +49,63 @@ int64_t getIVStep(BlockArgument arg) {
   llvm_unreachable("Get IV Step on non-IV");
 }
 
-int64_t RelativeAccessPattern::totalInnerBytes() const {
+static Optional<StrideInfo> flatten(MemRefType memRefType,
+                                    ArrayRef<StrideInfo> dimensional) {
+  assert(memRefType.getRank() == static_cast<int64_t>(dimensional.size()) &&
+         "memRef and dimensional rank mismatch");
+  // Get the memRef strides/offsets, and fail early if there is an isssue.
+  int64_t offset;
+  SmallVector<int64_t, 4> strides;
+  if (failed(getStridesAndOffset(memRefType, strides, offset)))
+    return None;
+
+  // Fail if anything is dynamic.
+  if (ShapedType::isDynamicStrideOrOffset(offset) ||
+      llvm::any_of(strides, ShapedType::isDynamicStrideOrOffset))
+    return None;
+
+  StrideInfo flat{offset};
+  for (size_t i = 0; i < strides.size(); i++) {
+    flat += dimensional[i] * strides[i];
+  }
+
+  return flat;
+}
+
+MemRefType RelativeAccessPattern::getMemRefType() const {
+  return memRef.getType().cast<MemRefType>();
+}
+
+int64_t RelativeAccessPattern::totalInnerCount() const {
   int64_t ret = 1;
   for (auto dim : innerCount) {
     ret *= dim;
   }
-  auto eltSize = llvm::divideCeil(memRefType.getElementTypeBitWidth(), 8);
-  return ret * eltSize;
+  return ret;
+}
+
+int64_t RelativeAccessPattern::totalInnerBytes() const {
+  auto eltSize = llvm::divideCeil(getMemRefType().getElementTypeBitWidth(), 8);
+  return totalInnerCount() * eltSize;
+}
+
+Optional<StrideInfo> RelativeAccessPattern::flatOuter() const {
+  return flatten(getMemRefType(), outer);
+}
+
+Optional<StrideInfo> RelativeAccessPattern::flatInner() const {
+  return flatten(getMemRefType(), inner);
 }
 
 StrideRange::StrideRange(BlockArgument arg)
     : valid(false), minVal(0), maxVal(0), stride(0) {
   if (auto ap = dyn_cast<AffineParallelOp>(arg.getOwner()->getParentOp())) {
-    auto range_expr = ap.getRangesValueMap().getResult(arg.getArgNumber());
-    auto range_cst = range_expr.dyn_cast<AffineConstantExpr>();
-    if (!range_cst) {
+    auto rangeExpr = ap.getRangesValueMap().getResult(arg.getArgNumber());
+    auto rangeConstantExpr = rangeExpr.dyn_cast<AffineConstantExpr>();
+    if (!rangeConstantExpr) {
       return;
     }
-    int64_t range = range_cst.getValue();
+    int64_t range = rangeConstantExpr.getValue();
     if (range < 1) {
       return;
     }
@@ -229,13 +269,21 @@ void StrideInfo::print(raw_ostream &os, Block *relative) const {
                       kvp.second);
     }
   }
-  os << offset << ":[";
-  for (auto item : llvm::enumerate(ordered)) {
-    if (item.index())
-      os << ", ";
-    os << item.value().first << "=" << item.value().second;
+  os << offset;
+  if (ordered.size()) {
+    os << ":[";
+    for (auto item : llvm::enumerate(ordered)) {
+      if (item.index())
+        os << ", ";
+      os << item.value().first << "=" << item.value().second;
+    }
+    os << ']';
   }
-  os << ']';
+}
+
+std::ostream &operator<<(std::ostream &os, const StrideInfo &x) {
+  os << debugString(x);
+  return os;
 }
 
 AffineValueMap convertToValueMap(MLIRContext *ctx, ArrayRef<StrideInfo> dims) {
@@ -354,9 +402,9 @@ Optional<StrideInfo> computeStrideInfo(AffineExpr expr, ValueRange args) {
   return None;
 }
 
-Optional<llvm::SmallVector<StrideInfo, 4>> computeStrideInfo(AffineMap map,
-                                                             ValueRange args) {
-  llvm::SmallVector<StrideInfo, 4> results;
+Optional<SmallVector<StrideInfo, 4>> computeStrideInfo(AffineMap map,
+                                                       ValueRange args) {
+  SmallVector<StrideInfo, 4> results;
   for (auto expr : map.getResults()) {
     auto dimStride = computeStrideInfo(expr, args);
     if (!dimStride) {
@@ -373,7 +421,7 @@ Optional<StrideInfo> computeStrideInfo(MemRefType memRefType, AffineMap map,
   assert(map.getNumResults() == memRefType.getRank());
   assert(map.getNumInputs() == values.size());
 
-  // Get the memRef strides/offsets, and fail early if there is an isssue.
+  // Get the memRef strides/offsets, and fail early if there is an issse.
   int64_t memRefOffset;
   SmallVector<int64_t, 4> memRefStrides;
   if (failed(getStridesAndOffset(memRefType, memRefStrides, memRefOffset)))
@@ -405,22 +453,22 @@ Optional<StrideInfo> computeStrideInfo(MemRefType memRefType, AffineMap map,
   return out;
 }
 
-Optional<StrideInfo> computeStrideInfo(pxa::PxaLoadOp op) {
+Optional<StrideInfo> computeStrideInfo(PxaLoadOp op) {
   return computeStrideInfo(op.getMemRefType(), op.getAffineMap(),
                            op.getMapOperands());
 }
 
-Optional<StrideInfo> computeStrideInfo(pxa::PxaReduceOp op) {
+Optional<StrideInfo> computeStrideInfo(PxaReduceOp op) {
   return computeStrideInfo(op.getMemRefType(), op.getAffineMap(),
                            op.getMapOperands());
 }
 
-Optional<StrideInfo> computeStrideInfo(pxa::PxaVectorLoadOp op) {
+Optional<StrideInfo> computeStrideInfo(PxaVectorLoadOp op) {
   return computeStrideInfo(op.getMemRefType(), op.getAffineMap(),
                            op.getMapOperands());
 }
 
-Optional<StrideInfo> computeStrideInfo(pxa::PxaVectorReduceOp op) {
+Optional<StrideInfo> computeStrideInfo(PxaVectorReduceOp op) {
   return computeStrideInfo(op.getMemRefType(), op.getAffineMap(),
                            op.getMapOperands());
 }
@@ -428,36 +476,37 @@ Optional<StrideInfo> computeStrideInfo(pxa::PxaVectorReduceOp op) {
 Optional<RelativeAccessPattern>
 computeRelativeAccess(Operation *op, BlockArgumentBoundaryFn fn) {
   ArrayRef<int64_t> vecSize;
-  MemRefType memRefType;
-  using MaybeStrides = Optional<llvm::SmallVector<StrideInfo, 4>>;
+  Value memref;
+  using MaybeStrides = Optional<SmallVector<StrideInfo, 4>>;
   auto maybeStrides =
       TypeSwitch<Operation *, MaybeStrides>(op)
-          .Case<pxa::PxaLoadOp>([&](auto op) {
-            memRefType = op.getMemRefType();
+          .Case<PxaLoadOp>([&](auto op) {
+            memref = op.memref();
             return computeStrideInfo(op.getAffineMap(), op.getMapOperands());
           })
-          .Case<pxa::PxaReduceOp>([&](auto op) {
-            memRefType = op.getMemRefType();
+          .Case<PxaReduceOp>([&](auto op) {
+            memref = op.memref();
             return computeStrideInfo(op.getAffineMap(), op.getMapOperands());
           })
-          .Case<pxa::PxaVectorLoadOp>([&](auto op) {
-            memRefType = op.getMemRefType();
+          .Case<PxaVectorLoadOp>([&](auto op) {
+            memref = op.memref();
             vecSize = op.getVectorType().getShape();
             return computeStrideInfo(op.getAffineMap(), op.getMapOperands());
           })
-          .Case<pxa::PxaVectorReduceOp>([&](auto op) {
-            memRefType = op.getMemRefType();
+          .Case<PxaVectorReduceOp>([&](auto op) {
+            memref = op.memref();
             vecSize = op.getVectorType().getShape();
             return computeStrideInfo(op.getAffineMap(), op.getMapOperands());
           })
-          .Default([](auto op) { return llvm::None; });
+          .Default([](auto op) { return None; });
   if (!maybeStrides) {
-    return llvm::None;
+    return None;
   }
   auto &strides = *maybeStrides;
-  RelativeAccessPattern ret(memRefType);
+  RelativeAccessPattern ret(memref);
   for (size_t i = 0; i < strides.size(); i++) {
-    ret.outer.push_back(strides[i].outer(fn));
+    auto outer = strides[i].outer(fn);
+    ret.outer.push_back(outer);
     auto inner = strides[i].inner(fn);
     ret.inner.push_back(inner);
     StrideRange range = inner.range();
@@ -469,7 +518,7 @@ computeRelativeAccess(Operation *op, BlockArgumentBoundaryFn fn) {
       }
     }
     if (!range.valid || range.minVal != 0) {
-      return llvm::None;
+      return None;
     }
     ret.innerCount.push_back(range.count());
     int64_t stride = range.stride;
@@ -520,7 +569,7 @@ void StrideArray::print(raw_ostream &os) {
 Optional<StrideArray> computeStrideArray(AffineMap map) {
   std::vector<SmallVector<int64_t, 8>> flat;
   if (failed(getFlattenedAffineExprs(map, &flat, nullptr)))
-    return llvm::None;
+    return None;
 
   StrideArray ret(map.getNumDims(), flat.front().back());
   for (unsigned i = 0, e = map.getNumDims(); i < e; i++) {
@@ -530,4 +579,4 @@ Optional<StrideArray> computeStrideArray(AffineMap map) {
   return ret;
 }
 
-} // namespace mlir
+} // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -421,7 +421,7 @@ Optional<StrideInfo> computeStrideInfo(MemRefType memRefType, AffineMap map,
   assert(map.getNumResults() == memRefType.getRank());
   assert(map.getNumInputs() == values.size());
 
-  // Get the memRef strides/offsets, and fail early if there is an issse.
+  // Get the memRef strides/offsets, and fail early if there is an issue.
   int64_t memRefOffset;
   SmallVector<int64_t, 4> memRefStrides;
   if (failed(getStridesAndOffset(memRefType, memRefStrides, memRefOffset)))

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -53,7 +53,7 @@ static Optional<StrideInfo> flatten(MemRefType memRefType,
                                     ArrayRef<StrideInfo> dimensional) {
   assert(memRefType.getRank() == static_cast<int64_t>(dimensional.size()) &&
          "memRef and dimensional rank mismatch");
-  // Get the memRef strides/offsets, and fail early if there is an isssue.
+  // Get the memRef strides/offsets, and fail early if there is an issue.
   int64_t offset;
   SmallVector<int64_t, 4> strides;
   if (failed(getStridesAndOffset(memRefType, strides, offset)))

--- a/pmlc/dialect/pxa/ir/ops.cc
+++ b/pmlc/dialect/pxa/ir/ops.cc
@@ -96,8 +96,9 @@ template <>
 void SimplifyAffineOp<PxaReduceOp>::replaceAffineOp(
     PatternRewriter &rewriter, PxaReduceOp op, AffineMap map,
     ArrayRef<Value> mapOperands) const {
-  rewriter.replaceOpWithNewOp<PxaReduceOp>(
-      op, op.getMemRefType(), op.agg(), op.val(), op.mem(), map, mapOperands);
+  rewriter.replaceOpWithNewOp<PxaReduceOp>(op, op.getMemRefType(), op.agg(),
+                                           op.val(), op.memref(), map,
+                                           mapOperands);
 }
 
 template <>
@@ -113,7 +114,7 @@ void SimplifyAffineOp<PxaVectorReduceOp>::replaceAffineOp(
     ArrayRef<Value> mapOperands) const {
   rewriter.replaceOpWithNewOp<PxaVectorReduceOp>(op, op.getMemRefType(),
                                                  op.agg(), op.vector(),
-                                                 op.mem(), map, mapOperands);
+                                                 op.memref(), map, mapOperands);
 }
 
 /// This is a common class used for patterns of the form
@@ -323,13 +324,13 @@ void printPxaReduceOp(OpAsmPrinter &p, PxaReduceOp op) {
   p << op.getOperation()->getName() << ' ';
   p << stringifyAtomicRMWKind(op.agg()) << ' ';
   p << op.val() << ", ";
-  p << op.mem() << '[';
+  p << op.memref() << '[';
   auto mapAttr = op.getAttrOfType<AffineMapAttr>("map");
   p.printAffineMapOfSSAIds(mapAttr, op.idxs());
   p << ']';
   p.printOptionalAttrDict(op.getAttrs(), {"agg", "map"});
   p << " : ";
-  p.printType(op.mem().getType());
+  p.printType(op.memref().getType());
 }
 
 // <operation> ::= `pxa.reduce` keyword ssa-use `,` ssa-use `[` ssa-use-list `]`
@@ -464,13 +465,13 @@ void printPxaVectorReduceOp(OpAsmPrinter &p, PxaVectorReduceOp op) {
   p << op.getOperation()->getName() << ' ';
   p << stringifyAtomicRMWKind(op.agg()) << ' ';
   p << op.vector() << ", ";
-  p << op.mem() << '[';
+  p << op.memref() << '[';
   auto mapAttr = op.getAttrOfType<AffineMapAttr>("map");
   p.printAffineMapOfSSAIds(mapAttr, op.idxs());
   p << ']';
   p.printOptionalAttrDict(op.getAttrs(), {"agg", "map"});
   p << " : ";
-  p.printType(op.mem().getType());
+  p.printType(op.memref().getType());
   p << ", ";
   p.printType(op.vector().getType());
 }

--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -31,7 +31,7 @@ def PxaReduceOp : PXA_OpWithPP<"reduce"> {
   let arguments = (ins
     AtomicRMWKindAttr:$agg,
     AnyType:$val,
-    Arg<AnyMemRef, "the memref to reduce", [MemRead, MemWrite]>:$mem,
+    AnyMemRef:$memref,
     AffineMapAttr:$map,
     Variadic<Index>:$idxs
   );
@@ -48,10 +48,10 @@ def PxaReduceOp : PXA_OpWithPP<"reduce"> {
   >];
 
   let extraClassDeclaration = [{
-    Value getMemRef() { return mem(); }
+    Value getMemRef() { return memref(); }
     unsigned getMemRefOperandIndex() { return 1; }
     void setMemRef(Value value) { setOperand(getMemRefOperandIndex(), value); }
-    MemRefType getMemRefType() { return mem().getType().cast<MemRefType>(); }
+    MemRefType getMemRefType() { return memref().getType().cast<MemRefType>(); }
     AffineMap getAffineMap() { return map(); }
     operand_range getMapOperands() { return idxs(); }
     static StringRef getMapAttrName() { return "map"; }
@@ -83,12 +83,12 @@ def PxaGemmOp : PXA_OpWithPP<"gemm"> {
   }];
 }
 
-def PxaVectorReduceOp : PXA_OpWithPP<"vector_reduce", []> {
+def PxaVectorReduceOp : PXA_OpWithPP<"vector_reduce"> {
   let summary = "affine vector reduction operation";
   let arguments = (ins
     AtomicRMWKindAttr:$agg,
     AnyVector:$vector,
-    Arg<AnyMemRef, "the memref to reduce", [MemRead, MemWrite]>:$mem,
+    AnyMemRef:$memref,
     AffineMapAttr:$map,
     Variadic<Index>:$idxs
   );
@@ -105,10 +105,10 @@ def PxaVectorReduceOp : PXA_OpWithPP<"vector_reduce", []> {
   >];
 
   let extraClassDeclaration = [{
-    Value getMemRef() { return mem(); }
+    Value getMemRef() { return memref(); }
     unsigned getMemRefOperandIndex() { return 1; }
     void setMemRef(Value value) { setOperand(getMemRefOperandIndex(), value); }
-    MemRefType getMemRefType() { return mem().getType().cast<MemRefType>(); }
+    MemRefType getMemRefType() { return memref().getType().cast<MemRefType>(); }
     AffineMap getAffineMap() { return map(); }
     operand_range getMapOperands() { return idxs(); }
     static StringRef getMapAttrName() { return "map"; }
@@ -122,9 +122,10 @@ def PxaVectorReduceOp : PXA_OpWithPP<"vector_reduce", []> {
 class PxaLoadOpBase<string mnemonic, list<OpTrait> traits = []> :
     PXA_OpWithPP<mnemonic, !listconcat(traits,
         [DeclareOpInterfaceMethods<AffineReadOpInterface>])> {
-  let arguments = (ins Arg<AnyMemRef, "the reference to load from",
-      [MemRead]>:$memref,
-      Variadic<Index>:$indices);
+  let arguments = (ins
+    AnyMemRef:$memref,
+    Variadic<Index>:$indices
+  );
 
   code extraClassDeclarationBase = [{
     /// Returns the operand index of the memref.
@@ -141,7 +142,7 @@ class PxaLoadOpBase<string mnemonic, list<OpTrait> traits = []> :
   }];
 }
 
-def PxaLoadOp : PxaLoadOpBase<"load"> {
+def PxaLoadOp : PxaLoadOpBase<"load", [NoSideEffect]> {
   let summary = "affine load operation";
   let description = [{
     The "affine.load" op reads an element from a memref, where the index

--- a/pmlc/dialect/pxa/tests/dataflow_opt.mlir
+++ b/pmlc/dialect/pxa/tests/dataflow_opt.mlir
@@ -1,7 +1,7 @@
 // RUN: pmlc-opt -pxa-dataflow-opt -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: func @simple
-func @simple(%out : memref<2xf32>) {
+func @simple(%out : memref<2xf32>) -> memref<2xf32> {
   // CHECK: constant 0.0
   %zero = constant 0.0 : f32
   %buf = alloc() : memref<2xf32>
@@ -13,7 +13,7 @@ func @simple(%out : memref<2xf32>) {
     %3 = pxa.reduce addf %2, %out[%i] : memref<2xf32>
     affine.yield %3 : memref<2xf32>
   }
-  return
+  return %0 : memref<2xf32>
 }
 
 // CHECK-LABEL: func @grn

--- a/pmlc/dialect/pxa/tests/fusion.mlir
+++ b/pmlc/dialect/pxa/tests/fusion.mlir
@@ -1,7 +1,7 @@
 // RUN: pmlc-opt -pxa-normalize -canonicalize -pxa-fusion -pxa-normalize -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: func @simple_fusion
-func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32>, %D: memref<2x3xf32>) {
+func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32>, %D: memref<2x3xf32>) -> memref<2x3xf32> {
   %T = alloc() : memref<2x3xf32>
   %4 = affine.parallel (%i, %j) = (0, 0) to (2, 3) reduce ("assign") -> (memref<2x3xf32>) {
     %0 = pxa.load %A[%i, %j] : memref<2x3xf32>
@@ -17,7 +17,7 @@ func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32
     %3 = pxa.reduce assign %2, %D[%i, %j] : memref<2x3xf32>
     affine.yield %3 : memref<2x3xf32>
   }
-  return
+  return %5 : memref<2x3xf32>
   // CHECK: affine.parallel (%{{.*}}, %{{.*}}) = (0, 0) to (2, 3)
   // CHECK: pxa.load
   // CHECK: pxa.load

--- a/pmlc/dialect/pxa/tests/resize_tmps.mlir
+++ b/pmlc/dialect/pxa/tests/resize_tmps.mlir
@@ -58,7 +58,7 @@ func @no_resize_return() -> memref<10x10xf32> {
 }
 
 #set0 = affine_set<(d0, d1, d2, d3) : (d0 * -30 - d1 + 221 >= 0, d2 * -30 - d3 + 221 >= 0)>
-func @no_resize_expand(%arg0: memref<32x30xf32>) {
+func @no_resize_expand(%arg0: memref<32x30xf32>) -> memref<1x222x222x32xf32> {
 // CHECK-LABEL: func @no_resize_expand
   %0 = alloc() : memref<1x30x32x8x8x32xf32>
   %1 = alloc() : memref<1x222x222x32xf32>
@@ -75,5 +75,5 @@ func @no_resize_expand(%arg0: memref<32x30xf32>) {
     }
     affine.yield %4 : memref<1x222x222x32xf32>
   }
-  return
+  return %2 : memref<1x222x222x32xf32>
 }

--- a/pmlc/dialect/pxa/transforms/cache.h
+++ b/pmlc/dialect/pxa/transforms/cache.h
@@ -3,12 +3,22 @@
 #pragma once
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+
+#include "pmlc/dialect/pxa/analysis/strides.h"
 #include "pmlc/dialect/pxa/ir/ops.h"
 
 namespace pmlc::dialect::pxa {
 
-LogicalResult cacheLoad(mlir::AffineParallelOp par, PxaLoadOp load);
-LogicalResult cacheReduce(mlir::AffineParallelOp par, PxaReduceOp reduce);
+struct CacheInfo {
+  mlir::AffineParallelOp copyLoopOp;
+  RelativeAccessPattern relativeAccess;
+};
+
+mlir::Optional<CacheInfo> cacheLoad(mlir::AffineParallelOp par, PxaLoadOp load);
+
+mlir::Optional<CacheInfo> cacheReduce(mlir::AffineParallelOp par,
+                                      PxaReduceOp reduce);
+
 LogicalResult cacheLoadAsVector(mlir::AffineParallelOp par, PxaLoadOp load,
                                 int64_t reqVecSize = 0);
 

--- a/pmlc/dialect/pxa/transforms/stencil.cc
+++ b/pmlc/dialect/pxa/transforms/stencil.cc
@@ -105,8 +105,7 @@ int64_t StencilBase::getIdxRange(mlir::BlockArgument idx) {
   return ranges[idx.getArgNumber()];
 }
 
-mlir::Optional<mlir::StrideInfo>
-StencilBase::getStrideInfo(mlir::Operation *op) {
+mlir::Optional<StrideInfo> StencilBase::getStrideInfo(mlir::Operation *op) {
   // want?
   auto cached = strideInfoCache.find(op);
   if (cached != strideInfoCache.end()) {

--- a/pmlc/dialect/pxa/transforms/stencil.h
+++ b/pmlc/dialect/pxa/transforms/stencil.h
@@ -200,7 +200,7 @@ protected:
 
   // Call `computeStrideInfo` with caching and automatic conversion to whichever
   // of PxaLoadOp, or PxaReduceOp is correct
-  mlir::Optional<mlir::StrideInfo> getStrideInfo(mlir::Operation *ioOp);
+  mlir::Optional<StrideInfo> getStrideInfo(mlir::Operation *ioOp);
 
   // Print a log of the best stencil (reporting on cost, permutation, and
   // tiling) provided verbosity is at least `logLevel`
@@ -238,8 +238,7 @@ private:
   llvm::SmallVector<int64_t, 8> ranges;
 
   // Cache of StrideInfo results
-  llvm::DenseMap<mlir::Operation *, mlir::Optional<mlir::StrideInfo>>
-      strideInfoCache;
+  llvm::DenseMap<mlir::Operation *, mlir::Optional<StrideInfo>> strideInfoCache;
 
   // The load and store ops
   LoadStoreOps loadsAndStores;

--- a/pmlc/dialect/pxa/transforms/tile_accumulate.cc
+++ b/pmlc/dialect/pxa/transforms/tile_accumulate.cc
@@ -29,9 +29,9 @@ AffineParallelOp tileAccumulations(AffineParallelOp op, bool skipTrivial) {
   // Find the originating reduce
   assert(op.getNumResults() == 1);
   auto srcDef = getOriginalDef(op.getResult(0));
-  auto red = mlir::cast<PxaReduceOp>(srcDef);
+  auto reduceOp = cast<PxaReduceOp>(srcDef);
   // Get strides for output
-  auto si = *computeStrideInfo(red);
+  auto si = *computeStrideInfo(reduceOp);
   // Find all the accumulation indexes (stride 0 with respect to output) and
   // tile them into an inner block
   auto ranges = *op.getConstantRanges();
@@ -62,10 +62,6 @@ AffineParallelOp tileAccumulations(AffineParallelOp op, bool skipTrivial) {
 }
 
 namespace {
-using llvm::DenseMap;
-using llvm::DenseSet;
-using llvm::SmallVector;
-using mlir::BlockArgument;
 
 struct TileAccumulatePass : public TileAccumulateBase<TileAccumulatePass> {
   void runOnFunction() final {
@@ -78,9 +74,10 @@ struct TileAccumulatePass : public TileAccumulateBase<TileAccumulatePass> {
     }
   }
 };
+
 } // namespace
 
-std::unique_ptr<mlir::Pass> createTileAccumulatePass() {
+std::unique_ptr<Pass> createTileAccumulatePass() {
   return std::make_unique<TileAccumulatePass>();
 }
 

--- a/pmlc/dialect/pxa/transforms/vectorize.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize.cc
@@ -150,7 +150,6 @@ public:
   }
 
   void vectorizeReduceOp(PxaReduceOp op) {
-    Value mem = op.mem();
     Value val = op.val();
     OpBuilder builder(op);
     if (!val.getType().isa<VectorType>()) {
@@ -160,8 +159,8 @@ public:
       val = bcast.getResult();
     }
     auto vecOp = builder.create<PxaVectorReduceOp>(
-        op.getLoc(), ArrayRef<Type>{mem.getType()}, op.agg(), val, mem,
-        op.map(), op.idxs());
+        op.getLoc(), ArrayRef<Type>{op.getMemRefType()}, op.agg(), val,
+        op.memref(), op.map(), op.idxs());
     op.replaceAllUsesWith(vecOp.getResult());
     op.erase();
   }

--- a/pmlc/target/x86/xsmm_lowering.cc
+++ b/pmlc/target/x86/xsmm_lowering.cc
@@ -19,14 +19,14 @@ namespace xsmm = dialect::xsmm;
 
 namespace {
 
-StrideArray getStrideArray(Value operand, AffineMap tileMap) {
+pxa::StrideArray getStrideArray(Value operand, AffineMap tileMap) {
   int64_t offset;
   SmallVector<int64_t, 4> strides;
   auto type = operand.getType().cast<MemRefType>();
   getStridesAndOffset(type, strides, offset);
   auto layoutMap =
       makeStridedLinearLayoutMap(strides, offset, operand.getContext());
-  auto info = computeStrideArray(layoutMap.compose(tileMap));
+  auto info = pxa::computeStrideArray(layoutMap.compose(tileMap));
   assert(info.hasValue() && "computeStrideArray must succeed");
   return *info;
 }


### PR DESCRIPTION
* Move StrideInfo and related utilities into pxa namespace.
* Rename mem argument to memref in PXA ops for consistency.
* Mark PxaLoadOp as NoSideEffect (there are presently issues with attempting the same with PxaReduceOp).
* Fix existing PXA tests to return results, as required by the PXA dialect.
* Add flatOuter() and flatInner() to RelativeAccessPattern, which provides the 1-dimensional linearized strides on a per IV basis.
* Allow pxa::getOriginalDef() to return nullptr if the value is defined by a BlockArgument.
* Cache transformations now return a CacheInfo.