### PR TITLE
Add exactly-match option for fusion pass

### DIFF
--- a/pmlc/dialect/pxa/tests/fusion-match.mlir
+++ b/pmlc/dialect/pxa/tests/fusion-match.mlir
@@ -1,0 +1,34 @@
+// RUN: pmlc-opt -pxa-fusion="exactly-match=true" -pxa-normalize -canonicalize %s | FileCheck %s
+
+func @fusion_different_idxs(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3x4xf32>, %D: memref<2x3x4xf32>) -> memref<2x3x4xf32> {
+  %T = alloc() : memref<2x3xf32>
+  %4 = affine.parallel (%i, %j) = (0, 0) to (2, 3) reduce ("assign") -> (memref<2x3xf32>) {
+    %0 = pxa.load %A[%i, %j] : memref<2x3xf32>
+    %1 = pxa.load %B[%i, %j] : memref<2x3xf32>
+    %2 = addf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %T[%i, %j] : memref<2x3xf32>
+    affine.yield %3 : memref<2x3xf32>
+  }
+  %5 = affine.parallel (%i, %j, %k) = (0, 0, 0) to (2, 3, 4) reduce ("assign") -> (memref<2x3x4xf32>) {
+    %0 = pxa.load %4[%i, %j] : memref<2x3xf32>
+    %1 = pxa.load %C[%i, %j, %k] : memref<2x3x4xf32>
+    %2 = mulf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %D[%i, %j, %k] : memref<2x3x4xf32>
+    affine.yield %3 : memref<2x3x4xf32>
+  }
+  return %5 : memref<2x3x4xf32>
+}
+
+// CHECK-LABEL: func @fusion_different_idxs
+// CHECK:       affine.parallel (%{{.*}}, %{{.*}}) = (0, 0) to (2, 3)
+// CHECK:         pxa.load
+// CHECK:         pxa.load
+// CHECK:         addf
+// CHECK:         pxa.reduce
+// CHECK:         affine.yield
+// CHECK:       affine.parallel (%{{.*}}, %{{.*}}, %{{.*}}) = (0, 0, 0) to (2, 3, 4)
+// CHECK:         pxa.load
+// CHECK:         pxa.load
+// CHECK:         mulf
+// CHECK:         pxa.reduce
+// CHECK:         affine.yield

--- a/pmlc/dialect/pxa/tests/fusion.mlir
+++ b/pmlc/dialect/pxa/tests/fusion.mlir
@@ -34,6 +34,41 @@ func @simple_fusion(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3xf32
 
 // -----
 
+func @fusion_different_idxs(%A: memref<2x3xf32>, %B: memref<2x3xf32>, %C: memref<2x3x4xf32>, %D: memref<2x3x4xf32>) -> memref<2x3x4xf32> {
+  %T = alloc() : memref<2x3xf32>
+  %4 = affine.parallel (%i, %j) = (0, 0) to (2, 3) reduce ("assign") -> (memref<2x3xf32>) {
+    %0 = pxa.load %A[%i, %j] : memref<2x3xf32>
+    %1 = pxa.load %B[%i, %j] : memref<2x3xf32>
+    %2 = addf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %T[%i, %j] : memref<2x3xf32>
+    affine.yield %3 : memref<2x3xf32>
+  }
+  %5 = affine.parallel (%i, %j, %k) = (0, 0, 0) to (2, 3, 4) reduce ("assign") -> (memref<2x3x4xf32>) {
+    %0 = pxa.load %4[%i, %j] : memref<2x3xf32>
+    %1 = pxa.load %C[%i, %j, %k] : memref<2x3x4xf32>
+    %2 = mulf %0, %1 : f32
+    %3 = pxa.reduce assign %2, %D[%i, %j, %k] : memref<2x3x4xf32>
+    affine.yield %3 : memref<2x3x4xf32>
+  }
+  return %5 : memref<2x3x4xf32>
+}
+
+// CHECK-LABEL: func @fusion_different_idxs
+// CHECK:       affine.parallel (%{{.*}}, %{{.*}}) = (0, 0) to (2, 3)
+// CHECK:         pxa.load
+// CHECK:         pxa.load
+// CHECK:         addf
+// CHECK:         pxa.reduce
+// CHECK:         affine.parallel (%{{.*}}) = (0) to (4)
+// CHECK:           pxa.load
+// CHECK:           pxa.load
+// CHECK:           mulf
+// CHECK:           pxa.reduce
+// CHECK:           affine.yield
+// CHECK:         affine.yield
+
+// -----
+
 func @resnet50_tail(%arg0: memref<1000xf32>, %arg1: memref<1x1000xf32>, %out: memref<1x1000xf32>) -> memref<1x1000xf32> {
   %cst = constant 0xFF800000 : f32
   %cst_1 = constant 0.000000e+00 : f32

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -27,7 +27,7 @@ std::unique_ptr<mlir::Pass> createBufferPlacementPass();
 std::unique_ptr<mlir::Pass> createCachePass();
 
 std::unique_ptr<mlir::Pass>
-createFusionPass(int64_t memoryActivityThreshold = 0);
+createFusionPass(int64_t memoryActivityThreshold = 0, bool exactlyMatch = false);
 
 std::unique_ptr<mlir::Pass> createGPUThreadPass();
 std::unique_ptr<mlir::Pass> createGPUThreadPass(unsigned maxThreads);

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -55,7 +55,10 @@ def Fusion : FunctionPass<"pxa-fusion"> {
     Option<"memoryActivityThreshold", "mem-threshold", "int64_t",
            /*default=*/"0",
            "Prevent over-fusion by specifying the maximum memory activity "
-           "(alloc, read, write) allowed">
+           "(alloc, read, write) allowed">,
+    Option<"exactlyMatch", "exactly-match", "bool",
+           /*default=*/"false",
+           "Whether fuse the loops with exactly matched indices">,
   ];
 }
 


### PR DESCRIPTION
If exactly-match is true, fuse the loops with only exactly matched indices. The default value is false.
In GRN case, apply one fusion pass with exactly-match==true and another pass with exactly-match==false. It would fuse GRN as a single big loop.