### PR TITLE
Fix some warnings that were causing errors building with the latest X…

### DIFF
--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -252,9 +252,9 @@ TEST_F(CppEdsl, BitXor) {
   std::vector<uint64_t> B_input{10, 11, 12,  //
                                 13, 14, 15,  //
                                 16, 17, 18};
-  std::vector<uint64_t> C_output{1 ^ 10, 2 ^ 11, 3 ^ 12,  //
-                                 4 ^ 13, 5 ^ 14, 6 ^ 15,  //
-                                 7 ^ 16, 8 ^ 17, 9 ^ 18};
+  std::vector<uint64_t> C_output{0x1 ^ 10, 0x2 ^ 11, 0x3 ^ 12,  //
+                                 0x4 ^ 13, 0x5 ^ 14, 0x6 ^ 15,  //
+                                 0x7 ^ 16, 0x8 ^ 17, 0x9 ^ 18};
   checkProgram(program, {{A, A_input}, {B, B_input}}, {{C, C_output}});
 }
 

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2905,7 +2905,7 @@ Value squeeze(const Value& value) {
     }
   }
   std::vector<Value> O_dims_values;
-  for (const auto& dim : O_dims) {
+  for (const TensorDim& dim : O_dims) {
     O_dims_values.push_back(Value{dim});
   }
   return reshape(make_tuple(Value{I}, Value{O_dims_values}));

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2905,7 +2905,7 @@ Value squeeze(const Value& value) {
     }
   }
   std::vector<Value> O_dims_values;
-  for (const auto dim : O_dims) {
+  for (const auto& dim : O_dims) {
     O_dims_values.push_back(Value{dim});
   }
   return reshape(make_tuple(Value{I}, Value{O_dims_values}));

--- a/pmlc/dialect/pxa/transforms/stencil.cc
+++ b/pmlc/dialect/pxa/transforms/stencil.cc
@@ -142,7 +142,7 @@ void StencilBase::RecursiveBindIndex(
     RecursiveTileIndex(TensorAndIndexPermutation(ioOps, boundIdxs),
                        currTileSize, 0);
   } else {
-    for (const auto &blockArg : getBlockArgsAsSet()) {
+    for (const auto blockArg : getBlockArgsAsSet()) {
       // Don't bind same index twice
       // Note: While it's awkward to be repeatedly searching a vector, I think
       // boundIdxs is small enough that it would not be efficient to maintain a

--- a/pmlc/dialect/tile/gradient.cc
+++ b/pmlc/dialect/tile/gradient.cc
@@ -84,7 +84,7 @@ void Gradient::ComputeOperandDerivs(mlir::Value val) {
   }
   if (mlir::isa<eltwise::EltwiseOp>(op)) {
     size_t idx = 0; // Need to track which operand we're at
-    for (const auto &operand : op->getOperands()) {
+    for (const auto operand : op->getOperands()) {
       auto dop = DeriveEltwise(grads_[val], val, idx);
       AddToGradient(operand, dop);
       idx++;
@@ -131,7 +131,7 @@ void Gradient::ComputeOperandDerivs(mlir::Value val) {
         "Unrecognized special operation, unable to differentiate");
   } else if (mlir::isa<DimOp>(op) || mlir::isa<eltwise::ScalarConstantOp>(op)) {
     auto dop = builder_->MakeScalarConstantOp(0.);
-    for (const auto &operand : op->getOperands()) {
+    for (const auto operand : op->getOperands()) {
       AddToGradient(operand, dop);
     }
   } else if (auto tmap_op = mlir::dyn_cast<AffineTensorMapOp>(op)) {
@@ -213,7 +213,7 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out,
         }
         new_srcs.push_back(src_op);
         std::vector<Value> dout_idxs;
-        for (const auto &dim :
+        for (const auto dim :
              llvm::cast<AffineMapOp>(op.sink().getDefiningOp()).dims()) {
           dout_idxs.push_back(dim);
         }
@@ -236,7 +236,7 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out,
         // This is the differentiated input; so swap in dout here to create the
         // new op
         std::vector<Value> dout_idxs;
-        for (const auto &dim :
+        for (const auto dim :
              llvm::cast<AffineMapOp>(op.sink().getDefiningOp()).dims()) {
           dout_idxs.push_back(dim);
         }
@@ -304,7 +304,7 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out,
     sizes.push_back(builder_->MakeDimOp(target_src_op.tensor(), i));
   }
   std::vector<mlir::Value> dsrc_idxs;
-  for (const auto &dim : target_src_op.dims()) {
+  for (const auto dim : target_src_op.dims()) {
     dsrc_idxs.push_back(dim);
   }
 
@@ -325,7 +325,7 @@ mlir::Value Gradient::DeriveContraction(mlir::Value dout, mlir::Value out,
   auto dst_cons =
       llvm::dyn_cast<AffineConstraintsOp>(dop.cons().getDefiningOp());
   mlir::SmallVector<mlir::Value, 6> pairs{src_cons.pairs()};
-  for (const auto &pair : src_cons.pairs()) {
+  for (const auto pair : src_cons.pairs()) {
     pairs.emplace_back(pair);
   }
   dst_cons.getOperation()->setOperands(pairs);

--- a/pmlc/rt/opencl/BUILD
+++ b/pmlc/rt/opencl/BUILD
@@ -9,4 +9,12 @@ cc_test(
     srcs = ["clprobe.cc"],
     deps = ["@opencl_icd_loader", "@opencl_hpp_headers"],
     size = "small",
+    copts = [
+      "-Werror",
+      "-Wimplicit-function-declaration",
+    ],
+    tags = [
+      "skip_macos",
+      "skip_windows",
+    ],
 )

--- a/pmlc/rt/opencl/BUILD
+++ b/pmlc/rt/opencl/BUILD
@@ -9,11 +9,8 @@ cc_test(
     srcs = ["clprobe.cc"],
     deps = ["@opencl_icd_loader", "@opencl_hpp_headers"],
     size = "small",
-    copts = [
-      "-Werror",
-      "-Wimplicit-function-declaration",
-    ],
     tags = [
+      "manual",
       "skip_macos",
       "skip_windows",
     ],

--- a/pmlc/rt/opencl/BUILD
+++ b/pmlc/rt/opencl/BUILD
@@ -9,9 +9,4 @@ cc_test(
     srcs = ["clprobe.cc"],
     deps = ["@opencl_icd_loader", "@opencl_hpp_headers"],
     size = "small",
-    tags = [
-      "manual",
-      "skip_macos",
-      "skip_windows",
-    ],
 )

--- a/vendor/opencl_icd_loader/opencl_icd_loader.BUILD
+++ b/vendor/opencl_icd_loader/opencl_icd_loader.BUILD
@@ -57,6 +57,7 @@ opencl_icd_loader_lnks = select({
 cc_library(
     name = "opencl_icd_loader",
     srcs = opencl_icd_loader_srcs,
+    copts = ["-w"],
     includes = ["loader"],
     linkopts = opencl_icd_loader_lnks,
     linkstatic = 1,


### PR DESCRIPTION
It appears the clang in the latest Xcode has better logic to detect copying caused by assigning a non reference return to a reference var.
    See below the exact fixes.
    Also, disabled the newly added opencl tests/build on MacOS and Windows - it was not building on MacOS, pulling linux header files.

    ERROR: /Users/llitchev/local/plaidml-v1/pmlc/dialect/pxa/transforms/BUILD:23:19: C++ compilation of rule '//pmlc/dialect/pxa/transforms:transforms' failed (Exit 1)
    pmlc/dialect/pxa/transforms/stencil.cc:145:22: error: loop variable 'blockArg' is always a copy because the range of type 'pmlc::dialect::pxa::BlockArgumentSet' (aka 'SmallPtrSet<mlir::BlockArgument, 8>') does not return a reference [-Werror,-Wrange-loop-analysis]
        for (const auto &blockArg : getBlockArgsAsSet()) {
                         ^
    pmlc/dialect/pxa/transforms/stencil.cc:145:10: note: use non-reference type 'mlir::BlockArgument'

    plaidml/op/lib/ops.cc:2908:19: error: loop variable 'dim' of type 'const plaidml::edsl::TensorDim' creates a copy from type 'const plaidml::edsl::TensorDim' [-Werror,-Wrange-loop-analysis]
      for (const auto dim : O_dims) {

    ERROR: /Users/llitchev/local/plaidml-v1/pmlc/dialect/tile/BUILD:7:19: C++ compilation of rule '//pmlc/dialect/tile:tile' failed (Exit 1)
    pmlc/dialect/tile/gradient.cc:87:22: error: loop variable 'operand' is always a copy because the range of type 'mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
        for (const auto &operand : op->getOperands()) {
                         ^
    pmlc/dialect/tile/gradient.cc:87:10: note: use non-reference type 'mlir::Value'
        for (const auto &operand : op->getOperands()) {
             ^~~~~~~~~~~~~~~~~~~~~
    pmlc/dialect/tile/gradient.cc:134:22: error: loop variable 'operand' is always a copy because the range of type 'mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
        for (const auto &operand : op->getOperands()) {
                         ^
    pmlc/dialect/tile/gradient.cc:134:10: note: use non-reference type 'mlir::Value'
        for (const auto &operand : op->getOperands()) {
             ^~~~~~~~~~~~~~~~~~~~~
    pmlc/dialect/tile/gradient.cc:216:26: error: loop variable 'dim' is always a copy because the range of type '::mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
            for (const auto &dim :
                             ^
    pmlc/dialect/tile/gradient.cc:216:14: note: use non-reference type 'mlir::Value'
            for (const auto &dim :
                 ^~~~~~~~~~~~~~~~~
    pmlc/dialect/tile/gradient.cc:239:26: error: loop variable 'dim' is always a copy because the range of type '::mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
            for (const auto &dim :
                             ^
    pmlc/dialect/tile/gradient.cc:239:14: note: use non-reference type 'mlir::Value'
            for (const auto &dim :
                 ^~~~~~~~~~~~~~~~~
    pmlc/dialect/tile/gradient.cc:307:20: error: loop variable 'dim' is always a copy because the range of type '::mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
      for (const auto &dim : target_src_op.dims()) {
                       ^
    pmlc/dialect/tile/gradient.cc:307:8: note: use non-reference type 'mlir::Value'
      for (const auto &dim : target_src_op.dims()) {
           ^~~~~~~~~~~~~~~~~
    pmlc/dialect/tile/gradient.cc:328:20: error: loop variable 'pair' is always a copy because the range of type '::mlir::Operation::operand_range' (aka 'mlir::OperandRange') does not return a reference [-Werror,-Wrange-loop-analysis]
      for (const auto &pair : src_cons.pairs()) {
                       ^
    pmlc/dialect/tile/gradient.cc:328:8: note: use non-reference type 'mlir::Value'
      for (const auto &pair : src_cons.pairs()) {
           ^~~~~~~~~~~~~~~~~~

    plaidml/edsl/tests/edsl_test.cc:255:44: error: result of '2 ^ 11' is 9; did you mean '1 << 11' (2048)? [-Werror,-Wxor-used-as-pow]
      std::vector<uint64_t> C_output{1 ^ 10, 2 ^ 11, 3 ^ 12,  //
                                             ~~^~~~
                                             1 << 11