### PR TITLE
[OpenCL] Add lowering for std.exp to spv.OCL.exp

### DIFF
--- a/pmlc/conversion/gpu_to_spirv/passes.h
+++ b/pmlc/conversion/gpu_to_spirv/passes.h
@@ -27,6 +27,10 @@ void populateCustomGLSLToStdSpirvPatterns(
     mlir::MLIRContext *context, mlir::SPIRVTypeConverter &typeConverter,
     mlir::OwningRewritePatternList &patterns);
 
+void populateCustomStdToOCLSpirvPatterns(
+    mlir::MLIRContext *context, mlir::SPIRVTypeConverter &typeConverter,
+    mlir::OwningRewritePatternList &patterns);
+
 std::unique_ptr<mlir::Pass> createGPUToSPIRVCustomPass();
 
 /// Generate the code for registering conversion passes.


### PR DESCRIPTION
ResNet-50 running in full with conformance - checked with `plaidbench keras`.