### PR TITLE
Update Repeat to Fluent API

### DIFF
--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -599,10 +599,35 @@ inline edsl::Tensor reorg_yolo(const edsl::Tensor& I, int stride, bool decrease,
   return details::op("reorg_yolo", args).as_tensor();
 }
 
-inline edsl::Tensor repeat(const edsl::Tensor& I, int repeats, int axis) {
-  auto args = edsl::make_tuple(I, repeats, axis);
-  return details::op("repeat", args).as_tensor();
-}
+class repeat {
+ public:
+  explicit repeat(const edsl::Tensor& I) : I_(I) {}
+
+  repeat& repeats(int repeats) {
+    repeats_ = edsl::Value(repeats);
+    return *this;
+  }
+
+  repeat& repeats(const edsl::TensorDim& repeats) {
+    repeats_ = edsl::Value(repeats);
+    return *this;
+  }
+
+  repeat& axis(int axis) {
+    axis_ = edsl::Value(axis);
+    return *this;
+  }
+
+  operator edsl::Tensor() const {
+    auto args = edsl::make_tuple(I_, repeats_, axis_);
+    return details::op("repeat", args).as_tensor();
+  }
+
+ private:
+  edsl::Tensor I_;
+  edsl::Value repeats_ = edsl::Value(1);
+  edsl::Value axis_ = edsl::Value(0);
+};
 
 inline edsl::Tensor reshape(const edsl::Tensor& I, const edsl::Value& dims) {
   auto args = edsl::make_tuple(I, dims);

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -603,13 +603,13 @@ class repeat {
  public:
   explicit repeat(const edsl::Tensor& I) : I_(I) {}
 
-  repeat& repeats(int repeats) {
-    repeats_ = edsl::Value(repeats);
+  repeat& count(int count) {
+    count_ = edsl::Value(count);
     return *this;
   }
 
-  repeat& repeats(const edsl::TensorDim& repeats) {
-    repeats_ = edsl::Value(repeats);
+  repeat& count(const edsl::TensorDim& count) {
+    count_ = edsl::Value(count);
     return *this;
   }
 
@@ -619,13 +619,13 @@ class repeat {
   }
 
   operator edsl::Tensor() const {
-    auto args = edsl::make_tuple(I_, repeats_, axis_);
+    auto args = edsl::make_tuple(I_, count_, axis_);
     return details::op("repeat", args).as_tensor();
   }
 
  private:
   edsl::Tensor I_;
-  edsl::Value repeats_ = edsl::Value(1);
+  edsl::Value count_ = edsl::Value(1);
   edsl::Value axis_ = edsl::Value(0);
 };
 

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -533,7 +533,7 @@ TEST_F(OpTest, ReorgYoloNHWC) {
 
 TEST_F(OpTest, Repeat) {
   auto A = Placeholder(DType::FLOAT32, {32, 1, 4, 1}, "A");
-  auto X = op::repeat(A).repeats(3).axis(2);
+  auto X = op::repeat(A).count(3).axis(2);
   auto program = makeProgram("repeat", {A}, {X});
   runProgram(program);
 }

--- a/plaidml/op/op_test.cc
+++ b/plaidml/op/op_test.cc
@@ -533,7 +533,7 @@ TEST_F(OpTest, ReorgYoloNHWC) {
 
 TEST_F(OpTest, Repeat) {
   auto A = Placeholder(DType::FLOAT32, {32, 1, 4, 1}, "A");
-  auto X = op::repeat(A, 3, 2);
+  auto X = op::repeat(A).repeats(3).axis(2);
   auto program = makeProgram("repeat", {A}, {X});
   runProgram(program);
 }


### PR DESCRIPTION
Upgrade the API for repeat to enable the use of the new TensorDim repeats parameter, which I overlooked in #1518.