### PR TITLE
use stopwatch for v1 kernel timing

### DIFF
--- a/plaidbench/plaidbench/core.py
+++ b/plaidbench/plaidbench/core.py
@@ -288,7 +288,7 @@ def _inner_run(reports,
         execution_duration = overrides.get('time', stop_watch.elapsed())
         exec_per_example = execution_duration / params.examples
         tile_exec_per_example = exec_per_example
-        if not timef.tot_time_ns == 0:
+        if timef.tot_time_ns:
             tile_exec_per_example = 1e-9 + timef.tot_time_ns / 10.0**9 / params.examples
 
         compile_duration = compile_stop_watch.elapsed()

--- a/plaidbench/plaidbench/core.py
+++ b/plaidbench/plaidbench/core.py
@@ -286,8 +286,11 @@ def _inner_run(reports,
 
         # Record stopwatch times
         execution_duration = overrides.get('time', stop_watch.elapsed())
-        tile_exec_per_example = 1e-9 + timef.tot_time_ns / 10.0**9 / params.examples
         exec_per_example = execution_duration / params.examples
+        tile_exec_per_example = exec_per_example
+        if not timef.tot_time_ns == 0:
+            tile_exec_per_example = 1e-9 + timef.tot_time_ns / 10.0**9 / params.examples
+
         compile_duration = compile_stop_watch.elapsed()
         flops = overrides.get('flops', None)
         gflops = None
@@ -309,8 +312,7 @@ def _inner_run(reports,
         if gflops:
             resstr += ', {:.2f} (GFLOP/s)'.format(gflops)
         click.secho(resstr, fg='cyan', bold=True)
-        if frontend.name == 'plaidml' and 'metal' in str(device):
-            tile_exec_per_example = exec_per_example
+
         print(
             "-----------------------------------------------------------------------------------------"
         )


### PR DESCRIPTION
Sets stopwatch time as duration_per_example in the absence of more accurate kernel timings.  For ResNet:

```
resnet50             1576.95 ms                1576.95 ms / 0.63 fps
Correctness: PASS, max_error: 7.918380106275436e-06, max_abs_error: 1.4603137969970703e-06, fail_ratio: 0.0
{'backend': 'plaid',
 'batch_size': 1,
 'compile_duration': 14.441735982894897,
 'correct': True,
 'duration_per_example': 1.5769538879394531,
 'examples': 1,
 'fail_ratio': 0.0,
 'max_abs_error': 1.4603137969970703e-06,
 'max_error': 7.918380106275436e-06,
 'model': 'resnet50',
 'tile_duration_per_example': 1.5769538879394531}
```