### PR TITLE
Move -Wall to PlaidML code only

### DIFF
--- a/bzl/plaidml.bzl
+++ b/bzl/plaidml.bzl
@@ -13,6 +13,7 @@ PLAIDML_COPTS = select({
     ],
     "//conditions:default": [
         "-std=c++17",
+        "-Wall",
         "-Werror",
     ],
 })

--- a/toolchain/build_defs.bzl
+++ b/toolchain/build_defs.bzl
@@ -84,11 +84,9 @@ def _impl(ctx):
                     flag_group(
                         flags = [
                             "-fstack-protector",
-                            "-Wall",
-                            "-Wunused-but-set-parameter",
-                            "-Wno-free-nonheap-object",
-                            "-Wno-error=pragmas",
-                            "-Wno-unknown-pragmas",
+                            "-Wno-return-type",
+                            "-Wno-attributes",
+                            "-Wno-deprecated-declarations",
                             "-fno-omit-frame-pointer",
                         ],
                     ),


### PR DESCRIPTION
Hey, @flaub -- thoughts?  I was doing a build and watching the build warnings from the parts of the codebase we don't control; I'm thinking that maybe we should keep being strict about our own code, but maybe remove some of the noise coming from other components.