### PR TITLE
'Fix' batch norm folding support in plaidbench

### DIFF
--- a/plaidbench/plaidbench/frontend_keras.py
+++ b/plaidbench/plaidbench/frontend_keras.py
@@ -198,9 +198,9 @@ class Model(core.Model):
             eval(code, mod)
         self.x = mod['scale_dataset'](self.x)
         self.model = mod['build_model'](**build_model_kwargs)
-        # if self.enable_bn_folding:
-        #     click.echo('Model loaded, folding in batch_norm')
-        #     self.model = self.fold_batch_norm(self.model)
+        if self.enable_bn_folding:
+            click.echo('Model loaded, folding in batch_norm')
+            self.model = self.fold_batch_norm(self.model)
 
     def compile(self):
         if self.params.network_name[:3] == 'vgg':

--- a/plaidml/edsl/__init__.py
+++ b/plaidml/edsl/__init__.py
@@ -552,6 +552,7 @@ class Tensor(ForeignObject):
     def set_param_value(self, buffer):
         # Changes the value of a parameter tensor (i.e. one explicitly set to a buffer value)
         # Illegal on other tensors
+        self._buffer = buffer
         ffi_call(lib.plaidml_expr_param_reset, self.__ffi_obj__, buffer.as_ptr())
 
     def __hash__(self):


### PR DESCRIPTION
Make comparison to v0 apples to apples, improves kernel times to 43ms, see my email for details.