### PR TITLE
[comp] Add pass to reduce number of device allocations

### DIFF
--- a/pmlc/dialect/comp/tests/minimize_allocations.mlir
+++ b/pmlc/dialect/comp/tests/minimize_allocations.mlir
@@ -1,0 +1,58 @@
+// RUN: pmlc-opt --comp-minimize-allocations --allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-LABEL: func @two_wo_host
+//  CHECK-SAME:     %[[ENV:[a-zA-Z0-9]*]]: !comp.execenv
+//       CHECK:   %[[MEM:.*]] = comp.alloc %[[ENV]]
+//  CHECK-NEXT:   "op1"(%[[MEM]])
+//  CHECK-NEXT:   "op2"(%[[MEM]])
+//  CHECK-NEXT:   comp.dealloc %[[ENV]] %[[MEM]]
+func @two_wo_host(%env: !comp.execenv<ocl:0,(11)>) {
+  %mem1 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  "op1"(%mem1) : (memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+
+  %mem2 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  "op2"(%mem2) : (memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem2 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+  return
+}
+
+// CHECK-LABEL: func @two_with_host
+//  CHECK-SAME:     %[[ENV:[a-zA-Z0-9]*]]: !comp.execenv
+//  CHECK-SAME:     %[[ARG:[a-zA-Z0-9]*]]: memref
+//       CHECK:   %[[MEM:.*]] = comp.alloc %[[ENV]] %[[ARG]]
+//  CHECK-NEXT:   "op1"(%[[MEM]])
+//  CHECK-NEXT:   %[[WEV:.*]] = comp.schedule_write %[[ARG]] to %[[MEM]]
+//  CHECK-NEXT:   comp.wait %[[WEV]]
+//  CHECK-NEXT:   "op2"(%[[MEM]])
+//  CHECK-NEXT:   comp.dealloc %[[ENV]] %[[MEM]]
+func @two_with_host(%env: !comp.execenv<ocl:0,(11)>, %arg: memref<2x3xf32>) {
+  %mem1 = comp.alloc %env %arg : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  "op1"(%mem1) : (memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+
+  %mem2 = comp.alloc %env %arg : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  "op2"(%mem2) : (memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem2 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+  return
+}
+
+// CHECK-LABEL: func @three_overlaping
+//  CHECK-SAME:     %[[ENV:[a-zA-Z0-9]*]]: !comp.execenv
+//       CHECK:   %[[MEM1:.*]] = comp.alloc %[[ENV]]
+//       CHECK:   %[[MEM2:.*]] = comp.alloc %[[ENV]]
+//       CHECK:   "op1"(%[[MEM1]], %[[MEM2]])
+//       CHECK:   "op2"(%[[MEM2]], %[[MEM1]])
+//   CHECK-DAG:   comp.dealloc %[[ENV]] %[[MEM1]]
+//   CHECK-DAG:   comp.dealloc %[[ENV]] %[[MEM2]]
+func @three_overlaping(%env: !comp.execenv<ocl:0,(11)>) {
+  %mem1 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %mem2 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  "op1"(%mem1, %mem2) :  (memref<2x3xf32, 11>, memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+  %mem3 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  "op2"(%mem2, %mem3) :  (memref<2x3xf32, 11>, memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem2 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+  comp.dealloc %env %mem3 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
+  return
+}

--- a/pmlc/dialect/comp/transforms/BUILD
+++ b/pmlc/dialect/comp/transforms/BUILD
@@ -25,6 +25,7 @@ plaidml_cc_library(
     srcs = [
         "execenv_coalescing.cc",
         "pass_detail.h",
+        "minimize_allocations.cc",
     ],
     hdrs = [
         "passes.h",

--- a/pmlc/dialect/comp/transforms/minimize_allocations.cc
+++ b/pmlc/dialect/comp/transforms/minimize_allocations.cc
@@ -1,0 +1,96 @@
+// Copyright 2020 Intel Corporation
+
+#include <unordered_map>
+
+#include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
+
+#include "pmlc/dialect/comp/ir/dialect.h"
+#include "pmlc/dialect/comp/transforms/pass_detail.h"
+#include "pmlc/dialect/comp/transforms/passes.h"
+
+namespace pmlc::dialect::comp {
+
+namespace {
+
+template <typename T>
+class LLVMHash {
+public:
+  llvm::hash_code operator()(const T &val) const {
+    return llvm::hash_value(val);
+  }
+};
+
+/// Performs very greedy linear scan for memory reuse opportunities.
+/// Does not check any interference for Out-of-Order execution.
+void greedyInPlaceReuse(mlir::Block &block) {
+  auto builder = mlir::OpBuilder::atBlockBegin(&block);
+  // Replaces Alloc `op` with already allocated `memory`.
+  // Inserts copying of host memory if needed.
+  auto replaceAlloc = [&](Alloc op, mlir::Value memory) {
+    if (mlir::Value hostMem = op.hostMem()) {
+      builder.setInsertionPoint(op);
+      mlir::Value execEnv = op.execEnv();
+      ExecEnvType execEnvType = execEnv.getType().cast<ExecEnvType>();
+      EventType eventType = execEnvType.getEventType();
+      mlir::Value event = builder.create<ScheduleWrite>(
+          op.getLoc(), eventType, hostMem, memory, execEnv, mlir::ValueRange{});
+      builder.create<Wait>(op.getLoc(), event);
+    }
+    op.replaceAllUsesWith(memory);
+    op.erase();
+  };
+  // Map used to store deallocated memory. After processing Dealloc op it is
+  // assumed that further operations can safely reuse it.
+  using EnvMemTypePair = std::pair<mlir::Value, mlir::MemRefType>;
+  std::unordered_multimap<EnvMemTypePair, Dealloc, LLVMHash<EnvMemTypePair>>
+      deallocated;
+  // Constructs deallocated map key from Dealloc `op`.
+  auto getDeallocKey = [](Dealloc op) {
+    mlir::Value execEnv = op.execEnv();
+    mlir::Value memory = op.deviceMem();
+    auto memoryType = memory.getType().cast<mlir::MemRefType>();
+    return std::make_pair(execEnv, memoryType);
+  };
+  // Constructs deallocated map key from Alloc `op`.
+  auto getAllocKey = [](Alloc op) {
+    mlir::Value execEnv = op.execEnv();
+    auto memoryType = op.getType().cast<mlir::MemRefType>();
+    return std::make_pair(execEnv, memoryType);
+  };
+
+  for (mlir::Operation &operation : llvm::make_early_inc_range(block)) {
+    if (auto deallocOp = mlir::dyn_cast<Dealloc>(operation)) {
+      EnvMemTypePair key = getDeallocKey(deallocOp);
+      deallocated.emplace(key, deallocOp);
+    }
+    if (auto allocOp = mlir::dyn_cast<Alloc>(operation)) {
+      EnvMemTypePair key = getAllocKey(allocOp);
+      auto deallocIt = deallocated.find(key);
+      if (deallocIt != deallocated.end()) {
+        Dealloc deallocOp = deallocIt->second;
+        replaceAlloc(allocOp, deallocOp.deviceMem());
+        deallocOp.erase();
+        deallocated.erase(deallocIt);
+      }
+    }
+  }
+}
+
+class MinimizeAllocationsPass final
+    : public MinimizeAllocationsBase<MinimizeAllocationsPass> {
+public:
+  void runOnFunction() {
+    mlir::FuncOp func = getFunction();
+    for (mlir::Block &block : func) {
+      greedyInPlaceReuse(block);
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> createMinimizeAllocationsPass() {
+  return std::make_unique<MinimizeAllocationsPass>();
+}
+
+} // namespace pmlc::dialect::comp

--- a/pmlc/dialect/comp/transforms/passes.h
+++ b/pmlc/dialect/comp/transforms/passes.h
@@ -13,6 +13,8 @@ namespace pmlc::dialect::comp {
 
 std::unique_ptr<mlir::Pass> createExecEnvCoalescingPass();
 
+std::unique_ptr<mlir::Pass> createMinimizeAllocationsPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "pmlc/dialect/comp/transforms/passes.h.inc"

--- a/pmlc/dialect/comp/transforms/passes.td
+++ b/pmlc/dialect/comp/transforms/passes.td
@@ -40,4 +40,9 @@ def ExecEnvCoalescing : FunctionPass<"comp-execenv-coalescing"> {
   let constructor = "pmlc::dialect::comp::createExecEnvCoalescingPass()";
 }
 
+def MinimizeAllocations : FunctionPass<"comp-minimize-allocations"> {
+  let summary = "Minimize number and total size of memory allocations on device";
+  let constructor = "pmlc::dialect::comp::createMinimizeAllocationsPass()";
+}
+
 #endif // __PMLC_DIALECT_COMP_TRANSFORMS__

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -105,6 +105,7 @@ void pipelineBuilder(OpPassManager &pm) {
     pm.addPass(std::move(convertPass));
   }
   pm.addPass(comp::createExecEnvCoalescingPass());
+  pm.addPass(comp::createMinimizeAllocationsPass());
 
   // GPU to SPIR-V.
   pm.addPass(createLegalizeStdOpsForSPIRVLoweringPass());


### PR DESCRIPTION
This is very rough and naive first attempt at solving this problem.
In ResNet-50 this reduces number of `comp.alloc` ops from 716 down to 72.