### PR TITLE
[OpenCL] Add temporary sub-group size lowering

### DIFF
--- a/pmlc/target/intel_gen_ocl_spirv/pass_detail.h
+++ b/pmlc/target/intel_gen_ocl_spirv/pass_detail.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "mlir/Dialect/SPIRV/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace pmlc::target::intel_gen_ocl_spirv {

--- a/pmlc/target/intel_gen_ocl_spirv/passes.h
+++ b/pmlc/target/intel_gen_ocl_spirv/passes.h
@@ -11,6 +11,8 @@ namespace pmlc::target::intel_gen_ocl_spirv {
 
 std::unique_ptr<mlir::Pass> createAddSpirvTargetPass();
 
+std::unique_ptr<mlir::Pass> createSetSubgroupSizePass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "pmlc/target/intel_gen_ocl_spirv/passes.h.inc"

--- a/pmlc/target/intel_gen_ocl_spirv/passes.td
+++ b/pmlc/target/intel_gen_ocl_spirv/passes.td
@@ -10,4 +10,10 @@ def IntelGenOclAddSpirvTarget : Pass<"intel-gen-ocl-add-spirv-target", "mlir::Mo
   let dependentDialects = ["mlir::spirv::SPIRVDialect"];
 }
 
+def IntelGenOclSetSubgroupSize : Pass<"intel-gen-ocl-set-subgroup-size", "mlir::spirv::ModuleOp"> {
+  let summary = "Set sub-group size for each spirv module to first (x) block dimension";
+  let constructor = "pmlc::target::intel_gen_ocl_spirv::createSetSubgroupSizePass()";
+  let dependentDialects = ["mlir::spirv::SPIRVDialect"];
+}
+
 #endif // __PMLC_TARGET_INTEL_GEN__OCL_SPIRV_PASSES__

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -53,8 +53,8 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // Do subgroup or accumulation
-  // pm.addPass(pmlc::dialect::pxa::createSubgroupsPass());
-  pm.addPass(pmlc::dialect::pxa::createTileAccumulatePass());
+  pm.addPass(pmlc::dialect::pxa::createSubgroupsPass());
+  // pm.addPass(pmlc::dialect::pxa::createTileAccumulatePass());
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass(/*promote=*/false));
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
@@ -82,7 +82,7 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(dialect::stdx::createI1StorageToI32Pass());
 
   // Devectorize
-  // pm.addPass(createSubgroupBroadcastPass());
+  pm.addPass(pmlc::target::intel_gen::createSubgroupBroadcastPass());
   pm.addPass(createCSEPass());
 
   // Lower mapped scf.parallel's to GPU
@@ -110,6 +110,7 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(conversion::gpu_to_spirv::createGPUToSPIRVCustomPass());
 
   // SPIR-V passes for lowering attributes.
+  pm.addPass(createSetSubgroupSizePass());
   pm.addPass(spirv::createLowerABIAttributesPass());
   pm.addPass(spirv::createUpdateVersionCapabilityExtensionPass());
 

--- a/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
@@ -20,8 +20,9 @@ public:
         spirv::getTargetEnvAttrName());
     if (!target_env) {
       auto triple = spirv::VerCapExtAttr::get(
-          spirv::Version::V_1_0,
+          spirv::Version::V_1_1,
           {spirv::Capability::Kernel, spirv::Capability::Addresses,
+           spirv::Capability::Groups, spirv::Capability::SubgroupDispatch,
            spirv::Capability::Int64, spirv::Capability::Int16,
            spirv::Capability::Int8, spirv::Capability::Float64,
            spirv::Capability::Float16},

--- a/pmlc/target/intel_gen_ocl_spirv/sub_group_size.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/sub_group_size.cc
@@ -1,0 +1,65 @@
+// Copyright 2020, Intel Corporation
+
+#include "pmlc/target/intel_gen_ocl_spirv/pass_detail.h"
+#include "pmlc/target/intel_gen_ocl_spirv/passes.h"
+
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
+#include "mlir/Dialect/SPIRV/TargetAndABI.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
+
+namespace pmlc::target::intel_gen_ocl_spirv {
+namespace spirv = mlir::spirv;
+
+namespace {
+
+class IntelGenOclSetSubgroupSize
+    : public IntelGenOclSetSubgroupSizeBase<IntelGenOclSetSubgroupSize> {
+public:
+  /// Returns entry point function in module or nullptr if there is none.
+  spirv::FuncOp getEntryPoint(spirv::ModuleOp module) {
+    spirv::FuncOp func = nullptr;
+    module.walk([&](spirv::FuncOp op) {
+      if (!op.getAttr(spirv::getEntryPointABIAttrName()))
+        return mlir::WalkResult::advance();
+      func = op;
+      return mlir::WalkResult::interrupt();
+    });
+    return func;
+  }
+  /// Extracts local size attribute from entry point function.
+  mlir::DenseIntElementsAttr getLocalSize(spirv::FuncOp func) {
+    auto entryPointAttr = func.getAttrOfType<spirv::EntryPointABIAttr>(
+        spirv::getEntryPointABIAttrName());
+    if (!entryPointAttr)
+      return {};
+    return entryPointAttr.local_size();
+  }
+
+  void runOnOperation() {
+    spirv::ModuleOp module = getOperation();
+    spirv::FuncOp func = getEntryPoint(module);
+    if (!func)
+      return;
+    mlir::DenseIntElementsAttr localSize = getLocalSize(func);
+    if (!localSize)
+      return;
+    mlir::APInt localX = *localSize.begin();
+    if (localX == 1)
+      return;
+    // Insert ExecutionMode at the end.
+    int32_t localXi32 = static_cast<int32_t>(localX.getZExtValue());
+    auto builder = mlir::OpBuilder::atBlockTerminator(&module.getBlock());
+    builder.create<spirv::ExecutionModeOp>(func.getLoc(), func,
+                                           spirv::ExecutionMode::SubgroupSize,
+                                           mlir::ArrayRef<int32_t>{localXi32});
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> createSetSubgroupSizePass() {
+  return std::make_unique<IntelGenOclSetSubgroupSize>();
+}
+
+} // namespace pmlc::target::intel_gen_ocl_spirv

--- a/pmlc/target/intel_gen_ocl_spirv/tests/subgroup_size.mlir
+++ b/pmlc/target/intel_gen_ocl_spirv/tests/subgroup_size.mlir
@@ -1,0 +1,33 @@
+// RUN: pmlc-opt --intel-gen-ocl-set-subgroup-size %s | FileCheck %s
+
+spv.module @subgroup Physical64 OpenCL {
+  spv.func @kernel() "None" attributes {spv.entry_point_abi = {local_size = dense<[16, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+    spv.Return
+  }
+  // CHECK: spv.ExecutionMode @kernel "SubgroupSize", 16
+}
+
+spv.module @no_subgroup Physical64 OpenCL {
+  spv.func @kernel() "None" attributes {spv.entry_point_abi = {local_size = dense<[1, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+    spv.Return
+  }
+  // CHECK-NOT: spv.ExecutionMode @kernel "SubgroupSize"
+}
+
+spv.module @func_and_kernel Physical64 OpenCL {
+  spv.func @func() "None" {
+    spv.Return
+  }
+
+  spv.func @kernel() "None" attributes {spv.entry_point_abi = {local_size = dense<[32, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+    spv.Return
+  }
+  // CHECK: spv.ExecutionMode @kernel "SubgroupSize", 32
+}
+
+spv.module @only_func Physical64 OpenCL {
+  spv.func @func() "None" {
+    spv.Return
+  }
+  // CHECK-NOT: spv.ExecutionMode
+}


### PR DESCRIPTION
This change adds lowering for sub-group size based on first block
dimension, same as it is done for Vulkan.