### PR TITLE
[edsl] Add support for layout-agnostic ops

### DIFF
--- a/plaidml/core/ffi.cc
+++ b/plaidml/core/ffi.cc
@@ -228,30 +228,16 @@ plaidml_datatype plaidml_shape_get_dtype(  //
 plaidml_integers* plaidml_shape_get_sizes(  //
     plaidml_error* err,                     //
     plaidml_shape* shape) {
-  return ffi_wrap<plaidml_integers*>(err, 0, [&] {
-    const auto& sizes = shape->shape.sizes;
-    auto ret = new plaidml_integers{sizes.size(), new int64_t[sizes.size()]};
-    for (unsigned i = 0; i < sizes.size(); i++) {
-      if (sizes[i] < 0) {
-        ret->elts[i] = 0;
-      } else {
-        ret->elts[i] = sizes[i];
-      }
-    }
-    return ret;
+  return ffi_wrap<plaidml_integers*>(err, nullptr, [&] {  //
+    return ffi_vector<plaidml_integers>(shape->shape.sizes);
   });
 }
 
 plaidml_integers* plaidml_shape_get_strides(  //
     plaidml_error* err,                       //
     plaidml_shape* shape) {
-  return ffi_wrap<plaidml_integers*>(err, 0, [&] {
-    const auto& strides = shape->shape.strides;
-    auto ret = new plaidml_integers{strides.size(), new int64_t[strides.size()]};
-    for (unsigned i = 0; i < strides.size(); i++) {
-      ret->elts[i] = strides[i];
-    }
-    return ret;
+  return ffi_wrap<plaidml_integers*>(err, nullptr, [&] {  //
+    return ffi_vector<plaidml_integers>(shape->shape.strides);
   });
 }
 

--- a/plaidml/core/internal.h
+++ b/plaidml/core/internal.h
@@ -83,6 +83,18 @@ ResultT* ffi_vector(const std::vector<T>& vec) {
   return result.release();
 }
 
+template <typename ResultT>
+ResultT* ffi_vector(const std::vector<int64_t>& vec) {
+  std::unique_ptr<int64_t[]> elts{new int64_t[vec.size()]};
+  auto result = std::make_unique<ResultT>();
+  for (size_t i = 0; i < vec.size(); i++) {
+    elts[i] = vec[i];
+  }
+  result->size = vec.size();
+  result->elts = elts.release();
+  return result.release();
+}
+
 plaidml_datatype convertIntoDataType(pmlc::util::DataType type);
 pmlc::util::DataType convertFromDataType(plaidml_datatype dtype);
 

--- a/plaidml/edsl/__init__.py
+++ b/plaidml/edsl/__init__.py
@@ -49,9 +49,6 @@ class TensorDim(ForeignObject):
             expr = ffi_call(lib.plaidml_dim_expr_none)
         super(TensorDim, self).__init__(expr)
 
-    def _bind(self, expr):
-        self.take_ptr(expr)
-
     def __neg__(self):
         """Negates a TensorDim in a polynomial expression.
 
@@ -300,9 +297,30 @@ class TensorIndex(ForeignObject):
         return TensorIndex(_poly_op(lib.PLAIDML_INT_OP_DIV, lhs, self))
 
 
+class TensorLens(object):
+
+    def __init__(self, source='', target=''):
+        self.map = []
+        if len(source) != len(target):
+            raise ValueError('source and target rank mismatch')
+        for i in range(len(source)):
+            pos = target.find(source[i])
+            if pos == -1:
+                raise ValueError('source and target dims mismatch')
+            self.map.append(pos)
+
+    def apply(self, dims):
+        if len(self.map) == 0:
+            return dims
+        if len(dims) != len(self.map):
+            raise ValueError('rank mismatch in TensorLens apply')
+        return [dims[x] for x in self.map]
+
+
 class Contraction(object):
 
-    def __init__(self, name=''):
+    def __init__(self, lens=TensorLens(), name=''):
+        self.__lens = lens
         self.__name = name
         self.__outDims = []
         self.__outIdxs = []
@@ -399,10 +417,10 @@ class Contraction(object):
             return [idxs]
 
         dims = [_wrap_dim(x) for x in self.__outDims]
-        raw_dims = [x.as_ptr() for x in dims]
+        raw_dims = [x.as_ptr() for x in self.__lens.apply(dims)]
 
         idxs = [_wrap_poly(x) for x in make_list(self.__outIdxs)]
-        raw_idxs = [x.as_ptr() for x in idxs]
+        raw_idxs = [x.as_ptr() for x in self.__lens.apply(idxs)]
 
         init = ffi.NULL
         if self.__init:
@@ -426,7 +444,7 @@ class Contraction(object):
 
         for operand in operands:
             idxs = [_wrap_poly(x) for x in make_list(operand._idxs)]
-            raw_idxs = [x.as_ptr() for x in idxs]
+            raw_idxs = [x.as_ptr() for x in operand._ref._lens.apply(idxs)]
             ffi_call(
                 lib.plaidml_contraction_add_operand,
                 tensor.as_ptr(),
@@ -494,8 +512,8 @@ class Tensor(ForeignObject):
     __ffi_del__ = lib.plaidml_expr_free
     __ffi_repr__ = lib.plaidml_expr_repr
 
-    def __init__(self, expr=None, value=None, name=''):
-        self._name = name
+    def __init__(self, expr=None, value=None, lens=TensorLens()):
+        self._lens = lens
         if value is not None:
             if isinstance(value, six.integer_types):
                 expr = ffi_call(lib.plaidml_expr_int, value)
@@ -626,25 +644,14 @@ class Tensor(ForeignObject):
 
     # Verify that the specified dims match the dims of this tensor.
     def bind_dims(self, *dims):
-        raw_dims = [x.as_ptr() for x in dims]
+        raw_dims = [x.as_ptr() for x in self._lens.apply(dims)]
         self._methodcall(lib.plaidml_expr_bind_dims, len(raw_dims), raw_dims)
 
     def element(self, ordinal):
         return Tensor(expr=self._methodcall(lib.plaidml_expr_element, ordinal))
 
-
-class TensorRef:
-
-    def __init__(self, tensor):
-        self.tensor = tensor
-
-    def __hash__(self):
-        return hash(ffi_call(lib.plaidml_expr_ptr, self.tensor.as_ptr()))
-
-    def __eq__(self, other):
-        if isinstance(other, Tensor):
-            return self.__hash__() == TensorRef(other).__hash__()
-        return self.__hash__() == other.__hash__()
+    def use(self, lens):
+        return Tensor(expr=self._methodcall(lib.plaidml_expr_clone), lens=lens)
 
 
 class Value(ForeignObject):

--- a/plaidml/edsl/__init__.py
+++ b/plaidml/edsl/__init__.py
@@ -14,14 +14,6 @@ from plaidml.ffi import ForeignObject, ffi, ffi_call, lib
 
 logger = logging.getLogger(__name__)
 
-
-def __init():
-    """Initializes the PlaidML EDSL API."""
-    ffi_call(lib.plaidml_edsl_init)
-
-
-ffi.init_once(__init, 'plaidml_edsl_init')
-
 Constraint = namedtuple('Constraint', ['lhs', 'rhs'])
 
 

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -22,7 +22,6 @@ class IndexedTensor;
 class Tensor;
 class TensorDim;
 class TensorIndex;
-struct TensorRef;
 class Value;
 
 namespace details {
@@ -220,6 +219,19 @@ struct Constraint {
   TensorDim rhs;
 };
 
+class TensorLens {
+ public:
+  TensorLens() = default;
+
+  TensorLens(const std::string& source, const std::string& target);
+
+  template <typename T>
+  std::vector<T> apply(const std::vector<T>& dims) const;
+
+ private:
+  std::vector<size_t> map;
+};
+
 ///
 /// \ingroup edsl_objects
 /// \class Tensor
@@ -318,6 +330,7 @@ class Tensor {
     for (size_t i = 0; i < dims.size(); i++) {
       raw_dims[i] = dims[i].as_ptr();
     }
+    raw_dims = lens_.apply(raw_dims);
     ffi::call_void(plaidml_expr_bind_dims, as_ptr(), raw_dims.size(), raw_dims.data());
   }
 
@@ -336,44 +349,18 @@ class Tensor {
   ///
   Tensor element(size_t ordinal) const;
 
+  Tensor use(const TensorLens& lens) const { return Tensor(*this, lens); }
+
   plaidml_expr* as_ptr() const { return ptr_.get(); }
 
   void* raw_ptr() const { return ffi::call<void*>(plaidml_expr_ptr, as_ptr()); }
 
  private:
+  Tensor(const Tensor& rhs, const TensorLens& lens) : ptr_(rhs.ptr_), lens_(lens) {}
+
+ private:
   std::shared_ptr<plaidml_expr> ptr_;
-};
-
-///
-/// \ingroup edsl_objects
-/// \struct TensorRef
-/// A reference to a Tensor
-///
-struct TensorRef {
-  ///
-  /// The `Tensor` that the `TensorRef` is referencing
-  ///
-  Tensor tensor;
-
-  ///
-  /// TensorRef constructor
-  ///
-  TensorRef(const Tensor& tensor) : tensor(tensor) {}  // NOLINT[runtime/explicit]
-
-  ///
-  /// TODO
-  ///
-  operator Tensor() const { return tensor; }
-
-  ///
-  /// TODO
-  ///
-  bool operator<(const TensorRef& rhs) const { return tensor.raw_ptr() < rhs.tensor.raw_ptr(); }
-
-  ///
-  /// TODO
-  ///
-  bool operator==(const TensorRef& rhs) const { return tensor.raw_ptr() == rhs.tensor.raw_ptr(); }
+  TensorLens lens_;
 };
 
 ///
@@ -422,6 +409,8 @@ inline IndexedTensor cond(const IndexedTensor& lhs, const IndexedTensor& rhs, co
 
 class Contraction {
  public:
+  explicit Contraction(const TensorLens& lens, const std::string& name = "") : name_(name), lens_(lens) {}
+
   explicit Contraction(const std::string& name = "") : name_(name) {}
 
   Contraction(const std::vector<TensorDim>& dims, const std::vector<TensorIndex>& idxs, const std::string& name = "")
@@ -494,6 +483,7 @@ class Contraction {
   IndexedTensor rhs_;
   plaidml_agg_op agg_op_;
   Tensor init_;
+  TensorLens lens_;
 };
 
 template <typename... Ts>
@@ -584,6 +574,9 @@ inline Tensor Contraction::build() {
     dims[i] = outDims_[i].as_ptr();
   }
 
+  idxs = lens_.apply(idxs);
+  dims = lens_.apply(dims);
+
   auto* ptr = ffi::call<plaidml_expr*>(  //
       plaidml_expr_contraction,          //
       agg_op_,                           //
@@ -627,14 +620,40 @@ inline Tensor Contraction::build() {
   return Tensor(ptr);
 }
 
+inline TensorLens::TensorLens(const std::string& source, const std::string& target) : map(source.size()) {
+  if (source.size() != target.size()) {
+    throw std::runtime_error("source and target rank mismatch");
+  }
+  for (unsigned i = 0; i < source.size(); i++) {
+    auto pos = target.find(source[i]);
+    if (pos == std::string::npos) {
+      throw std::runtime_error("source and target dims mismatch");
+    }
+    map[i] = pos;
+  }
+}
+
+template <typename T>
+inline std::vector<T> TensorLens::apply(const std::vector<T>& dims) const {
+  if (map.empty()) {
+    return dims;
+  }
+  std::vector<T> ret(dims.size());
+  for (unsigned i = 0; i < dims.size(); i++) {
+    ret[i] = dims[map[i]];
+  }
+  return ret;
+}
+
 template <typename... Ts>
 inline IndexedTensor Tensor::operator()(Ts... idxs) const {
   std::vector<TensorIndex> vec;
   details::into_vector(&vec, std::forward<Ts>(idxs)...);
-  return IndexedTensor(*this, vec);
+  return IndexedTensor(*this, lens_.apply(vec));
 }
+
 inline IndexedTensor Tensor::operator()(const std::vector<TensorIndex>& idxs) const {
-  return IndexedTensor(*this, idxs);
+  return IndexedTensor(*this, lens_.apply(idxs));
 }
 
 inline Tensor Tensor::element(size_t ordinal) const {

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -622,12 +623,16 @@ inline Tensor Contraction::build() {
 
 inline TensorLens::TensorLens(const std::string& source, const std::string& target) : map(source.size()) {
   if (source.size() != target.size()) {
-    throw std::runtime_error("source and target rank mismatch");
+    std::stringstream ss;
+    ss << "source and target rank mismatch: " << source << " != " << target;
+    throw std::runtime_error(ss.str());
   }
   for (unsigned i = 0; i < source.size(); i++) {
     auto pos = target.find(source[i]);
     if (pos == std::string::npos) {
-      throw std::runtime_error("source and target dims mismatch");
+      std::stringstream ss;
+      ss << "source and target dims mismatch: " << source << " != " << target;
+      throw std::runtime_error(ss.str());
     }
     map[i] = pos;
   }
@@ -637,6 +642,9 @@ template <typename T>
 inline std::vector<T> TensorLens::apply(const std::vector<T>& dims) const {
   if (map.empty()) {
     return dims;
+  }
+  if (dims.size() != map.size()) {
+    throw std::runtime_error("rank mismatch in TensorLens apply");
   }
   std::vector<T> ret(dims.size());
   for (unsigned i = 0; i < dims.size(); i++) {

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -56,10 +56,7 @@ void into_vector(std::vector<T>* into, Head&& head, Tail&&... tail) {
 ///
 /// Initializes the PlaidML EDSL API.
 ///
-inline void init() {
-  plaidml::init();
-  ffi::call_void(plaidml_edsl_init);
-}
+inline void init() { plaidml::init(); }
 
 ///
 /// Lists the available targets.

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -140,7 +140,7 @@ plaidml_datatype plaidml_expr_get_dtype(  //
   return ffi_wrap<plaidml_datatype>(err, PLAIDML_DATA_INVALID, [&] {
     IVLOG(3, "plaidml_expr_get_dtype");
     ast::Evaluator evaluator;
-    TensorShape shape = evaluator.getShape(expr->node.get());
+    TensorShape shape = evaluator.getShape(expr->node);
     return convertIntoDataType(shape.elementType);
   });
 }
@@ -150,7 +150,7 @@ size_t plaidml_expr_get_rank(  //
     plaidml_expr* expr) {
   return ffi_wrap<size_t>(err, 0, [&] {
     ast::Evaluator evaluator;
-    TensorShape shape = evaluator.getShape(expr->node.get());
+    TensorShape shape = evaluator.getShape(expr->node);
     return shape.getRank();
   });
 }
@@ -161,7 +161,7 @@ plaidml_shape* plaidml_expr_get_shape(  //
   return ffi_wrap<plaidml_shape*>(err, nullptr, [&] {
     IVLOG(3, "plaidml_expr_get_shape");
     ast::Evaluator evaluator;
-    TensorShape shape = evaluator.getShape(expr->node.get());
+    TensorShape shape = evaluator.getShape(expr->node);
     return new plaidml_shape{shape};
   });
 }
@@ -173,9 +173,12 @@ void plaidml_expr_bind_dims(  //
     plaidml_dim_expr** dims) {
   return ffi_wrap_void(err, [&] {
     IVLOG(3, "plaidml_expr_bind_dims> " << expr->node->str());
+    llvm::SmallVector<ast::DimNodePtr*, 8> into;
     for (size_t i = 0; i < rank; i++) {
-      dims[i]->node = std::make_shared<ast::DimNodeRef>(expr->node, i);
+      into.push_back(&dims[i]->node);
     }
+    ast::Evaluator evaluator;
+    evaluator.bindDims(expr->node, into);
   });
 }
 

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -106,16 +106,6 @@ struct plaidml_dim_expr {
   ast::DimNodePtr node;
 };
 
-void plaidml_edsl_init(  //
-    plaidml_error* err) {
-  static std::once_flag is_initialized;
-  ffi_wrap_void(err, [&] {
-    std::call_once(is_initialized, []() {  //
-      IVLOG(1, "plaidml_edsl_init");
-    });
-  });
-}
-
 void plaidml_expr_free(  //
     plaidml_error* err,  //
     plaidml_expr* expr) {

--- a/plaidml/ffi.py
+++ b/plaidml/ffi.py
@@ -102,9 +102,3 @@ class ForeignObject(object):
         if release:
             self.__ffi_obj__ = None
         return ret
-
-    def set_ptr(self, ffi_obj):
-        self.__ffi_obj__ = ffi_obj
-
-    def take_ptr(self, obj):
-        self.__ffi_obj__ = obj.as_ptr(True)

--- a/plaidml/op/__init__.py
+++ b/plaidml/op/__init__.py
@@ -11,13 +11,6 @@ from plaidml.ffi import ffi, ffi_call, lib
 logger = logging.getLogger(__name__)
 
 
-def __init():
-    ffi_call(lib.plaidml_op_init)
-
-
-ffi.init_once(__init, 'plaidml_op_init')
-
-
 class AutoDimMode(enum.IntEnum):
     MATCH = 0
     FILL = -1
@@ -196,30 +189,6 @@ def minimum(x, y):
     return op('minimum', [x, y]).as_tensor()
 
 
-def scale_gradient(x, scale=-1.0):
-    return op('scale_gradient', [x, scale]).as_tensor()
-
-
-def relu(x, alpha=None, max_value=None, threshold=0.):
-    return op('relu', [x, alpha, max_value, threshold]).as_tensor()
-
-
-def repeat(x, repeats, axis):
-    return op('repeat', [x, repeats, axis]).as_tensor()
-
-
-def sigmoid(x):
-    return op('sigmoid', [x]).as_tensor()
-
-
-def softmax(x, axis=None):
-    return op('softmax', [x, axis]).as_tensor()
-
-
-def reshape(x, shape):
-    return op('reshape', [x, shape]).as_tensor()
-
-
 def prod(x, axis=None, keepdims=False):
     return op('prod', [x, axis, keepdims]).as_tensor()
 
@@ -248,6 +217,30 @@ def pool(
     ]).as_tensor()
 
 
+def relu(x, alpha=None, max_value=None, threshold=0.):
+    return op('relu', [x, alpha, max_value, threshold]).as_tensor()
+
+
+def reorg_yolo(x, stride, decrease, layout='NCHW'):
+    return op('reorg_yolo', [x, stride, decrease, layout])
+
+
+def repeat(x, repeats, axis):
+    return op('repeat', [x, repeats, axis]).as_tensor()
+
+
+def reshape(x, shape):
+    return op('reshape', [x, shape]).as_tensor()
+
+
+def scale_gradient(x, scale=-1.0):
+    return op('scale_gradient', [x, scale]).as_tensor()
+
+
+def sigmoid(x):
+    return op('sigmoid', [x]).as_tensor()
+
+
 def slice_of(x, slices):
     # Note: ellipses and too-short slice lists must be handled by the calling op if desired
     reformatted_slices = list()
@@ -260,6 +253,10 @@ def slice_of(x, slices):
             continue
         raise ValueError("Unexpected type {} used to slice tensor".format(type(s)))
     return op("slice", [x, reformatted_slices]).as_tensor()
+
+
+def softmax(x, axis=None):
+    return op('softmax', [x, axis]).as_tensor()
 
 
 def spatial_padding(x, lo_pads, hi_pads, data_layout):

--- a/plaidml/op/ffi.cc
+++ b/plaidml/op/ffi.cc
@@ -11,28 +11,18 @@
 #include "pmlc/util/logging.h"
 
 using plaidml::core::ffi_wrap;
-using plaidml::core::ffi_wrap_void;
 using namespace plaidml::op;    // NOLINT
 using namespace plaidml::edsl;  // NOLINT
 
 extern "C" {
-
-void plaidml_op_init(  //
-    plaidml_error* err) {
-  static std::once_flag is_initialized;
-  ffi_wrap_void(err, [&] {
-    std::call_once(is_initialized, []() {
-      IVLOG(1, "plaidml_op_init");
-      lib::RegisterOps();
-    });
-  });
-}
 
 plaidml_value* plaidml_op_make(  //
     plaidml_error* err,          //
     const char* op_name,         //
     plaidml_value* value) {
   return ffi_wrap<plaidml_value*>(err, nullptr, [&] {
+    static std::once_flag is_initialized;
+    std::call_once(is_initialized, []() { lib::RegisterOps(); });
     auto op = lib::OperationRegistry::Instance()->Resolve(op_name);
     if (!op) {
       throw std::runtime_error(llvm::formatv("Operation not registered: {0}", op_name).str());

--- a/plaidml/op/ffi.h
+++ b/plaidml/op/ffi.h
@@ -8,9 +8,6 @@
 extern "C" {
 #endif  // __cplusplus
 
-void plaidml_op_init(  //
-    plaidml_error* err);
-
 plaidml_value* plaidml_op_make(  //
     plaidml_error* err,          //
     const char* op_name,         //

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -595,8 +595,8 @@ class relu {
   double threshold_ = 0.0;
 };
 
-inline edsl::Tensor reorg_yolo(const edsl::Tensor& I, int stride, bool decrease) {
-  auto args = edsl::make_tuple(I, stride, decrease);
+inline edsl::Tensor reorg_yolo(const edsl::Tensor& I, int stride, bool decrease, const std::string& layout = "NCHW") {
+  auto args = edsl::make_tuple(I, stride, decrease, layout);
   return details::op("reorg_yolo", args).as_tensor();
 }
 

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -14,7 +14,6 @@ namespace op {
 inline void init() {
   plaidml::init();
   plaidml::edsl::init();
-  ffi::call_void(plaidml_op_init);
 }
 
 namespace details {

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -495,14 +495,12 @@ TEST_F(OpTest, ReorgYoloDecrease) {
   auto I = Placeholder(DType::INT64, {N, C, H, W});
   auto O = op::reorg_yolo(I, S, decrease);
   auto program = makeProgram("reorg_yolo", {I}, {O});
-  IVLOG(1, "program:\n" << program);
 
   std::vector<int64_t> I_input(N * C * H * W);
   for (unsigned i = 0; i < I_input.size(); i++) {
     I_input[i] = i;
   }
   auto O_expected = reorgYoloRefImpl(I_input, N, C, H, W, S, decrease);
-  IVLOG(1, "expected:\n" << O_expected);
   checkExact(program, {I_input}, {O_expected});
 }
 
@@ -514,15 +512,23 @@ TEST_F(OpTest, ReorgYoloIncrease) {
   auto I = Placeholder(DType::INT64, {N, C, H, W});
   auto O = op::reorg_yolo(I, S, decrease);
   auto program = makeProgram("reorg_yolo", {I}, {O});
-  IVLOG(1, "program:\n" << program);
 
   std::vector<int64_t> I_input(N * C * H * W);
   for (unsigned i = 0; i < I_input.size(); i++) {
     I_input[i] = i;
   }
   auto O_expected = reorgYoloRefImpl(I_input, N, C_out, H_out, W_out, S, decrease);
-  IVLOG(1, "expected:\n" << O_expected);
   checkExact(program, {I_input}, {O_expected});
+}
+
+TEST_F(OpTest, ReorgYoloNHWC) {
+  const unsigned N = 1, C = 4, H = 6, W = 6, S = 2;
+  const bool decrease = true;
+
+  auto I = Placeholder(DType::INT64, {N, H, W, C});
+  auto O = op::reorg_yolo(I, S, decrease, /*layout=*/"NHWC");
+  auto program = makeProgram("reorg_yolo", {I}, {O});
+  runProgram(program);
 }
 
 TEST_F(OpTest, Repeat) {

--- a/plaidml/plaidml_link.jsonnet
+++ b/plaidml/plaidml_link.jsonnet
@@ -41,7 +41,6 @@ local exports = [
   'plaidml_contraction_add_constraint',
   'plaidml_contraction_add_operand',
   'plaidml_contraction_build',
-  'plaidml_edsl_init',
   'plaidml_dim_expr_free',
   'plaidml_dim_expr_int',
   'plaidml_dim_expr_none',
@@ -94,7 +93,6 @@ local exports = [
   'plaidml_value_tuple_get',
 
   // op/ffi.h
-  'plaidml_op_init',
   'plaidml_op_make',
 
   // exec/ffi.h

--- a/pmlc/ast/ast.cc
+++ b/pmlc/ast/ast.cc
@@ -182,9 +182,7 @@ std::string ExprNodePragma::str() const { return op; }
 // DimNode tree
 //
 
-std::string DimNodeLiteral::str() const {
-  return llvm::formatv("{0}:ix", value);
-}
+std::string DimNodeLiteral::str() const { return llvm::formatv("{0}", value); }
 
 std::string DimNodeOp::str() const {
   std::stringstream ss;

--- a/pmlc/ast/ast.h
+++ b/pmlc/ast/ast.h
@@ -245,7 +245,7 @@ struct DimNodeLiteral : NodeBase<DimNodeLiteral, DimNode> {
 };
 
 struct DimNodeNone : NodeBase<DimNodeNone, DimNode> {
-  std::string str() const final { return "none"; }
+  std::string str() const final { return "?"; }
 };
 
 struct DimNodeOp : NodeBase<DimNodeOp, DimNode> {

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -452,7 +452,7 @@ struct ContractionBuilder : PolyVisitor<ContractionBuilder, AffineExpr> {
 
 struct ProgramBuilder {
   explicit ProgramBuilder(llvm::StringRef name)
-      : program(std::make_shared<compiler::Program>(0, name)),
+      : program(std::make_shared<compiler::Program>(name)),
         context(&program->context), loc(UnknownLoc::get(context)),
         module(*program->module), builder(module) {}
 

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -100,8 +100,12 @@ public:
   Value lookupNode(const ExprNodePtr &node) {
     auto it = exprMap.find(node.get());
     if (it == exprMap.end()) {
-      // NOTE: this can happen if the user forgets to add an input to the
-      // edsl::Program constructor.
+      if (isa<ExprNodeInput>(node.get())) {
+        // NOTE: this can happen if the user forgets to add an input to the
+        // edsl::Program constructor.
+        throw std::runtime_error(llvm::formatv(
+            "Missing placeholder during program build: {0}", node->str()));
+      }
       throw std::runtime_error(
           llvm::formatv("ExprNode not found: {0}", node->str()));
     }

--- a/pmlc/ast/eval.h
+++ b/pmlc/ast/eval.h
@@ -38,6 +38,8 @@ public:
 
   void verify(const ExprNodePtr &node);
 
+  void bindDims(const ExprNodePtr &node, llvm::ArrayRef<DimNodePtr *> into);
+
 private:
   util::TensorShapes computeShapes(const ExprNode *node);
 

--- a/pmlc/compiler/program.cc
+++ b/pmlc/compiler/program.cc
@@ -79,7 +79,7 @@ private:
 
 } // namespace
 
-Program::Program(int x, llvm::StringRef name)
+Program::Program(llvm::StringRef name)
     : module(ModuleOp::create(UnknownLoc::get(&context), name)) {}
 
 Program::Program(mlir::ModuleOp module) : module(module) {}

--- a/pmlc/compiler/program.h
+++ b/pmlc/compiler/program.h
@@ -33,7 +33,7 @@ struct Program {
   std::vector<ConstantArgument> constants;
   std::vector<PassInfo> passes;
 
-  explicit Program(int x, llvm::StringRef name = "");
+  explicit Program(llvm::StringRef name = "");
   explicit Program(mlir::ModuleOp module);
   explicit Program(std::unique_ptr<llvm::MemoryBuffer> buffer);
 


### PR DESCRIPTION
Adding the concept of a `TensorLens`. A lens is used to provide a translation map between some `source` logical layout into some `target` logical layout. Op authors can use a lens so that they can focus on writing the op in some canonical logical layout.

Note that these logical layouts have no relation to the physical layout that a tensor will have in memory. This should be specified by users for inputs/outputs/constants and decided on by the compiler for intermediates.

See the `reorg_yolo` op for an example of its usage.