### PR TITLE
resizeTmpPass improvements

### DIFF
--- a/pmlc/dialect/pxa/transforms/dataflow_opt.cc
+++ b/pmlc/dialect/pxa/transforms/dataflow_opt.cc
@@ -47,7 +47,7 @@ struct MemRefAccess {
 struct MemRefDataFlowOptPass
     : public MemRefDataFlowOptBase<MemRefDataFlowOptPass> {
 
-  explicit MemRefDataFlowOptPass(int64_t onlyParallelNested) {
+  explicit MemRefDataFlowOptPass(bool onlyParallelNested) {
     this->onlyParallelNested = onlyParallelNested;
   }
 

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -45,7 +45,8 @@ createMemRefDataFlowOptPass(bool onlyParallelNested = false);
 std::unique_ptr<mlir::Pass> createNestLoopsPass();
 std::unique_ptr<mlir::Pass> createNestLoopsPass(unsigned minLoopIVs);
 
-std::unique_ptr<mlir::Pass> createResizeTmpsPass();
+std::unique_ptr<mlir::Pass>
+createResizeTmpsPass(bool onlyParallelNested = false);
 
 std::unique_ptr<mlir::Pass> createStencilGEMMPass();
 std::unique_ptr<mlir::Pass> createStencilGEMMPass(unsigned numThreads,

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -114,6 +114,11 @@ def NestLoops : FunctionPass<"pxa-nest-loops"> {
 def ResizeTmps : FunctionPass<"pxa-resize-tmps"> {
   let summary = "Resize temporary buffers to minimal sizes";
   let constructor = "pmlc::dialect::pxa::createResizeTmpsPass()";
+  let options = [
+  Option<"onlyParallelNested", "only-parallel-nested", "bool",
+         /*default=*/"false",
+         "Perform resize tmp optimizations only under AffineParallel's scope.">,
+  ];
 }
 
 def Subgroups : FunctionPass<"pxa-subgroups"> {

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -138,15 +138,15 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // Do tiled fusion
-  pm.addPass(pxa::createFusionPass(0 /*memoryActivityThreshold*/,
-                                   false /*exactlyMatch*/, true /*tiledFusion*/,
-                                   3 /*loopDepth*/));
+  pm.addPass(pxa::createFusionPass(/*memoryActivityThreshold=*/0,
+                                   /*exactlyMatch=*/false, /*tiledFusion=*/true,
+                                   /*loopDepth=*/3));
   pm.addPass(pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(pxa::createMemRefDataFlowOptPass(true /*onlyParallelNested*/));
+  pm.addPass(pxa::createMemRefDataFlowOptPass(/*onlyParallelNested=*/true));
   pm.addPass(createCanonicalizerPass());
   pm.addPass(pxa::createLocalizePass());
-  pm.addPass(pxa::createResizeTmpsPass());
+  pm.addPass(pxa::createResizeTmpsPass(/*onlyParallelNested=*/true));
   pm.addPass(pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -71,8 +71,8 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(pxa::createMemRefDataFlowOptPass(/*onlyParallelNested=*/true));
   pm.addPass(createCanonicalizerPass());
   // TODO: parametrize localize pass depending on memory size and HW caps
-  // pm.addPass(pxa::createLocalizePass());
-  pm.addPass(pxa::createResizeTmpsPass());
+  pm.addPass(pxa::createLocalizePass());
+  pm.addPass(pxa::createResizeTmpsPass(/*onlyParallelNested=*/true));
   pm.addPass(pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());


### PR DESCRIPTION
Added vector ops support.
Added option to apply only to allocOp in nested ops (right now resizing global mem causes output verification fails)