### PR TITLE
add Vulkan kernel timing

### DIFF
--- a/pmlc/rt/vulkan/vulkan_invocation.cc
+++ b/pmlc/rt/vulkan/vulkan_invocation.cc
@@ -220,30 +220,46 @@ void VulkanInvocation::submitCommandBuffers() {
   throwOnVulkanError(vkQueueWaitIdle(device->getQueue()), "vkQueueWaitIdle");
 
   if (device->getTimestampValidBits()) {
-    uint64_t *results =
-        reinterpret_cast<uint64_t *>(calloc(8192, sizeof(uint64_t)));
+    uint64_t *results = reinterpret_cast<uint64_t *>(
+        calloc(timestampQueryCount, sizeof(uint64_t)));
     vkGetQueryPoolResults(device->getDevice(), timestampQueryPool,
                           /*firstQuery=*/0,
-                          /*queryCount=*/8192,
-                          /*dataSize=*/16, results,
-                          /*stride=*/8,
+                          /*queryCount=*/timestampQueryCount,
+                          /*dataSize=*/timestampQueryCount * sizeof(uint64_t),
+                          results,
+                          /*stride=*/sizeof(uint64_t),
                           (VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT));
 
-    IVLOG(1, "timestampQuery = " << timestampQuery);
-    uint64_t ns = (results[1] - results[0]) * device->getTimestampPeriod();
     const double NS_PER_MS = 1000000.0;
-    IVLOG(1, "Total program execution duration: " << ns);
-    IVLOG(1, "Execution time: " << ns << "ns");
-    IVLOG(1, "Execution time: " << ns / NS_PER_MS << "ms");
+    uint64_t overall_ns =
+        (results[1] - results[0]) * device->getTimestampPeriod();
+    IVLOG(1, "Overall Vulkan time: " << overall_ns / NS_PER_MS << "ms");
 
-    for (uint32_t i = 2; i < timestampQuery; i += 2) {
-      uint64_t ns =
+    uint64_t total_kernel_ns = 0;
+
+    for (uint32_t i = 2; i < timestampQueryCount; i += 2) {
+      uint64_t kernel_ns =
           (results[i + 1] - results[i]) * device->getTimestampPeriod();
-      IVLOG(1, "  start:            " << results[i]);
-      IVLOG(1, "  end:              " << results[i + 1]);
-      IVLOG(1, "  Kernel exec time: " << ns << "ns");
-      IVLOG(1, "  Kernel exec time: " << ns / NS_PER_MS << "ms");
+
+      IVLOG(1, "  Vulkan kernel exec time: " << kernel_ns / NS_PER_MS << "ms");
+
+      total_kernel_ns += kernel_ns;
     }
+
+    IVLOG(1, "Total Vulkan kernels: " << (timestampQueryCount - 2) / 2);
+    IVLOG(1, "Total Vulkan kernel exec time: " << total_kernel_ns / NS_PER_MS
+                                               << "ms");
+    IVLOG(1, "Percentage Vulkan kernel exec time: "
+                 << total_kernel_ns * 100 / static_cast<double>(overall_ns)
+                 << "%");
+
+    uint64_t total_memxfer_ns = overall_ns - total_kernel_ns;
+    IVLOG(1, "Total Vulkan memory transfers: " << memoryTransferCount);
+    IVLOG(1, "Total (esimtated) Vulkan memory transfer time: "
+                 << total_memxfer_ns / NS_PER_MS << "ms");
+    IVLOG(1, "Percentage (estimated) Vulkan memory transfer time: "
+                 << total_memxfer_ns * 100 / static_cast<double>(overall_ns)
+                 << "%");
   }
 
   updateHostMemoryBuffers();
@@ -680,14 +696,14 @@ void VulkanInvocation::createSchedule() {
 
   if (device->getTimestampValidBits()) {
     vkCmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                        timestampQueryPool, 0 /*timestampQuery++*/);
+                        timestampQueryPool, /*query=*/0);
   }
 
   for (const auto &action : schedule) {
     if (auto kernel = std::dynamic_pointer_cast<LaunchKernelAction>(action)) {
       if (device->getTimestampValidBits()) {
         vkCmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                            timestampQueryPool, timestampQuery++);
+                            timestampQueryPool, timestampQueryCount++);
       }
 
       if (kernel->deps.size()) {
@@ -724,10 +740,11 @@ void VulkanInvocation::createSchedule() {
 
       if (device->getTimestampValidBits()) {
         vkCmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                            timestampQueryPool, timestampQuery++);
+                            timestampQueryPool, timestampQueryCount++);
       }
     }
     if (auto xfer = std::dynamic_pointer_cast<MemoryTransferAction>(action)) {
+      memoryTransferCount++;
       vkCmdCopyBuffer(commandBuffer,
                       /*srcBuffer=*/xfer->src,
                       /*dstBuffer=*/xfer->dst,
@@ -738,7 +755,7 @@ void VulkanInvocation::createSchedule() {
 
   if (device->getTimestampValidBits()) {
     vkCmdWriteTimestamp(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                        timestampQueryPool, 1 /*timestampQuery++*/);
+                        timestampQueryPool, /*query=*/1);
   }
 
   throwOnVulkanError(vkEndCommandBuffer(commandBuffer), "vkEndCommandBuffer");

--- a/pmlc/rt/vulkan/vulkan_invocation.h
+++ b/pmlc/rt/vulkan/vulkan_invocation.h
@@ -189,7 +189,7 @@ private:
   VkCommandPool commandPool;
   llvm::SmallVector<VkCommandBuffer, 1> commandBuffers;
   VkQueryPool timestampQueryPool;
-  const uint32_t timestampQueryPoolSize{2};
+  const uint32_t timestampQueryPoolSize{8192};
   uint32_t timestampQueryCount{2};
   uint32_t memoryTransferCount{0};
 };

--- a/pmlc/rt/vulkan/vulkan_invocation.h
+++ b/pmlc/rt/vulkan/vulkan_invocation.h
@@ -189,6 +189,7 @@ private:
   VkCommandPool commandPool;
   VkQueryPool timestampQueryPool;
   llvm::SmallVector<VkCommandBuffer, 1> commandBuffers;
+  uint32_t timestampQuery{2};
 };
 
 } // namespace pmlc::rt::vulkan

--- a/pmlc/rt/vulkan/vulkan_invocation.h
+++ b/pmlc/rt/vulkan/vulkan_invocation.h
@@ -187,8 +187,9 @@ private:
   std::shared_ptr<LaunchKernelAction> curr;
   std::shared_ptr<VulkanDevice> device;
   VkCommandPool commandPool;
-  VkQueryPool timestampQueryPool;
   llvm::SmallVector<VkCommandBuffer, 1> commandBuffers;
+  VkQueryPool timestampQueryPool;
+  const uint32_t timestampQueryPoolSize{2};
   uint32_t timestampQueryCount{2};
   uint32_t memoryTransferCount{0};
 };

--- a/pmlc/rt/vulkan/vulkan_invocation.h
+++ b/pmlc/rt/vulkan/vulkan_invocation.h
@@ -189,7 +189,8 @@ private:
   VkCommandPool commandPool;
   VkQueryPool timestampQueryPool;
   llvm::SmallVector<VkCommandBuffer, 1> commandBuffers;
-  uint32_t timestampQuery{2};
+  uint32_t timestampQueryCount{2};
+  uint32_t memoryTransferCount{0};
 };
 
 } // namespace pmlc::rt::vulkan


### PR DESCRIPTION
Command:
```
PLAIDML_TARGET=intel_gen PLAIDML_DEVICE=vulkan.0 PLAIDML_VERBOSE=1 bazelisk run //plaidml/bridge/keras:backend_test -- TestBackendOps.resnetLayer1
```
Prints:
```
2020-09-11 15:07:57,987 VERBOSE-1 [default] Instantiating Vulkan device: Intel(R) Iris(R) Plus Graphics 650 (Kaby Lake GT3e) (KBL GT3)
2020-09-11 15:07:58,008 VERBOSE-1 [default] Overall Vulkan time: 7.27317ms
2020-09-11 15:07:58,008 VERBOSE-1 [default]   Vulkan kernel exec time: 0.47525ms
2020-09-11 15:07:58,009 VERBOSE-1 [default]   Vulkan kernel exec time: 6.35542ms
2020-09-11 15:07:58,009 VERBOSE-1 [default] Total Vulkan kernels: 2
2020-09-11 15:07:58,009 VERBOSE-1 [default] Total Vulkan kernel exec time: 6.83067ms
2020-09-11 15:07:58,009 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 93.916%
2020-09-11 15:07:58,009 VERBOSE-1 [default] Total Vulkan memory transfers: 1
2020-09-11 15:07:58,009 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.4425ms
2020-09-11 15:07:58,009 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 6.08401%
```