### PR TITLE
Get SinH etc to lower to GPU dialect.

### DIFF
--- a/pmlc/target/intel_gen/pass_detail.h
+++ b/pmlc/target/intel_gen/pass_detail.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
+
 #include "mlir/Pass/Pass.h"
 
 namespace pmlc::target::intel_gen {

--- a/pmlc/target/intel_gen/passes.h
+++ b/pmlc/target/intel_gen/passes.h
@@ -10,6 +10,8 @@ namespace pmlc::target::intel_gen {
 
 std::unique_ptr<mlir::Pass> createIntelGenLowerAffinePass();
 
+std::unique_ptr<mlir::Pass> createParallelLoopToGpuPass();
+
 void pipelineBuilder(mlir::OpPassManager &pm);
 
 } // namespace pmlc::target::intel_gen

--- a/pmlc/target/intel_gen/passes.td
+++ b/pmlc/target/intel_gen/passes.td
@@ -17,5 +17,12 @@ def ConvertStandardToLLVM : Pass<"intel-gen-convert-std-to-llvm", "mlir::ModuleO
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
+def ConvertParallelLoopToGpu : Pass<"intel-gen-convert-parallel-loops-to-gpu"> {
+  let summary = "Convert mapped scf.parallel ops to gpu launch operations";
+  let constructor = "pmlc::target::createParallelLoopToGpuPass()";
+  let dependentDialects = ["mlir::AffineDialect", "mlir::gpu::GPUDialect"];
+}
+
+
 #endif
 


### PR DESCRIPTION
As of this commit, many of the remaining EDSL tests that fail are caused by not having lowerings for our various stdx ops in https://github.com/plaidml/plaidml/blob/plaidml-v1/pmlc/conversion/gpu_to_spirv/gpu_to_spirv.cc.  At this point it should be a straightforward (if tedious) process to add such lowerings, and in many cases, the needed additions to the SPIRV dialect.
