### PR TITLE
Handle case of 0 physical cores reported

### DIFF
--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -177,7 +177,10 @@ void pipelineBuilder(OpPassManager &pm) {
   // Use OMP thread count
   unsigned maxThreads = omp_get_max_threads();
   unsigned physCores = getPhysicalCoreNumber();
-  maxThreads = std::min(physCores, maxThreads);
+  if (0 != physCores) {
+    maxThreads = std::min(physCores, maxThreads);
+  }
+
   pm.addPass(pxa::createCPUThreadPass(maxThreads));
 
   pm.addPass(pxa::createAffineNormalizePass());


### PR DESCRIPTION
When it is unknown manufacturer the physical cores could be reported as 0. Handle this case in the pipeline setup.