### PR TITLE
Plumb subgroup size control down to vulkan

### DIFF
--- a/pmlc/conversion/gpu/gpu_to_vulkan.cc
+++ b/pmlc/conversion/gpu/gpu_to_vulkan.cc
@@ -9,6 +9,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/Module.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Pass/Pass.h"
@@ -454,13 +455,10 @@ void ConvertGpuLaunchFuncToVulkanCalls::convertGpuLaunchFunc(
 
   // Presume block.x is the subgroup size
   auto blockSize = launchOp.getBlockSizeOperandValues();
-  auto constOp = blockSize.x.getDefiningOp<mlir::ConstantOp>();
   int64_t subgroupSize = 1;
-  if (constOp) {
-    auto asInt = constOp.getValue().dyn_cast<mlir::IntegerAttr>();
-    if (asInt) {
-      subgroupSize = asInt.getInt();
-    }
+  mlir::IntegerAttr intAttr;
+  if (matchPattern(blockSize.x, m_Constant(&intAttr))) {
+    subgroupSize = intAttr.getInt();
   }
   if (subgroupSize != 1) {
     IVLOG(2, "Subgroup size = " << subgroupSize);

--- a/pmlc/conversion/gpu/kernel_outlining.cc
+++ b/pmlc/conversion/gpu/kernel_outlining.cc
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/SPIRV/TargetAndABI.h"
 
 #include "pmlc/conversion/gpu/pass_detail.h"
+#include "pmlc/util/tags.h"
 using namespace mlir; // NOLINT[build/namespaces]
 
 template <typename OpTy>
@@ -126,9 +127,13 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
                                   gpu::GPUFuncOp kernelFunc,
                                   ValueRange operands) {
   OpBuilder builder(launchOp);
-  builder.create<gpu::LaunchFuncOp>(
+  auto launchFuncOp = builder.create<gpu::LaunchFuncOp>(
       launchOp.getLoc(), kernelFunc, launchOp.getGridSizeOperandValues(),
       launchOp.getBlockSizeOperandValues(), operands);
+
+  if (pmlc::hasTags(launchOp))
+    pmlc::copyTags(launchFuncOp, launchOp);
+
   launchOp.erase();
 }
 

--- a/pmlc/dialect/pxa/transforms/subgroups.cc
+++ b/pmlc/dialect/pxa/transforms/subgroups.cc
@@ -262,16 +262,15 @@ struct SubgroupsPass : public SubgroupsBase<SubgroupsPass> {
 
   void doSubgroups(AffineParallelOp op) {
     SubgroupParams params = {
-        // Currently we only allow size 8 since we can't control runtime
-        // subgroup size
-        {8}, // Subgroup sizes, currently
-        64,  // Maximum register per thread
+        {8, 16}, // Subgroup sizes to consider
+        40,      // Maximum register per thread
     };
     SubgroupCostModel cm(params, op);
     if (cm.bestCost == std::numeric_limits<double>::infinity()) {
       // If subgrouping fails, we tile accumulations instead to handle the other
       // cases
       tileAccumulations(op, false);
+      setIntegerTag(op, subgroupSizeTag(), 1);
       return;
     }
     IVLOG(2, "best plan = " << cm.bestPlan);

--- a/pmlc/rt/vulkan/vulkan_device.cc
+++ b/pmlc/rt/vulkan/vulkan_device.cc
@@ -25,6 +25,23 @@ using namespace mlir; // NOLINT[build/namespaces]
 
 namespace pmlc::rt::vulkan {
 
+void VulkanDevice::getExtensions(const VkPhysicalDevice &physicalDevice) {
+  uint32_t count;
+  vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &count,
+                                       nullptr); // get number of extensions
+  std::vector<VkExtensionProperties> extensions(count);
+  vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &count,
+                                       extensions.data()); // populate buffer
+
+  for (auto &extension : extensions) {
+    extensionList.insert(extension.extensionName);
+  }
+}
+
+bool VulkanDevice::isExtensionSupported(const std::string &extension_name) {
+  return extensionList.find(extension_name) != extensionList.end();
+}
+
 VulkanDevice::VulkanDevice(const VkPhysicalDevice &physicalDevice,
                            std::shared_ptr<VulkanState> state)
     : state{std::move(state)} {
@@ -33,7 +50,7 @@ VulkanDevice::VulkanDevice(const VkPhysicalDevice &physicalDevice,
   IVLOG(1, "Instantiating Vulkan device: " << props.deviceName);
 
   timestampPeriod = props.limits.timestampPeriod;
-
+  getExtensions(physicalDevice);
   getBestComputeQueue(physicalDevice);
 
   const float queuePrioritory = 1.0f;

--- a/pmlc/rt/vulkan/vulkan_device.h
+++ b/pmlc/rt/vulkan/vulkan_device.h
@@ -14,6 +14,8 @@
 #pragma once
 
 #include <memory>
+#include <set>
+#include <string>
 #include <vector>
 
 #include "mlir/Dialect/SPIRV/SPIRVOps.h"
@@ -53,8 +55,11 @@ public:
   float getTimestampPeriod() const { return timestampPeriod; }
   uint32_t getTimestampValidBits() const { return timestampValidBits; }
 
+  bool isExtensionSupported(const std::string &extension_name);
+
 private:
   void getBestComputeQueue(const VkPhysicalDevice &physicalDevice);
+  void getExtensions(const VkPhysicalDevice &physicalDevice);
 
   // Accessor for the Vulkan runtime state.
   std::shared_ptr<VulkanState> state;
@@ -74,6 +79,8 @@ private:
   //===--------------------------------------------------------------------===//
   uint32_t queueFamilyIndex{0};
   uint32_t memoryTypeIndex{VK_MAX_MEMORY_TYPES};
+
+  std::set<std::string> extensionList;
 };
 
 } // namespace pmlc::rt::vulkan

--- a/pmlc/rt/vulkan/vulkan_invocation.h
+++ b/pmlc/rt/vulkan/vulkan_invocation.h
@@ -141,7 +141,7 @@ public:
                                 const char *entryPoint,
                                 NumWorkGroups numWorkGroups);
 
-  void setLaunchKernelAction();
+  void setLaunchKernelAction(uint32_t subgroupSize);
 
   void addLaunchActionToSchedule();
 
@@ -175,7 +175,7 @@ private:
   void initDescriptorSetLayoutBindingMap();
   void createDescriptorSetLayout();
   void createPipelineLayout();
-  void createComputePipeline();
+  void createComputePipeline(uint32_t subgroupSize);
   void createDescriptorPool();
   void allocateDescriptorSets();
   void setWriteDescriptors();

--- a/pmlc/rt/vulkan/wrappers.cc
+++ b/pmlc/rt/vulkan/wrappers.cc
@@ -67,8 +67,9 @@ void createVulkanMemoryTransferAction(void *vkInvocation, uint64_t src_index,
                                    dst_binding);
 }
 
-void setVulkanLaunchKernelAction(void *vkInvocation) {
-  static_cast<VulkanInvocation *>(vkInvocation)->setLaunchKernelAction();
+void setVulkanLaunchKernelAction(void *vkInvocation, uint32_t subgroupSize) {
+  static_cast<VulkanInvocation *>(vkInvocation)
+      ->setLaunchKernelAction(subgroupSize);
 }
 
 void addVulkanLaunchActionToSchedule(void *vkInvocation) {

--- a/pmlc/target/intel_gen/affine_index_pack.cc
+++ b/pmlc/target/intel_gen/affine_index_pack.cc
@@ -36,8 +36,7 @@ struct AffineIndexPackPass : public AffineIndexPackBase<AffineIndexPackPass> {
     bool isThread = hasUnitTag(op, gpuThreadTag());
     bool isBlock = hasUnitTag(op, gpuBlockTag());
     bool isHardware = (isBlock || isThread);
-    auto subgroupSize = getIntegerTag(op, subgroupSizeTag(), 1);
-    unsigned maxDims = (isThread && subgroupSize > 1) ? 2 : 3;
+    unsigned maxDims = isThread ? 2 : 3;
     if (!isHardware ||
         (op.getIVs().size() <= maxDims && op.getIVs().size() != 0)) {
       // Doesn't need special handling

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -228,7 +228,7 @@ struct SubgroupBroadcastPass
     auto func = getFunction();
     func.walk([&](scf::ParallelOp op) {
       int64_t subgroupSize = getIntegerTag(op, subgroupSizeTag(), 1);
-      if (hasUnitTag(op, gpuThreadTag()) && subgroupSize > 1) {
+      if (hasUnitTag(op, gpuThreadTag())) {
         DevectorizeImpl impl(op, subgroupSize, useBlockOps.getValue());
         if (failed(impl.devectorize())) {
           signalPassFailure();


### PR DESCRIPTION
Use block.x as subgroup size of all kernels.  TODO: We should probably add support for subgroup size control to the upstream GPU dialect.