### PR TITLE
Fix caching issue in TF tests

### DIFF
--- a/plaidml/bridge/tensorflow/tests/i3d_test_gen.py
+++ b/plaidml/bridge/tensorflow/tests/i3d_test_gen.py
@@ -17,6 +17,7 @@ def main(args):
         tmp_path = pathlib.Path(tmp_dir)
         os.environ['XLA_FLAGS'] = '--xla_dump_to={}'.format(tmp_dir)
         os.environ['TF_XLA_FLAGS'] = '--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit'
+        os.environ["TFHUB_CACHE_DIR"] = tmp_dir
         tf.compat.v1.enable_eager_execution()
 
         hub_url = "https://tfhub.dev/deepmind/i3d-kinetics-400/1"


### PR DESCRIPTION
#1367 was experiencing some errors due to stale TF models being left over from previous builds.

Upon further examination, I noticed that `hub.KerasLayer` was caching models outside of the temporary directory created within the test.

I've modified the `TFHUB_CACHE_DIR` environment variable to specify that the cache should be created in the temporary directory.