### PR TITLE
Add loop unrolling to the x86 pipeline.

### DIFF
--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -144,6 +144,14 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   pm.addPass(createLowerPXAToAffinePass());
+
+  // Unroll affine.for loops.
+  pm.addPass(createLoopUnrollPass(
+      /*unrollFactor=*/32,
+      /*unrollUpToFactor=*/true));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   pm.addPass(createLoopInvariantCodeMotionPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());


### PR DESCRIPTION
The result is 12% perf improvement on a single core. The best results were achieved with unroll  factor  of 32.
Overall, the perf of PlaidML v1 now is 33.31% better on single core (Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz) CPU, compared to Stripe (v0) of PlaidML.

Data:
PLAIDML-STRIPE-V0

Command: PLAIDML_USE_STRIPE=1 taskset -c 10  bazelisk run //plaidbench:bin -- -n 1000  resnet50
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             160.32 ms                 158.90 ms / 6.29 fps
Correctness: PASS, max_error: 8.240351235144772e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0


PLAIDML-V1
Command: taskset -c 10  bazelisk run //plaidbench:bin -- -n 1000  keras resnet50
No Unroll
—————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             120.23 ms                 120.23 ms / 8.32 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 6
————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             109.19 ms                 109.19 ms / 9.16 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 16
————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             106.96 ms                 106.96 ms / 9.35 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 32
————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             105.97 ms                 105.97 ms / 9.44 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 64
————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             108.47 ms                 108.47 ms / 9.22 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 128
—————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             113.17 ms                 113.17 ms / 8.84 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0

Unroll factor 256
—————
-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS
-----------------------------------------------------------------------------------------
resnet50             110.23 ms                 110.23 ms / 9.07 fps
Correctness: PASS, max_error: 9.953708286047913e-06, max_abs_error: 1.1920928955078125e-06, fail_ratio: 0.0