### PR TITLE
Add and integrate UnrollLoop pass in the intel_gen pipeline.

### DIFF
--- a/pmlc/target/intel_gen/BUILD
+++ b/pmlc/target/intel_gen/BUILD
@@ -37,6 +37,7 @@ plaidml_cc_library(
         "//pmlc/dialect/tile/transforms",
         "//pmlc/rt/vulkan",
         "//pmlc/target/x86:prng_lowering",
+        "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:AffineToStandardTransforms",
         "@llvm-project//mlir:GPUToSPIRVTransforms",
         "@llvm-project//mlir:GPUToVulkanTransforms",

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -7,6 +7,7 @@
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h"
+#include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/GPU/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SPIRV/Passes.h"
@@ -145,6 +146,14 @@ void pipelineBuilder(OpPassManager &pm) {
 
   // Lower out of PXA memory semantics
   pm.addPass(createLowerPXAToAffinePass());
+
+  // Unroll affine.for loops.
+  pm.addPass(createLoopUnrollPass(
+                      /*unrollFactor=*/6,
+                      /*unrollUpToFactor=*/true,
+                      /*unrollFull=*/true));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
 
   // Pack dims
   pm.addPass(createAffineIndexPackPass());

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -150,8 +150,7 @@ void pipelineBuilder(OpPassManager &pm) {
   // Unroll affine.for loops.
   pm.addPass(createLoopUnrollPass(
                       /*unrollFactor=*/6,
-                      /*unrollUpToFactor=*/true,
-                      /*unrollFull=*/true));
+                      /*unrollUpToFactor=*/true));
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 


### PR DESCRIPTION
The loop unrolling gives the following benefits (specific run numbers below):
resnetLayer1: 2.7 %
resnetLayer2: 3.4 %
Whole resnet50: 3.3 %

Layer1:
======
W/t LoopUnroll
2020-10-07 23:47:40,207 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:47:40,243 VERBOSE-1 [default] Overall Vulkan time: 6.01925ms
2020-10-07 23:47:40,243 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:47:40,243 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.7215ms
2020-10-07 23:47:40,243 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.44%
2020-10-07 23:47:40,243 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:47:40,243 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.29775ms
2020-10-07 23:47:40,243 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.56%
2020-10-07 23:47:40,250 VERBOSE-1 [default] Execution time: 27.3642ms
ok

2020-10-07 23:48:04,918 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:48:04,955 VERBOSE-1 [default] Overall Vulkan time: 6.12625ms
2020-10-07 23:48:04,955 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:48:04,955 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.80067ms
2020-10-07 23:48:04,955 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.3622%
2020-10-07 23:48:04,955 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:48:04,955 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.32558ms
2020-10-07 23:48:04,955 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.6378%
2020-10-07 23:48:04,961 VERBOSE-1 [default] Execution time: 26.7437ms
ok

2020-10-07 23:48:25,754 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:48:25,790 VERBOSE-1 [default] Overall Vulkan time: 6.001ms
2020-10-07 23:48:25,790 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:48:25,790 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.42383ms
2020-10-07 23:48:25,790 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 73.7183%
2020-10-07 23:48:25,790 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:48:25,790 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.57717ms
2020-10-07 23:48:25,790 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 26.2817%
2020-10-07 23:48:25,794 VERBOSE-1 [default] Execution time: 24.0713ms
ok

2020-10-07 23:48:54,683 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:48:54,719 VERBOSE-1 [default] Overall Vulkan time: 6.00358ms
2020-10-07 23:48:54,719 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:48:54,719 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.71267ms
2020-10-07 23:48:54,719 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.4976%
2020-10-07 23:48:54,719 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:48:54,719 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.29092ms
2020-10-07 23:48:54,719 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.5024%
2020-10-07 23:48:54,726 VERBOSE-1 [default] Execution time: 26.6695ms
ok

2020-10-07 23:49:11,742 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:49:11,778 VERBOSE-1 [default] Overall Vulkan time: 6.03842ms
2020-10-07 23:49:11,778 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:49:11,778 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.71308ms
2020-10-07 23:49:11,778 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.0516%
2020-10-07 23:49:11,778 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:49:11,778 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.32533ms
2020-10-07 23:49:11,778 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.9484%
2020-10-07 23:49:11,782 VERBOSE-1 [default] Execution time: 24.1025ms
ok

No unroll: 25.79024

With LoopUnroll

2020-10-07 23:50:01,699 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:50:01,736 VERBOSE-1 [default] Overall Vulkan time: 6.00075ms
2020-10-07 23:50:01,736 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:50:01,736 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.70567ms
2020-10-07 23:50:01,736 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.418%
2020-10-07 23:50:01,736 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:50:01,736 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.29508ms
2020-10-07 23:50:01,736 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.582%
2020-10-07 23:50:01,742 VERBOSE-1 [default] Execution time: 26.0916ms
ok

2020-10-07 23:50:19,855 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:50:19,892 VERBOSE-1 [default] Overall Vulkan time: 6.02508ms
2020-10-07 23:50:19,892 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:50:19,892 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.7225ms
2020-10-07 23:50:19,892 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.3807%
2020-10-07 23:50:19,892 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:50:19,892 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.30258ms
2020-10-07 23:50:19,892 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.6193%
2020-10-07 23:50:19,896 VERBOSE-1 [default] Execution time: 24.609ms
ok

2020-10-07 23:50:36,747 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:50:36,784 VERBOSE-1 [default] Overall Vulkan time: 6.01642ms
2020-10-07 23:50:36,784 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:50:36,784 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.72708ms
2020-10-07 23:50:36,784 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.5697%
2020-10-07 23:50:36,784 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:50:36,784 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.28933ms
2020-10-07 23:50:36,784 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.4303%
2020-10-07 23:50:36,788 VERBOSE-1 [default] Execution time: 24.0787ms
ok

2020-10-07 23:50:52,434 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:50:52,474 VERBOSE-1 [default] Overall Vulkan time: 8.41958ms
2020-10-07 23:50:52,474 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:50:52,474 VERBOSE-1 [default] Total Vulkan kernel exec time: 6.607ms
2020-10-07 23:50:52,474 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.4718%
2020-10-07 23:50:52,474 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:50:52,474 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.81258ms
2020-10-07 23:50:52,474 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.5282%
2020-10-07 23:50:52,478 VERBOSE-1 [default] Execution time: 26.5819ms
ok

2020-10-07 23:51:48,350 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:51:48,387 VERBOSE-1 [default] Overall Vulkan time: 6.02033ms
2020-10-07 23:51:48,387 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:51:48,387 VERBOSE-1 [default] Total Vulkan kernel exec time: 4.69767ms
2020-10-07 23:51:48,387 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 78.03%
2020-10-07 23:51:48,387 VERBOSE-1 [default] Total Vulkan memory transfers: 5
2020-10-07 23:51:48,387 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 1.32267ms
2020-10-07 23:51:48,387 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 21.97%
2020-10-07 23:51:48,391 VERBOSE-1 [default] Execution time: 24.1228ms
ok

Unroll: 25.0968

Benefit of loop unrolling: 2.7%

Layer2
=====
W/t LoopUnroll
2020-10-07 23:57:50,337 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:57:50,366 VERBOSE-1 [default] Overall Vulkan time: 2.41033ms
2020-10-07 23:57:50,366 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:57:50,366 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.73333ms
2020-10-07 23:57:50,366 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 71.9126%
2020-10-07 23:57:50,366 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:57:50,366 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.677ms
2020-10-07 23:57:50,366 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 28.0874%
2020-10-07 23:57:50,368 VERBOSE-1 [default] Execution time: 13.231ms
ok

2020-10-07 23:58:30,625 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:58:30,654 VERBOSE-1 [default] Overall Vulkan time: 2.49383ms
2020-10-07 23:58:30,654 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:58:30,654 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.79592ms
2020-10-07 23:58:30,654 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.0143%
2020-10-07 23:58:30,654 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:58:30,654 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.697917ms
2020-10-07 23:58:30,654 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.9857%
2020-10-07 23:58:30,658 VERBOSE-1 [default] Execution time: 14.8424ms
ok

2020-10-07 23:58:47,570 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:58:47,599 VERBOSE-1 [default] Overall Vulkan time: 3.32108ms
2020-10-07 23:58:47,599 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:58:47,599 VERBOSE-1 [default] Total Vulkan kernel exec time: 2.35108ms
2020-10-07 23:58:47,599 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 70.7927%
2020-10-07 23:58:47,599 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:58:47,599 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.97ms
2020-10-07 23:58:47,599 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 29.2073%
2020-10-07 23:58:47,602 VERBOSE-1 [default] Execution time: 14.2589ms
ok

2020-10-07 23:59:03,171 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:59:03,199 VERBOSE-1 [default] Overall Vulkan time: 2.39867ms
2020-10-07 23:59:03,199 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:59:03,199 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.71742ms
2020-10-07 23:59:03,199 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 71.5988%
2020-10-07 23:59:03,199 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:59:03,199 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.68125ms
2020-10-07 23:59:03,199 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 28.4012%
2020-10-07 23:59:03,202 VERBOSE-1 [default] Execution time: 13.3173ms
ok

2020-10-07 23:59:34,693 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:59:34,722 VERBOSE-1 [default] Overall Vulkan time: 2.45408ms
2020-10-07 23:59:34,722 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:59:34,722 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.77858ms
2020-10-07 23:59:34,722 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.4744%
2020-10-07 23:59:34,722 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:59:34,722 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.6755ms
2020-10-07 23:59:34,722 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.5256%
2020-10-07 23:59:34,724 VERBOSE-1 [default] Execution time: 13.2525ms
ok

No Unroll: 13.7804

With LoopUnroll
2020-10-07 23:53:02,767 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:53:02,796 VERBOSE-1 [default] Overall Vulkan time: 2.4655ms
2020-10-07 23:53:02,796 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:53:02,796 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.78042ms
2020-10-07 23:53:02,796 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.2132%
2020-10-07 23:53:02,796 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:53:02,796 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.685083ms
2020-10-07 23:53:02,796 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.7868%
2020-10-07 23:53:02,799 VERBOSE-1 [default] Execution time: 13.4563ms
ok

2020-10-07 23:53:32,999 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:53:33,028 VERBOSE-1 [default] Overall Vulkan time: 2.47742ms
2020-10-07 23:53:33,028 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:53:33,028 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.79242ms
2020-10-07 23:53:33,028 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.3502%
2020-10-07 23:53:33,028 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:53:33,028 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.685ms
2020-10-07 23:53:33,028 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.6498%
2020-10-07 23:53:33,030 VERBOSE-1 [default] Execution time: 13.3351ms
ok

2020-10-07 23:53:50,256 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:53:50,285 VERBOSE-1 [default] Overall Vulkan time: 2.46942ms
2020-10-07 23:53:50,285 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:53:50,285 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.78533ms
2020-10-07 23:53:50,285 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.2978%
2020-10-07 23:53:50,285 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:53:50,285 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.684083ms
2020-10-07 23:53:50,285 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.7022%
2020-10-07 23:53:50,287 VERBOSE-1 [default] Execution time: 13.3254ms
ok

2020-10-07 23:54:16,616 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:54:16,644 VERBOSE-1 [default] Overall Vulkan time: 2.42458ms
2020-10-07 23:54:16,644 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:54:16,644 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.75417ms
2020-10-07 23:54:16,644 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 72.3492%
2020-10-07 23:54:16,644 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:54:16,644 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.670417ms
2020-10-07 23:54:16,644 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 27.6508%
2020-10-07 23:54:16,647 VERBOSE-1 [default] Execution time: 13.2743ms
ok

2020-10-07 23:54:42,915 VERBOSE-1 [default] JITing for device: vulkan.0
2020-10-07 23:54:42,944 VERBOSE-1 [default] Overall Vulkan time: 2.40008ms
2020-10-07 23:54:42,944 VERBOSE-1 [default] Total Vulkan kernels: 6
2020-10-07 23:54:42,944 VERBOSE-1 [default] Total Vulkan kernel exec time: 1.72408ms
2020-10-07 23:54:42,944 VERBOSE-1 [default] Percentage Vulkan kernel exec time: 71.8343%
2020-10-07 23:54:42,944 VERBOSE-1 [default] Total Vulkan memory transfers: 6
2020-10-07 23:54:42,944 VERBOSE-1 [default] Total (esimtated) Vulkan memory transfer time: 0.676ms
2020-10-07 23:54:42,944 VERBOSE-1 [default] Percentage (estimated) Vulkan memory transfer time: 28.1657%
2020-10-07 23:54:42,946 VERBOSE-1 [default] Execution time: 13.167ms
ok

Unroll: 13.31162

Benefit of loop unroll: 3.4%

Resnet50
=======
W/t LoopUnroll
resnet50             701.96 ms                 701.96 ms / 1.42 fps
resnet50             714.43 ms                 714.43 ms / 1.40 fps
resnet50             701.14 ms                 701.14 ms / 1.43 fps
resnet50             718.44 ms                 718.44 ms / 1.39 fps
resnet50             719.96 ms                 719.96 ms / 1.39 fps

No unroll: 711,186

With LoopUnroll
resnet50             684.99 ms                 684.99 ms / 1.46 fps
resnet50             690.78 ms                 690.78 ms / 1.45 fps
resnet50             685.76 ms                 685.76 ms / 1.46 fps
resnet50             685.63 ms                 685.63 ms / 1.46 fps
resnet50             689.97 ms                 689.97 ms / 1.45 fps

Unroll: 687.426

Benefit of loop unrolling: 3.3%