### PR TITLE
WIP: Vectorize memory ops

### DIFF
--- a/pmlc/conversion/gpu_to_spirv/BUILD
+++ b/pmlc/conversion/gpu_to_spirv/BUILD
@@ -35,5 +35,6 @@ plaidml_cc_library(
         "@llvm-project//mlir:GPUToSPIRVTransforms",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:SPIRVDialect",
+        "@llvm-project//mlir:VectorOps",
     ],
 )

--- a/pmlc/dialect/pxa/transforms/BUILD
+++ b/pmlc/dialect/pxa/transforms/BUILD
@@ -42,6 +42,7 @@ plaidml_cc_library(
         "tile.cc",
         "tile_accumulate.cc",
         "vectorize.cc",
+        "vectorize_mem.cc",
     ],
     hdrs = [
         "autotile.h",

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -68,6 +68,8 @@ std::unique_ptr<mlir::Pass> createVectorizePass();
 std::unique_ptr<mlir::Pass> createVectorizePass(mlir::StringRef strategy,
                                                 unsigned vectorWidth = 8);
 
+std::unique_ptr<mlir::Pass> createVectorizeMemPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "pmlc/dialect/pxa/transforms/passes.h.inc"

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -160,4 +160,9 @@ def Vectorize : FunctionPass<"pxa-vectorize"> {
   ];
 }
 
+def VectorizeMem : FunctionPass<"pxa-vectorize-mem"> {
+  let summary = "Vectorize load and reduce assign ops";
+  let constructor = "pmlc::dialect::pxa::createVectorizeMemPass()";
+}
+
 #endif // __PMLC_DIALECT_PXA_PASSES__

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -1,0 +1,151 @@
+// Copyright 2020 Intel Corporation
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "pmlc/dialect/pxa/analysis/strides.h"
+
+#include "pmlc/dialect/pxa/ir/ops.h"
+#include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/util/logging.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+// TODO: add detailed description here
+
+namespace pmlc::dialect::pxa {
+
+namespace {
+
+// TODO: Maybe move this to a generic utility somewhere
+template <typename OpTy, typename... Args>
+static OpTy replaceOp(Operation *op, Args &&... args) {
+  OpBuilder builder(op);
+  auto newOp = builder.create<OpTy>(op->getLoc(), std::forward<Args>(args)...);
+  op->getResult(0).replaceAllUsesWith(newOp.getResult());
+  op->erase();
+  return newOp;
+}
+
+struct VectorizeMemPass : public VectorizeMemBase<VectorizeMemPass> {
+  void runOnFunction() final {
+    FuncOp f = getFunction();
+    // TODO: generalize this for all read\write ops
+    f.walk([&](PxaReadOpInterface loadOp) {
+      auto defOp = loadOp.getMemRef().getDefiningOp();
+      if (defOp) {
+        return;
+      }
+
+      // TODO: consider adding case with vload usage also, not only vectorized
+      // block read
+      auto vectorLoad = dyn_cast<PxaVectorLoadOp>(loadOp.getOperation());
+      if (!vectorLoad) {
+        return;
+      }
+
+      // Check if op is inside AffineParallelOp to extract it from
+      auto loopOp = vectorLoad.getParentOfType<AffineParallelOp>();
+      if (!loopOp) {
+        return;
+      }
+
+      IVLOG(3, "Load Op: " << debugString(*vectorLoad));
+
+      // Check strides
+      auto maybeSI = computeStrideInfo(vectorLoad);
+      if (!maybeSI) {
+        return;
+      }
+      IVLOG(3, "StrideInfo: " << debugString(*maybeSI));
+
+      // TODO: verify if we can do vlock op here based on the strides and
+      // dimension we iterate in the parent loop
+      SmallVector<BlockArgument, 4> blockArgs;
+      for (auto ba : loopOp.getIVs()) {
+        if (maybeSI->strides.count(ba)) {
+          blockArgs.push_back(ba);
+        }
+      }
+
+      if (blockArgs.size() != 1) {
+        return;
+      }
+
+      // TODO: add checks if vector size is valid (2, 4, 8).
+      // For the block ops we limit to the 2, 4, 8, but if we
+      // consider vload then vec size 16 would be also allowed,
+      // at least it is in OpenCL, double check this.
+      auto ranges = loopOp.getConstantRanges();
+      if (!ranges) {
+        return;
+      }
+
+      auto argNum = blockArgs[0].getArgNumber();
+      auto loopVectorSize = (*ranges)[argNum];
+      IVLOG(3, "LoopVecSize: " << loopVectorSize);
+
+      if (!(loopVectorSize == 2 || loopVectorSize == 4 || loopVectorSize == 8))
+        return;
+
+      auto vecShape = vectorLoad.getVectorType().getShape();
+      // Accept only vectors with dim size 1
+      if (vecShape.size() != 1)
+        return;
+
+      // Create constant op of value 0, that would replace the actual IV of the
+      // loop we are extracting from
+      OpBuilder builder(loopOp);
+      auto const0 = builder.create<ConstantIndexOp>(loopOp.getLoc(), 0);
+
+      // Replace the IV except for the orginal operation that would become
+      // vector.extractelement later
+      llvm::SmallPtrSet<Operation *, 8> idxNoChange;
+      for (auto user : blockArgs[0].getUsers()) {
+        if (user != loadOp)
+          idxNoChange.insert(user);
+      }
+      blockArgs[0].replaceAllUsesExcept(const0, idxNoChange);
+
+      // Create new vector that would be of orginal size x loop size
+      auto vectorType =
+          VectorType::get({vecShape[0] * loopVectorSize},
+                          vectorLoad.getVectorType().getElementType());
+
+      // Create new vector load, extracted from the orginal loop
+      auto newLoadOp = builder.create<PxaVectorLoadOp>(
+          loopOp.getLoc(), vectorType, vectorLoad.getMemRef(),
+          vectorLoad.getAffineMap(), vectorLoad.getMapOperands());
+
+      // TODO: The below commented code implements additional temporary vector
+      // in case we would like to put few loads to single vector.
+      // auto nemMemrefType = MemRefType::get({1}, vectorType);
+      // auto newAllocOp = builder.create<AllocOp>(loopOp.getLoc(),
+      // nemMemrefType); SmallVector<Value, 4> indices;
+      // indices.push_back(const0.getResult());
+      // auto newStoreOp =
+      // builder.create<vector::TransferWriteOp>(loopOp.getLoc(),
+      // newLoadOp.getResult(), newAllocOp.getResult(), indices); auto
+      // newLoadOp2 =
+      // builder.create<vector::TransferReadOp>(vectorLoad.getLoc(), vectorType,
+      // newStoreOp.memref(), indices);
+
+      // Replace original op with extract map.
+      // Use extract map instead of extract element as we do not extract
+      // scalar but vector of size equal to subgroup
+      replaceOp<vector::ExtractMapOp>(vectorLoad, newLoadOp.getResult(),
+                                      blockArgs[0], loopVectorSize);
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createVectorizeMemPass() {
+  return std::make_unique<VectorizeMemPass>();
+}
+
+} // namespace pmlc::dialect::pxa

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -11,9 +11,11 @@
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/DebugStringHelper.h"
 
 #include "pmlc/dialect/stdx/ir/ops.h"
 #include "pmlc/target/intel_gen/pass_detail.h"
+#include "pmlc/util/logging.h"
 #include "pmlc/util/tags.h"
 
 using namespace mlir; // NOLINT[build/namespaces]
@@ -34,7 +36,7 @@ public:
       : loop(loop), vectorSize(vectorSize), useBlockOps(useBlockOps) {}
 
   bool isVectorTypeValid(VectorType type) {
-    return type.getRank() == 1 && type.getDimSize(0) == vectorSize;
+    return type.getRank() == 1 && type.getDimSize(0) % vectorSize == 0;
   }
 
   template <typename T>
@@ -81,6 +83,7 @@ public:
   }
 
   LogicalResult devectorizeTransferRead(vector::TransferReadOp op) {
+    IVLOG(3, "Orginal Op: " << debugString(*op));
     if (!isVectorTypeValid(op.getVectorType()) || op.indices().size() < 1)
       return failure();
     OpBuilder builder(op);
@@ -97,16 +100,57 @@ public:
     // TODO: add additional requirements like mem alignment
     if (useBlockOps && !invalidMemScope &&
         isBlockOpTypeSupported<vector::TransferReadOp>(op)) {
-      auto newBlockReadOp =
-          builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
-              op.getLoc(), op.memref(), idxs);
-      devectorizeVectorOp(newBlockReadOp.getOperation());
-      op.replaceAllUsesWith(newBlockReadOp.getResult());
+      // Case1: vector size is the multiplication of subgroup size, in this case
+      // we use vector of size divided by subgroup size as output from
+      // SubgroupBlockReadINTELOp
+      if (op.getVectorType().getDimSize(0) > vectorSize) {
+        // Change vector dimension, we already checked earlier that dimsize %
+        // vecsize == 0
+        auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
+        auto vectorType = VectorType::get({newVectorSize},
+                                          op.getVectorType().getElementType());
+        SmallVector<int64_t, 1> newShape;
+        newShape.push_back(newVectorSize);
+        auto newMemrefType =
+            VectorType::get(newShape, op.getVectorType().getElementType());
+        auto newBlockReadOp =
+            builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
+                op.getLoc(), newMemrefType, op.memref(), idxs);
+
+        IVLOG(3, "Load Op: " << debugString(*newBlockReadOp));
+        op.replaceAllUsesWith(newBlockReadOp.getResult());
+        // Case2: output from SubgroupBlockReadINTELOp is scalar,
+        // In this case it is also needed to devectorize the operands afterwards
+      } else {
+        auto newBlockReadOp =
+            builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
+                op.getLoc(), op.memref(), idxs);
+        devectorizeVectorOp(newBlockReadOp.getOperation());
+        op.replaceAllUsesWith(newBlockReadOp.getResult());
+        IVLOG(3, "Load Op: " << debugString(*newBlockReadOp));
+      }
+      // Case3: Used buffer was allocated inside the kernel, no block reads
+      // allowed. Check if element type of the allocated memory is vector, if so
+      // then it is needed to use vector TransferReadOp for writing
+    } else if (auto allocVecType =
+                   dyn_cast<AllocOp>(op.memref().getDefiningOp())
+                       .getType()
+                       .getElementType()
+                       .dyn_cast<VectorType>()) {
+      auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
+      auto vectorType =
+          VectorType::get({newVectorSize}, op.getVectorType().getElementType());
+      auto newLoadOp = builder.create<vector::TransferReadOp>(
+          op.getLoc(), vectorType, op.memref(), idxs);
+      IVLOG(3, "Block read Op: " << debugString(*newLoadOp));
+      op.replaceAllUsesWith(newLoadOp.getResult());
+      // Case4: No block reads or vectors, use default devectorization
     } else {
       idxs.back() = builder.create<AddIOp>(op.getLoc(), idxs.back(), sid);
       auto newLoadOp = builder.create<LoadOp>(op.getLoc(), op.memref(), idxs);
       devectorizeVectorOp(newLoadOp.getOperation());
       op.replaceAllUsesWith(newLoadOp.getResult());
+      IVLOG(3, "Load Op: " << debugString(*newLoadOp));
     }
     op.erase();
     return success();
@@ -127,19 +171,32 @@ public:
     // TODO: Based on the HW caps we should accept these for certain data types
     // Right now we accept i16/fp16 and i32/fp32 for the block read extensions
     // TODO: add additional requirements like mem alignment
+    // Case1: Use block write
     if (useBlockOps && !invalidMemScope &&
         isBlockOpTypeSupported<vector::TransferWriteOp>(op)) {
       auto newBlockWriteOp =
           builder.create<dialect::stdx::SubgroupBlockWriteINTELOp>(
               op.getLoc(), op.vector(), op.memref(), idxs);
       devectorizeVectorOp(newBlockWriteOp.getOperation());
+      IVLOG(3, "Block Write Op: " << debugString(*newBlockWriteOp));
+      op.erase();
+      // Case2: TODO: Change this condition to include memref being vector,
+      // where it is needed to use vector write instead
+    } else if (dyn_cast<dialect::stdx::SubgroupBlockReadINTELOp>(
+                   op.vector().getDefiningOp())) {
+      auto newStoreOp = builder.create<vector::TransferWriteOp>(
+          op.getLoc(), op.vector(), op.memref(), idxs);
+      IVLOG(3, "Block Write Op: " << debugString(*newStoreOp));
+      op.erase();
+      // Case3: No block writes or vectors, use default devectorization
     } else {
       idxs.back() = builder.create<AddIOp>(op.getLoc(), idxs.back(), sid);
       auto newStoreOp =
           builder.create<StoreOp>(op.getLoc(), op.vector(), op.memref(), idxs);
       devectorizeVectorOp(newStoreOp.getOperation());
+      IVLOG(3, "Block Write Op: " << debugString(*newStoreOp));
+      op.erase();
     }
-    op.erase();
     return success();
   }
 
@@ -151,13 +208,48 @@ public:
       return success();
     }
     auto shape = vecType.getShape();
-    if (shape.size() != 1 || shape[0] != vectorSize) {
+    if (shape.size() != 1) {
       // Vector allocations must match the subgroup size
       return failure();
     }
-    auto newMemRefType = MemRefType::Builder(oldMemRefType)
-                             .setElementType(vecType.getElementType());
+
+    // Check if element type is vector, it should be of size multiplication
+    // of subgroup size or equal. If it is multiplication then divide it by
+    // subgroup size to create new Alloc
+    Type newElementType = vecType.getElementType();
+    if (shape[0] > vectorSize) {
+      auto newVectorSize = shape[0] / vectorSize;
+      newElementType =
+          VectorType::get({newVectorSize}, vecType.getElementType());
+    } else if (shape[0] != vectorSize) {
+      return failure();
+    }
+
+    auto newMemRefType =
+        MemRefType::Builder(oldMemRefType).setElementType(newElementType);
     op.getResult().setType(newMemRefType);
+    IVLOG(3, "Alloc Op: " << debugString(*op));
+    return success();
+  }
+
+  LogicalResult devectorizeExtractMap(vector::ExtractMapOp op) {
+    OpBuilder builder(op);
+    auto idVal = op.id();
+    IVLOG(3, "oldExtractOp: " << debugString(*op));
+    // It is needed to use i32 type for extract element index. Use cast in case
+    // it comes from index
+    if (op.id().getType().dyn_cast<IndexType>()) {
+      auto indexCast = builder.create<IndexCastOp>(op.getLoc(), idVal,
+                                                   builder.getIntegerType(32));
+      idVal = indexCast.getResult();
+    }
+
+    auto newExtractOp = builder.create<vector::ExtractElementOp>(
+        op.getLoc(), op.vector(), idVal);
+    op.replaceAllUsesWith(newExtractOp.getResult());
+    op.erase();
+
+    IVLOG(3, "newExtractOp: " << debugString(*newExtractOp));
     return success();
   }
 
@@ -191,6 +283,8 @@ public:
       return devectorizeTransferWrite(vecWriteOp);
     } else if (auto vecBroadcastOp = dyn_cast<vector::BroadcastOp>(op)) {
       return devectorizeBroadcast(vecBroadcastOp);
+    } else if (auto extractMapOp = dyn_cast<vector::ExtractMapOp>(op)) {
+      return devectorizeExtractMap(extractMapOp);
     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       for (auto &innerOp : llvm::make_early_inc_range(forOp.getOps())) {
         if (failed(devectorizeOperation(&innerOp))) {

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -89,8 +89,8 @@ public:
     // TODO: Current HW supports only block read\write on global mem scope.
     // This can change in the future so probably need to be better handled with
     // HW specific parameters
-    auto invalidMemScope =
-        dyn_cast_or_null<AllocOp>(op.memref().getDefiningOp());
+    scf::ParallelOp actualBlock = loop.getParentOfType<scf::ParallelOp>();
+    bool invalidMemScope = !actualBlock.isDefinedOutsideOfLoop(op.memref());
 
     // TODO: Based on the HW caps we should accept these for certain data types
     // Right now we accept i16/fp16 and i32/fp32 for the block read extensions
@@ -121,8 +121,8 @@ public:
     // TODO: Current HW supports only block read\write on global mem scope.
     // This can change in the future so probably need to be better handled with
     // HW specific parameters
-    auto invalidMemScope =
-        dyn_cast_or_null<AllocOp>(op.memref().getDefiningOp());
+    scf::ParallelOp actualBlock = loop.getParentOfType<scf::ParallelOp>();
+    bool invalidMemScope = !actualBlock.isDefinedOutsideOfLoop(op.memref());
 
     // TODO: Based on the HW caps we should accept these for certain data types
     // Right now we accept i16/fp16 and i32/fp32 for the block read extensions

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -274,9 +274,13 @@ struct SubgroupBroadcastPass
     func.walk([&](scf::ParallelOp op) {
       int64_t subgroupSize = getIntegerTag(op, subgroupSizeTag(), 1);
       if (hasUnitTag(op, gpuThreadTag())) {
-        DevectorizeImpl impl(op, subgroupSize, useBlockOps.getValue());
-        if (failed(impl.devectorize())) {
-          signalPassFailure();
+        // Make sure that gpuBlock loop is present
+        auto gpuBlockOp = op.getParentOfType<scf::ParallelOp>();
+        if (gpuBlockOp && hasUnitTag(gpuBlockOp, gpuBlockTag())) {
+          DevectorizeImpl impl(op, subgroupSize, useBlockOps.getValue());
+          if (failed(impl.devectorize())) {
+            signalPassFailure();
+          }
         }
       }
     });

--- a/pmlc/target/intel_gen/tests/subgroup_block_ops.mlir
+++ b/pmlc/target/intel_gen/tests/subgroup_block_ops.mlir
@@ -7,15 +7,18 @@ func @subgroup_block_read_write(%arg0: memref<64xf32>, %arg1: memref<64xf32>) {
   %c64 = constant 64 : index
   %cst = constant 0.000000e+00 : f32
   %c1 = constant 1 : index
-  // CHECK:   scf.parallel (%{{.*}}, %[[IDX:.*]]) = (%{{.*}}, %{{.*}})
-  scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
-    // CHECK: stdx.subgroup_block_read_intel %{{.*}}[%[[IDX]]] : memref<64xf32>
-    %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
-    %1 = extract_element %0[%c1] : vector<8xf32>
-    %2 = vector.broadcast %1 : f32 to vector<8xf32>
-    // CHECK: stdx.subgroup_block_write_intel %{{.*}}, %{{.*}}[%[[IDX]]] : memref<64xf32>
-    vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
-    scf.yield
-  }  {tags = {gpuThread, subgroupSize=8}}
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    // CHECK:   scf.parallel (%{{.*}}, %[[IDX:.*]]) = (%{{.*}}, %{{.*}})
+    scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
+      // CHECK: stdx.subgroup_block_read_intel %{{.*}}[%[[IDX]]] : memref<64xf32>
+      %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
+      %1 = extract_element %0[%c1] : vector<8xf32>
+      %2 = vector.broadcast %1 : f32 to vector<8xf32>
+      // CHECK: stdx.subgroup_block_write_intel %{{.*}}, %{{.*}}[%[[IDX]]] : memref<64xf32>
+      vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
+      scf.yield
+    }  {tags = {gpuThread, subgroupSize=8}}
+  }  {tags = {gpuBlock, subgroupSize=8}}
   return
 }

--- a/pmlc/target/intel_gen/tests/subgroup_broadcast.mlir
+++ b/pmlc/target/intel_gen/tests/subgroup_broadcast.mlir
@@ -7,56 +7,64 @@ func @subgroup_read_extract_bcast_write(%arg0: memref<64xf32>, %arg1: memref<64x
   %c8 = constant 8 : index
   %c64 = constant 64 : index
   %cst = constant 0.000000e+00 : f32
-  // CHECK: constant 1 : index
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
   // CHECK: scf.parallel (%[[SID:.*]], %[[I:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
   // CHECK-NEXT:   %[[IDX:.*]] = addi %[[I]], %[[SID]] : index
   // CHECK-NEXT:   %[[LOAD:.*]] = load %{{.*}}[%[[IDX]]] : memref<64xf32>
   // CHECK-NEXT:   %[[BROADCAST:.*]] = stdx.subgroup_broadcast(%[[LOAD]], %{{.*}}) : f32
   // CHECK-NEXT:   store %[[BROADCAST]], %{{.*}}[%[[IDX]]] : memref<64xf32>
-  scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
-    %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
-    %1 = extract_element %0[%c1] : vector<8xf32>
-    %2 = vector.broadcast %1 : f32 to vector<8xf32>
-    vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
-    scf.yield
-  } {tags = {gpuThread, subgroupSize=8}}
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
+      %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
+      %1 = extract_element %0[%c1] : vector<8xf32>
+      %2 = vector.broadcast %1 : f32 to vector<8xf32>
+      vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
+      scf.yield
+    } {tags = {gpuThread, subgroupSize=8}}
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }
 
 // CHECK-LABEL: @subgroup_read_write
 func @subgroup_read_write(%arg0: memref<64xf32>, %arg1: memref<64xf32>) {
   %c0 = constant 0 : index
+  %c1 = constant 1 : index
   %c8 = constant 8 : index
   %c64 = constant 64 : index
   %cst = constant 0.000000e+00 : f32
-  // CHECK: constant 1 : index
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
   // CHECK: scf.parallel (%[[SID:.*]], %[[I:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
   // CHECK-NEXT:   %[[IDX:.*]] = addi %[[I]], %[[SID]] : index
   // CHECK-NEXT:   %[[LOAD:.*]] = load %{{.*}}[%[[IDX]]] : memref<64xf32>
   // CHECK-NEXT:   store %[[LOAD]], %{{.*}}[%[[IDX]]] : memref<64xf32>
-  scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
-    %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
-    vector.transfer_write %0, %arg1[%i] : vector<8xf32>, memref<64xf32>
-    scf.yield
-  } {tags = {gpuThread, subgroupSize=8}}
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
+      %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
+      vector.transfer_write %0, %arg1[%i] : vector<8xf32>, memref<64xf32>
+      scf.yield
+    } {tags = {gpuThread, subgroupSize=8}}
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }
 
 // CHECK-LABEL: @subgroup_bcast_write
 func @subgroup_bcast_write(%arg0: memref<64xf32>, %arg1: memref<64xf32>) {
   %c0 = constant 0 : index
+  %c1 = constant 1 : index
   %c8 = constant 8 : index
   %c64 = constant 64 : index
   %cst = constant 0.000000e+00 : f32
-  // CHECK: constant 1 : index
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
   // CHECK: scf.parallel (%[[SID:.*]], %[[I:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
   // CHECK-NEXT:   %[[IDX:.*]] = addi %[[I]], %[[SID]] : index
   // CHECK-NEXT:   store %{{.*}}, %{{.*}}[%[[IDX]]] : memref<64xf32>
-  scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
-    %2 = vector.broadcast %cst : f32 to vector<8xf32>
-    vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
-    scf.yield
-  } {tags = {gpuThread, subgroupSize=8}}
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
+      %2 = vector.broadcast %cst : f32 to vector<8xf32>
+      vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
+      scf.yield
+    } {tags = {gpuThread, subgroupSize=8}}
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }
 
@@ -67,21 +75,23 @@ func @subgroup_test_read_extract_broadcast_mulf_write(%arg0: memref<64xf32>, %ar
   %c8 = constant 8 : index
   %c64 = constant 64 : index
   %cst = constant 0.000000e+00 : f32
-  // CHECK: constant 1 : index
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
   // CHECK: scf.parallel (%[[SID:.*]], %[[I:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
   // CHECK-NEXT:   %[[IDX:.*]] = addi %[[I]], %[[SID]] : index
   // CHECK-NEXT:   %[[LOAD:.*]] = load %{{.*}}[%[[IDX]]] : memref<64xf32>
   // CHECK-NEXT:   %[[BROADCAST:.*]] = stdx.subgroup_broadcast(%[[LOAD]], %{{.*}}) : f32
   // CHECK-NEXT:   %[[MUL:.*]] = mulf %[[BROADCAST]], %[[LOAD]]
   // CHECK-NEXT:   store %[[MUL]], %{{.*}}[%[[IDX]]] : memref<64xf32>
-  scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
-    %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
-    %1 = extract_element %0[%c1] : vector<8xf32>
-    %2 = vector.broadcast %1 : f32 to vector<8xf32>
-    %mul = mulf %2, %0 : vector<8xf32>
-    vector.transfer_write %mul, %arg1[%i] : vector<8xf32>, memref<64xf32>
-    scf.yield
-  } {tags = {gpuThread, subgroupSize=8}}
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    scf.parallel (%i) = (%c0) to (%c64) step (%c8) {
+      %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
+      %1 = extract_element %0[%c1] : vector<8xf32>
+      %2 = vector.broadcast %1 : f32 to vector<8xf32>
+      %mul = mulf %2, %0 : vector<8xf32>
+      vector.transfer_write %mul, %arg1[%i] : vector<8xf32>, memref<64xf32>
+      scf.yield
+    } {tags = {gpuThread, subgroupSize=8}}
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }
 
@@ -111,8 +121,7 @@ func @subgroup_test_multiple_dim_inner_loop(%arg0: memref<1x1x8x16xf32>) {
       vector.transfer_write %mul, %3[%c0, %c0, %arg5, %arg6] : vector<8xf32>, memref<1x1x8x16xf32>
       scf.yield
     } {tags = {gpuThread, subgroupSize=8}}
-    scf.yield
-  }
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }
 
@@ -123,16 +132,19 @@ func @devectorize_constant() {
   %c1 = constant 1 : index
   %c4 = constant 4 : index
   %c8 = constant 8 : index
-  // CHECK: scf.parallel
-  scf.parallel (%arg4) = (%c0) to (%c4) step (%c1) {
-    // CHECK-NEXT: alloc() : memref<8x1xf32>
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT: constant 0.000000e+00 : f32
-    // CHECK-NEXT: store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<8x1xf32>
-    %0 = alloc() : memref<8x1xvector<8xf32>>
-    scf.for %arg5 = %c0 to %c8 step %c1 {
-      store %cst, %0[%arg5, %c0] : memref<8x1xvector<8xf32>>
-    }
-  } {tags = {gpuThread, subgroupSize = 8}}
+  // CHECK: scf.parallel (%{{.*}}) = (%{{.*}})
+  scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+    // CHECK: scf.parallel
+    scf.parallel (%arg4) = (%c0) to (%c4) step (%c1) {
+      // CHECK-NEXT: alloc() : memref<8x1xf32>
+      // CHECK-NEXT: scf.for
+      // CHECK-NEXT: constant 0.000000e+00 : f32
+      // CHECK-NEXT: store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<8x1xf32>
+      %0 = alloc() : memref<8x1xvector<8xf32>>
+      scf.for %arg5 = %c0 to %c8 step %c1 {
+        store %cst, %0[%arg5, %c0] : memref<8x1xvector<8xf32>>
+      }
+    } {tags = {gpuThread, subgroupSize = 8}}
+  } {tags = {gpuBlock, subgroupSize=8}}
   return
 }

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -99,10 +99,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addPass(createMemRefDataFlowOptPass());
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
-
   // Pack dims
   pm.addPass(pmlc::target::intel_gen::createAffineIndexPackPass());
   pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -77,6 +77,11 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  pm.addPass(pxa::createVectorizeMemPass());
+  pm.addPass(pxa::createAffineNormalizePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   // Assign GPU blocks + threads to outermost loop
   pm.addPass(pmlc::dialect::pxa::createGPUThreadPass(/*maxThreads=*/64));
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -85,11 +85,21 @@ void pipelineBuilder(OpPassManager &pm) {
 
   // Lower out of PXA memory semantics
   pm.addPass(pmlc::target::intel_gen::createLowerPXAToAffinePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  pm.addPass(createAffineLoopInvariantCodeMotionPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
 
   // Unroll affine.for loops.
   pm.addPass(createLoopUnrollPass(
       /*unrollFactor=*/256,
       /*unrollUpToFactor=*/true));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  pm.addPass(createMemRefDataFlowOptPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
@@ -25,7 +25,8 @@ public:
            spirv::Capability::Groups, spirv::Capability::SubgroupDispatch,
            spirv::Capability::Int64, spirv::Capability::Int16,
            spirv::Capability::Int8, spirv::Capability::Float64,
-           spirv::Capability::Float16, spirv::Capability::GroupNonUniformBallot,
+           spirv::Capability::Float16, spirv::Capability::Vector16,
+           spirv::Capability::GroupNonUniformBallot,
            spirv::Capability::SubgroupBufferBlockIOINTEL},
           mlir::ArrayRef<spirv::Extension>(
               spirv::Extension::SPV_INTEL_subgroups),


### PR DESCRIPTION
Show general direction of the memory ops vectorization pass, e.g. use subgroup_block_read8 instead of 8x subgroup_block_read1.

Things that are missing in llvm upstream (locally implemented, will move these to llvm next week):
1. New SPIRV Op OpVectorExtractDynamic
2. Lowering of vector.extract_element to SPIRV
3. Updates to Vector size verification. For OpenCL with Vector16 capability we are allowed to use vector size 8 and 16, which we want to leverage on. Per spirv spec, Vulkan does not allow it.

Things that are missing and not there yet:
1. Simple mlir tests for all new features (worked on real case conv1x1 scenario)
2. Proper logic and functional tests with the ops that we can actualy block read using these vectors, will check with Konrad's layouts reorders
3. Currently only vector_load supported, support vector write as well
4. Lowerings of vector_loads\stores to spirv in the llvm upstream
