### PR TITLE
Vectorize memory ops

### DIFF
--- a/pmlc/conversion/gpu_to_spirv/BUILD
+++ b/pmlc/conversion/gpu_to_spirv/BUILD
@@ -35,5 +35,6 @@ plaidml_cc_library(
         "@llvm-project//mlir:GPUToSPIRVTransforms",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:SPIRVDialect",
+        "@llvm-project//mlir:VectorOps",
     ],
 )

--- a/pmlc/dialect/pxa/analysis/affine_constraints.cc
+++ b/pmlc/dialect/pxa/analysis/affine_constraints.cc
@@ -26,10 +26,10 @@ addAffineParallelIVDomain(mlir::AffineParallelOp parallelOp, unsigned idx,
   mlir::AffineValueMap lowerMap = parallelOp.getLowerBoundsValueMap();
   mlir::AffineValueMap upperMap = parallelOp.getUpperBoundsValueMap();
   if (auto constLower =
-          lowerMap.getResult(idx).cast<mlir::AffineConstantExpr>())
+          lowerMap.getResult(idx).dyn_cast<mlir::AffineConstantExpr>())
     constraints.addConstantLowerBound(pos, constLower.getValue());
   if (auto constUpper =
-          upperMap.getResult(idx).cast<mlir::AffineConstantExpr>())
+          upperMap.getResult(idx).dyn_cast<mlir::AffineConstantExpr>())
     constraints.addConstantUpperBound(pos, constUpper.getValue() - 1);
   return mlir::success();
 }

--- a/pmlc/dialect/pxa/tests/vectorize-mem_ops.mlir
+++ b/pmlc/dialect/pxa/tests/vectorize-mem_ops.mlir
@@ -1,0 +1,18 @@
+// RUN: pmlc-opt -pxa-vectorize-mem -verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func @vectorize_mem 
+func @vectorize_mem(%arg0: memref<16x16xf32>) {
+  %0 = alloc() : memref<1x1x16x1xvector<16xf32>>
+  // CHECK: affine.parallel (%[[VECIDX:.*]])
+  // CHECK:   %[[VECLOAD:.*]] = pxa.vector_load
+  // CHECK:   affine.parallel
+  // CHECK:     %[[SUBIDX:.*]] = subi
+  // CHECK:     %[[EXTRACT:.*]] = vector.extract_map %[[VECLOAD]][%[[SUBIDX]] : 8] : vector<128xf32> to vector<16xf32>
+  // CHECK:     pxa.reduce assign %[[EXTRACT]]
+  %1 = affine.parallel (%arg9) = (0) to (16) reduce ("assign") -> (memref<1x1x16x1xvector<16xf32>>) {
+    %2 = pxa.vector_load %arg0[%arg9, 0] : memref<16x16xf32>, vector<16xf32>
+    %3 = pxa.reduce assign %2, %0[0, 0, %arg9, 0] : memref<1x1x16x1xvector<16xf32>>
+    affine.yield %3 : memref<1x1x16x1xvector<16xf32>>
+  }
+  return
+}

--- a/pmlc/dialect/pxa/tests/vectorize-mem_ops.mlir
+++ b/pmlc/dialect/pxa/tests/vectorize-mem_ops.mlir
@@ -16,3 +16,67 @@ func @vectorize_mem(%arg0: memref<16x16xf32>) {
   }
   return
 }
+
+// CHECK-LABEL: func @vectorize_mem_write
+func @vectorize_mem_write(%arg0: memref<16x16xf32>, %arg1: memref<16x16xf32>) {
+  %0 = alloc() : memref<16xvector<16xf32>>
+  // CHECK: affine.parallel (%[[VECIDX:.*]])
+  // CHECK:   %[[ALLOC:.*]] = alloc() : memref<128xf32>
+  // CHECK:   affine.parallel
+  // CHECK:     %[[LOAD_INNER:.*]] = pxa.load
+  // CHECK:     %[[SUBIDX:.*]] = subi
+  // CHECK:     %[[INSERT:.*]] = vector.insert_map %[[LOAD_INNER]], %[[SUBIDX]]
+  // CHECK:     %[[REDUCE_INNER:.*]] = pxa.vector_reduce assign %[[INSERT]], %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  // CHECK:     affine.yield %{{.*}} : memref<128xf32>
+  // CHECK:   %[[LOAD:.*]] = pxa.vector_load %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  // CHECK:   pxa.vector_reduce assign %[[LOAD]]
+  %1 = affine.parallel (%arg9) = (0) to (16) reduce ("assign") -> (memref<16x16xf32>) {
+    %2 = pxa.load %0[%arg9] : memref<16xvector<16xf32>>
+    %3 = pxa.vector_reduce assign %2, %arg1[%arg9, 0] : memref<16x16xf32>, vector<16xf32>
+    affine.yield %3 : memref<16x16xf32>
+  }
+  return
+}
+
+// CHECK-LABEL: func @vectorize_mem_read_write
+func @vectorize_mem_read_write(%arg0: memref<16x16xf32>, %arg1: memref<16x16xf32>) {
+  %0 = alloc() : memref<1x1x16x1xvector<16xf32>>
+  // CHECK: affine.parallel (%[[VECIDX:.*]])
+  // CHECK:   %[[VECLOAD:.*]] = pxa.vector_load
+  // CHECK:   %[[ALLOC:.*]] = alloc() : memref<128xf32>
+  // CHECK:   affine.parallel
+  // CHECK:     %[[SUBIDX:.*]] = subi
+  // CHECK:     %[[EXTRACT:.*]] = vector.extract_map %[[VECLOAD]][%[[SUBIDX]] : 8] : vector<128xf32> to vector<16xf32>
+  // CHECK:     %[[SUBIDX2:.*]] = subi
+  // CHECK:     %[[INSERT:.*]] = vector.insert_map %[[EXTRACT]], %[[SUBIDX2]]
+  // CHECK:     %[[REDUCE_INNER:.*]] = pxa.vector_reduce assign %[[INSERT]], %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  // CHECK:     affine.yield %{{.*}} : memref<128xf32>
+  // CHECK:   %[[LOAD:.*]] = pxa.vector_load %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  %1 = affine.parallel (%arg9) = (0) to (16) reduce ("assign") -> (memref<16x16xf32>) {
+    %2 = pxa.vector_load %arg0[%arg9, 0] : memref<16x16xf32>, vector<16xf32>
+    %3 = pxa.vector_reduce assign %2, %arg1[%arg9, 0] : memref<16x16xf32>, vector<16xf32>
+    affine.yield %3 : memref<16x16xf32>
+  }
+  return
+}
+
+// CHECK-LABEL: func @vectorize_mem_multi_dim
+func @vectorize_mem_multi_dim(%arg0: memref<4x16x16xf32>, %arg1: memref<4x16x16xf32>) {
+  // CHECK: affine.parallel (%{{.*}}, %[[VECIDX:.*]])
+  // CHECK:   %[[VECLOAD:.*]] = pxa.vector_load
+  // CHECK:   %[[ALLOC:.*]] = alloc() : memref<128xf32>
+  // CHECK:   affine.parallel
+  // CHECK:     %[[SUBIDX:.*]] = subi
+  // CHECK:     %[[EXTRACT:.*]] = vector.extract_map %[[VECLOAD]][%[[SUBIDX]] : 8] : vector<128xf32> to vector<16xf32>
+  // CHECK:     %[[SUBIDX2:.*]] = subi
+  // CHECK:     %[[INSERT:.*]] = vector.insert_map %[[EXTRACT]], %[[SUBIDX2]]
+  // CHECK:     %[[REDUCE_INNER:.*]] = pxa.vector_reduce assign %[[INSERT]], %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  // CHECK:     affine.yield %{{.*}} : memref<128xf32>
+  // CHECK:   %[[LOAD:.*]] = pxa.vector_load %[[ALLOC]][%{{.*}}] : memref<128xf32>, vector<128xf32>
+  %1 = affine.parallel (%arg8, %arg9) = (0, 0) to (4, 16) reduce ("assign") -> (memref<4x16x16xf32>) {
+    %2 = pxa.vector_load %arg0[%arg8, %arg9, 0] : memref<4x16x16xf32>, vector<16xf32>
+    %3 = pxa.vector_reduce assign %2, %arg1[%arg8, %arg9, 0] : memref<4x16x16xf32>, vector<16xf32>
+    affine.yield %3 : memref<4x16x16xf32>
+  }
+  return
+}

--- a/pmlc/dialect/pxa/transforms/BUILD
+++ b/pmlc/dialect/pxa/transforms/BUILD
@@ -45,6 +45,7 @@ plaidml_cc_library(
         "tile.cc",
         "tile_accumulate.cc",
         "vectorize.cc",
+        "vectorize_mem.cc",
     ],
     hdrs = [
         "autotile.h",

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -74,6 +74,8 @@ std::unique_ptr<mlir::Pass> createSimplifyWithConstraintsPass();
 std::unique_ptr<mlir::Pass> createReorderLayoutsPass();
 std::unique_ptr<mlir::Pass> createReorderLayoutsPass(bool allowReorder);
 
+std::unique_ptr<mlir::Pass> createVectorizeMemPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "pmlc/dialect/pxa/transforms/passes.h.inc"

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -242,4 +242,9 @@ def ReorderLayouts : FunctionPass<"pxa-reorder-layouts"> {
   ];
 }
 
+def VectorizeMem : FunctionPass<"pxa-vectorize-mem"> {
+  let summary = "Vectorize load and reduce assign ops";
+  let constructor = "pmlc::dialect::pxa::createVectorizeMemPass()";
+}
+
 #endif // __PMLC_DIALECT_PXA_PASSES__

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -245,6 +245,7 @@ def ReorderLayouts : FunctionPass<"pxa-reorder-layouts"> {
 def VectorizeMem : FunctionPass<"pxa-vectorize-mem"> {
   let summary = "Vectorize load and reduce assign ops";
   let constructor = "pmlc::dialect::pxa::createVectorizeMemPass()";
+  let dependentDialects = ["mlir::vector::VectorDialect"];
 }
 
 #endif // __PMLC_DIALECT_PXA_PASSES__

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -7,6 +7,7 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "pmlc/dialect/pxa/analysis/strides.h"
+#include "pmlc/dialect/pxa/transforms/tile.h"
 
 #include "pmlc/dialect/pxa/ir/ops.h"
 #include "pmlc/dialect/pxa/transforms/pass_detail.h"
@@ -14,130 +15,204 @@
 
 using namespace mlir; // NOLINT[build/namespaces]
 
-// TODO: add detailed description here
+// This pass extracts the block read and write operations from the
+// AffineParallel loop of certain size and conditions and vectorizes it. Instead
+// of having the vector_load or vector_reduce assign that operates on global
+// memory inside the loop, we leverage on the vectorized block ops HW
+// capability, to perform less reads and extract data from vector inside the
+// actual loop. This pass currently assumes using of intel block ops, and gets
+// most benefit after moving to block formats in layout reorder pass. The new
+// vector size is the multiplication of the subgroup_size and block op vector
+// size, and gets reduced upon devectorization and adding actual block ops. The
+// new ExtractMapOp cannot be used as is, it gets lowered to
+// vector.extractelement in the further passes.
+//
+// Sample:
+// Orginal Op:
+//  %1 = affine.parallel (%arg1) = (0) to (16) reduce ("assign") {
+//    %2 = pxa.vector_load %arg0[%arg1, 0] : memref<16x16xf32>, vector<16xf32>
+//    %3 = pxa.reduce assign
+//    affine.yield %3
+//  }
+//
+// Modified Op:
+//  %1 = affine.parallel (%arg1) = (0) to (16) step (8) {
+//    %2 = pxa.vector_load %arg0[%arg1, 0] : memref<16x16xf32>, vector<128xf32>
+//    %3 = affine.parallel (%arg2) = (%arg1) to (%arg1 + 8)
+//      %4 = subi %arg2, %arg1 : index
+//      %5 = vector.extract_map %2[%4 : 8] : vector<128xf32> to vector<16xf32>
+//      %6 = pxa.reduce assign
+//      affine.yield %6
+//    }
+//  }
 
 namespace pmlc::dialect::pxa {
 
 namespace {
 
-// TODO: Maybe move this to a generic utility somewhere
-template <typename OpTy, typename... Args>
-static OpTy replaceOp(Operation *op, Args &&... args) {
-  OpBuilder builder(op);
-  auto newOp = builder.create<OpTy>(op->getLoc(), std::forward<Args>(args)...);
-  op->getResult(0).replaceAllUsesWith(newOp.getResult());
-  op->erase();
-  return newOp;
+void getGlobalMemory(FuncOp f, std::list<Operation *> &globalAllocList) {
+  for (auto allocOp : f.getOps<AllocOp>()) {
+    globalAllocList.push_back(allocOp.getOperation());
+  }
+  for (auto parallelOp : f.getOps<AffineParallelOp>()) {
+    globalAllocList.push_back(parallelOp.getOperation());
+  }
+}
+
+void vectorizeReads(AffineParallelOp loopOp,
+                    std::list<Operation *> &globalAllocList) {
+  for (auto loadOp :
+       llvm::make_early_inc_range(loopOp.getOps<PxaReadOpInterface>())) {
+    auto defOp = loadOp.getMemRef().getDefiningOp();
+
+    // TODO: consider adding case with vload usage also, right now only support
+    // vector_loads
+    auto vectorLoad = dyn_cast<PxaVectorLoadOp>(loadOp.getOperation());
+    if (!vectorLoad) {
+      return;
+    }
+
+    // Check if vector_load reads from global memory. Currently it is not
+    // allowed to use block ops on in-kernel memory
+    if (defOp && std::find(globalAllocList.begin(), globalAllocList.end(),
+                           defOp) == globalAllocList.end()) {
+      return;
+    }
+    IVLOG(3, "Load Op: " << debugString(*vectorLoad));
+
+    // Get strides
+    auto maybeSI = computeStrideInfo(vectorLoad);
+    if (!maybeSI) {
+      return;
+    }
+    IVLOG(3, "StrideInfo: " << debugString(*maybeSI));
+
+    // Check if read op uses parallel op IV for a single dimension
+    auto strideVal = 0;
+    SmallVector<BlockArgument, 4> blockArgs;
+    for (auto ba : loopOp.getIVs()) {
+      if (maybeSI->strides.count(ba)) {
+        strideVal = maybeSI->strides.find(ba)->second;
+        blockArgs.push_back(ba);
+      }
+    }
+
+    if (blockArgs.size() != 1) {
+      return;
+    }
+
+    // Get the size of the considered dimension
+    auto ranges = loopOp.getConstantRanges();
+    if (!ranges) {
+      return;
+    }
+
+    auto argNum = blockArgs[0].getArgNumber();
+    auto loopVectorSize = (*ranges)[argNum];
+    IVLOG(3, "LoopVecSize: " << loopVectorSize);
+
+    // Check if loop size is a multiple of allowed vector size
+    // for the vectorized block op. Right now only 8, 4, 2 sizes are
+    // allowed for this extension. If size is bigger than vector size
+    // then there would be needed additional tiling
+    auto tileSize = 0;
+    SmallVector<int64_t, 4> allowedVecSizes({8, 4, 2});
+    for (auto allowedVecSize : allowedVecSizes) {
+      if (loopVectorSize % allowedVecSize == 0) {
+        tileSize = allowedVecSize;
+        break;
+      }
+    }
+    if (!tileSize)
+      return;
+
+    // Get the current vector size for vector_load op, this is modelled
+    // as subgroup size. With this pass it will be expanded to
+    // mem op vector size x subgroup size.
+    auto vecShape = vectorLoad.getVectorType().getShape();
+    if (vecShape.size() != 1)
+      return;
+    auto subgroupSize = vecShape[0];
+
+    // Check if data allows for the vectorized block read. Right now it is
+    // modelled as an additional dimension that is being added on reaorder
+    // layout pass. Thie minimum number of dimensions is 2.
+    auto memrefTypeShape = vectorLoad.getMemRefType().getShape();
+    if (memrefTypeShape.size() < 2)
+      return;
+
+    // Verify if our loop size matches the dimension size.
+    if (memrefTypeShape[memrefTypeShape.size() - 2] != loopVectorSize)
+      return;
+
+    // Finished with checks, now perform actual tiling if needed
+    BlockArgument tiledBlockArg;
+    if (tileSize != loopVectorSize) {
+      performTiling(loopOp, llvm::ArrayRef<int64_t>({tileSize}));
+      for (auto newLoopOp : loopOp.getOps<AffineParallelOp>()) {
+        blockArgs[0] = newLoopOp.getIVs()[0];
+        tiledBlockArg = loopOp.getIVs()[0];
+        loopOp = newLoopOp;
+      }
+    }
+
+    // Create constant op of value 0, that would replace the actual IV of the
+    // loop we are extracting from, in case the loop was not tiled.
+    // If it was tiled then it will be removed later on.
+    OpBuilder builder(loopOp);
+    auto const0 = builder.create<ConstantIndexOp>(loopOp.getLoc(), 0);
+
+    // Replace the IV except for the orginal operation that would become
+    // vector.extractelement later. In case of no tiling it would be 0,
+    // if tiled then the outer parallel op IV.
+    llvm::SmallPtrSet<Operation *, 8> idxNoChange;
+    for (auto user : blockArgs[0].getUsers()) {
+      if (user != loadOp)
+        idxNoChange.insert(user);
+    }
+    blockArgs[0].replaceAllUsesExcept(
+        tileSize != loopVectorSize ? dyn_cast<Value>(tiledBlockArg) : const0,
+        idxNoChange);
+
+    // Create new vector that would be of subgroup size x loop size
+    auto vectorType = VectorType::get(
+        {subgroupSize * tileSize}, vectorLoad.getVectorType().getElementType());
+
+    // Create new vector load with expanded vector size.
+    // This op is extracted from the orginal loop.
+    auto newLoadOp = builder.create<PxaVectorLoadOp>(
+        loopOp.getLoc(), vectorType, vectorLoad.getMemRef(),
+        vectorLoad.getAffineMap(), vectorLoad.getMapOperands());
+
+    // Replace original op with extract map. Use extract map instead of extract
+    // element as we do not extract scalar but vector of size equal to subgroup.
+    // In case we needed tiling, additional fix to the index computation needed
+    // to subtract the outer loop IV.
+    builder.setInsertionPoint(vectorLoad);
+    Value const1Result;
+    if (tileSize != loopVectorSize) {
+      auto const1 = builder.create<SubIOp>(vectorLoad.getLoc(), blockArgs[0],
+                                           tiledBlockArg);
+      const1Result = const1.getResult();
+    }
+    auto newExtractMapOp = builder.create<vector::ExtractMapOp>(
+        vectorLoad.getLoc(), newLoadOp.getResult(),
+        tileSize != loopVectorSize ? const1Result : blockArgs[0], tileSize);
+    vectorLoad.getResult().replaceAllUsesWith(newExtractMapOp.getResult());
+    vectorLoad.erase();
+  }
 }
 
 struct VectorizeMemPass : public VectorizeMemBase<VectorizeMemPass> {
   void runOnFunction() final {
     FuncOp f = getFunction();
-    // TODO: generalize this for all read\write ops
-    f.walk([&](PxaReadOpInterface loadOp) {
-      auto defOp = loadOp.getMemRef().getDefiningOp();
-      if (defOp) {
-        return;
-      }
 
-      // TODO: consider adding case with vload usage also, not only vectorized
-      // block read
-      auto vectorLoad = dyn_cast<PxaVectorLoadOp>(loadOp.getOperation());
-      if (!vectorLoad) {
-        return;
-      }
+    // Get global memory
+    std::list<Operation *> globalAllocList;
+    getGlobalMemory(f, globalAllocList);
 
-      // Check if op is inside AffineParallelOp to extract it from
-      auto loopOp = vectorLoad.getParentOfType<AffineParallelOp>();
-      if (!loopOp) {
-        return;
-      }
-
-      IVLOG(3, "Load Op: " << debugString(*vectorLoad));
-
-      // Check strides
-      auto maybeSI = computeStrideInfo(vectorLoad);
-      if (!maybeSI) {
-        return;
-      }
-      IVLOG(3, "StrideInfo: " << debugString(*maybeSI));
-
-      // TODO: verify if we can do vlock op here based on the strides and
-      // dimension we iterate in the parent loop
-      SmallVector<BlockArgument, 4> blockArgs;
-      for (auto ba : loopOp.getIVs()) {
-        if (maybeSI->strides.count(ba)) {
-          blockArgs.push_back(ba);
-        }
-      }
-
-      if (blockArgs.size() != 1) {
-        return;
-      }
-
-      // TODO: add checks if vector size is valid (2, 4, 8).
-      // For the block ops we limit to the 2, 4, 8, but if we
-      // consider vload then vec size 16 would be also allowed,
-      // at least it is in OpenCL, double check this.
-      auto ranges = loopOp.getConstantRanges();
-      if (!ranges) {
-        return;
-      }
-
-      auto argNum = blockArgs[0].getArgNumber();
-      auto loopVectorSize = (*ranges)[argNum];
-      IVLOG(3, "LoopVecSize: " << loopVectorSize);
-
-      if (!(loopVectorSize == 2 || loopVectorSize == 4 || loopVectorSize == 8))
-        return;
-
-      auto vecShape = vectorLoad.getVectorType().getShape();
-      // Accept only vectors with dim size 1
-      if (vecShape.size() != 1)
-        return;
-
-      // Create constant op of value 0, that would replace the actual IV of the
-      // loop we are extracting from
-      OpBuilder builder(loopOp);
-      auto const0 = builder.create<ConstantIndexOp>(loopOp.getLoc(), 0);
-
-      // Replace the IV except for the orginal operation that would become
-      // vector.extractelement later
-      llvm::SmallPtrSet<Operation *, 8> idxNoChange;
-      for (auto user : blockArgs[0].getUsers()) {
-        if (user != loadOp)
-          idxNoChange.insert(user);
-      }
-      blockArgs[0].replaceAllUsesExcept(const0, idxNoChange);
-
-      // Create new vector that would be of orginal size x loop size
-      auto vectorType =
-          VectorType::get({vecShape[0] * loopVectorSize},
-                          vectorLoad.getVectorType().getElementType());
-
-      // Create new vector load, extracted from the orginal loop
-      auto newLoadOp = builder.create<PxaVectorLoadOp>(
-          loopOp.getLoc(), vectorType, vectorLoad.getMemRef(),
-          vectorLoad.getAffineMap(), vectorLoad.getMapOperands());
-
-      // TODO: The below commented code implements additional temporary vector
-      // in case we would like to put few loads to single vector.
-      // auto nemMemrefType = MemRefType::get({1}, vectorType);
-      // auto newAllocOp = builder.create<AllocOp>(loopOp.getLoc(),
-      // nemMemrefType); SmallVector<Value, 4> indices;
-      // indices.push_back(const0.getResult());
-      // auto newStoreOp =
-      // builder.create<vector::TransferWriteOp>(loopOp.getLoc(),
-      // newLoadOp.getResult(), newAllocOp.getResult(), indices); auto
-      // newLoadOp2 =
-      // builder.create<vector::TransferReadOp>(vectorLoad.getLoc(), vectorType,
-      // newStoreOp.memref(), indices);
-
-      // Replace original op with extract map.
-      // Use extract map instead of extract element as we do not extract
-      // scalar but vector of size equal to subgroup
-      replaceOp<vector::ExtractMapOp>(vectorLoad, newLoadOp.getResult(),
-                                      blockArgs[0], loopVectorSize);
+    f.walk([&](AffineParallelOp loopOp) {
+      vectorizeReads(loopOp, globalAllocList);
     });
   }
 };

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -1,0 +1,151 @@
+// Copyright 2020 Intel Corporation
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "pmlc/dialect/pxa/analysis/strides.h"
+
+#include "pmlc/dialect/pxa/ir/ops.h"
+#include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/util/logging.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+// TODO: add detailed description here
+
+namespace pmlc::dialect::pxa {
+
+namespace {
+
+// TODO: Maybe move this to a generic utility somewhere
+template <typename OpTy, typename... Args>
+static OpTy replaceOp(Operation *op, Args &&... args) {
+  OpBuilder builder(op);
+  auto newOp = builder.create<OpTy>(op->getLoc(), std::forward<Args>(args)...);
+  op->getResult(0).replaceAllUsesWith(newOp.getResult());
+  op->erase();
+  return newOp;
+}
+
+struct VectorizeMemPass : public VectorizeMemBase<VectorizeMemPass> {
+  void runOnFunction() final {
+    FuncOp f = getFunction();
+    // TODO: generalize this for all read\write ops
+    f.walk([&](PxaReadOpInterface loadOp) {
+      auto defOp = loadOp.getMemRef().getDefiningOp();
+      if (defOp) {
+        return;
+      }
+
+      // TODO: consider adding case with vload usage also, not only vectorized
+      // block read
+      auto vectorLoad = dyn_cast<PxaVectorLoadOp>(loadOp.getOperation());
+      if (!vectorLoad) {
+        return;
+      }
+
+      // Check if op is inside AffineParallelOp to extract it from
+      auto loopOp = vectorLoad.getParentOfType<AffineParallelOp>();
+      if (!loopOp) {
+        return;
+      }
+
+      IVLOG(3, "Load Op: " << debugString(*vectorLoad));
+
+      // Check strides
+      auto maybeSI = computeStrideInfo(vectorLoad);
+      if (!maybeSI) {
+        return;
+      }
+      IVLOG(3, "StrideInfo: " << debugString(*maybeSI));
+
+      // TODO: verify if we can do vlock op here based on the strides and
+      // dimension we iterate in the parent loop
+      SmallVector<BlockArgument, 4> blockArgs;
+      for (auto ba : loopOp.getIVs()) {
+        if (maybeSI->strides.count(ba)) {
+          blockArgs.push_back(ba);
+        }
+      }
+
+      if (blockArgs.size() != 1) {
+        return;
+      }
+
+      // TODO: add checks if vector size is valid (2, 4, 8).
+      // For the block ops we limit to the 2, 4, 8, but if we
+      // consider vload then vec size 16 would be also allowed,
+      // at least it is in OpenCL, double check this.
+      auto ranges = loopOp.getConstantRanges();
+      if (!ranges) {
+        return;
+      }
+
+      auto argNum = blockArgs[0].getArgNumber();
+      auto loopVectorSize = (*ranges)[argNum];
+      IVLOG(3, "LoopVecSize: " << loopVectorSize);
+
+      if (!(loopVectorSize == 2 || loopVectorSize == 4 || loopVectorSize == 8))
+        return;
+
+      auto vecShape = vectorLoad.getVectorType().getShape();
+      // Accept only vectors with dim size 1
+      if (vecShape.size() != 1)
+        return;
+
+      // Create constant op of value 0, that would replace the actual IV of the
+      // loop we are extracting from
+      OpBuilder builder(loopOp);
+      auto const0 = builder.create<ConstantIndexOp>(loopOp.getLoc(), 0);
+
+      // Replace the IV except for the orginal operation that would become
+      // vector.extractelement later
+      llvm::SmallPtrSet<Operation *, 8> idxNoChange;
+      for (auto user : blockArgs[0].getUsers()) {
+        if (user != loadOp)
+          idxNoChange.insert(user);
+      }
+      blockArgs[0].replaceAllUsesExcept(const0, idxNoChange);
+
+      // Create new vector that would be of orginal size x loop size
+      auto vectorType =
+          VectorType::get({vecShape[0] * loopVectorSize},
+                          vectorLoad.getVectorType().getElementType());
+
+      // Create new vector load, extracted from the orginal loop
+      auto newLoadOp = builder.create<PxaVectorLoadOp>(
+          loopOp.getLoc(), vectorType, vectorLoad.getMemRef(),
+          vectorLoad.getAffineMap(), vectorLoad.getMapOperands());
+
+      // TODO: The below commented code implements additional temporary vector
+      // in case we would like to put few loads to single vector.
+      // auto nemMemrefType = MemRefType::get({1}, vectorType);
+      // auto newAllocOp = builder.create<AllocOp>(loopOp.getLoc(),
+      // nemMemrefType); SmallVector<Value, 4> indices;
+      // indices.push_back(const0.getResult());
+      // auto newStoreOp =
+      // builder.create<vector::TransferWriteOp>(loopOp.getLoc(),
+      // newLoadOp.getResult(), newAllocOp.getResult(), indices); auto
+      // newLoadOp2 =
+      // builder.create<vector::TransferReadOp>(vectorLoad.getLoc(), vectorType,
+      // newStoreOp.memref(), indices);
+
+      // Replace original op with extract map.
+      // Use extract map instead of extract element as we do not extract
+      // scalar but vector of size equal to subgroup
+      replaceOp<vector::ExtractMapOp>(vectorLoad, newLoadOp.getResult(),
+                                      blockArgs[0], loopVectorSize);
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createVectorizeMemPass() {
+  return std::make_unique<VectorizeMemPass>();
+}
+
+} // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -352,8 +352,9 @@ struct VectorizeMemImpl {
       // Set tile sizes, care only about the last dim, rest should be set to 1
       // If there are multiple arguments used in the vector op, we still do
       // tiling but only with 1's, as we need additional loop to extract from
-      for (auto i = 0; i < loopOp.getIVs().size(); i++) {
-        if (i == loopOp.getIVs().size() - 1 && memOpsPlan.tileSize != 0)
+      for (int i = 0; i < static_cast<int>(loopOp.getIVs().size()); i++) {
+        if (i == static_cast<int>(loopOp.getIVs().size()) - 1 &&
+            memOpsPlan.tileSize != 0)
           tileSizes.push_back(memOpsPlan.tileSize);
         else
           tileSizes.push_back(1);

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -38,64 +38,90 @@ using namespace mlir; // NOLINT[build/namespaces]
 // Modified Op:
 //  %1 = affine.parallel (%arg1) = (0) to (16) step (8) {
 //    %2 = pxa.vector_load %arg0[%arg1, 0] : memref<16x16xf32>, vector<128xf32>
-//    %3 = affine.parallel (%arg2) = (%arg1) to (%arg1 + 8)
+//    %3 = affine.parallel (%arg2) = (%arg1) to (%arg1 + 8) {
 //      %4 = subi %arg2, %arg1 : index
 //      %5 = vector.extract_map %2[%4 : 8] : vector<128xf32> to vector<16xf32>
 //      %6 = pxa.reduce assign
 //      affine.yield %6
 //    }
 //  }
+//
+// Sample regarding the vector_reduce assign op:
+// Orginal Op:
+//  %1 = affine.parallel (%arg1) = (0) to (16) reduce ("assign") {
+//    %2 = pxa.load
+//    %3 = pxa.reduce assign %2, %arg0[%arg1, 0] : memref<16x16xf32>,
+//    vector<16xf32> affine.yield %3
+//  }
+//
+// Modified Op:
+//  %1 = affine.parallel (%arg1) = (0) to (16) step (8) {
+//    %2 = alloc() : memref<128xf32>
+//    %3 = affine.parallel (%arg2) = (%arg1) to (%arg1 + 8) {
+//      %4 = pxa.load
+//      %5 = subi %arg2, %arg1 : index
+//      %6 = vector.insert_map %4, %5, 8 : vector<16xf32> to vector<128xf32>
+//      %7 = pxa.vector_reduce assign %6, %2[%c0_1] : memref<128xf32>,
+//      vector<128xf32> affine.yield %7
+//    }
+//    %4 = pxa.vector_load %2[%c0_1] : memref<128xf32>, vector<128xf32>
+//    %5 = pxa.vector_reduce assign %4, %arg1[%arg1, 0] : memref<16x16xf32>,
+//    vector<128xf32> affine.yield %5
+//  }
 
 namespace pmlc::dialect::pxa {
 
 namespace {
 
-void getGlobalMemory(FuncOp f, std::list<Operation *> &globalAllocList) {
-  for (auto allocOp : f.getOps<AllocOp>()) {
-    globalAllocList.push_back(allocOp.getOperation());
-  }
-  for (auto parallelOp : f.getOps<AffineParallelOp>()) {
-    globalAllocList.push_back(parallelOp.getOperation());
-  }
-}
+struct VectorizeMemImpl {
+  VectorizeMemImpl(AffineParallelOp loopOp,
+                   std::list<Operation *> &globalAllocList)
+      : loopOp(loopOp), globalAllocList(globalAllocList) {}
 
-void vectorizeReads(AffineParallelOp loopOp,
-                    std::list<Operation *> &globalAllocList) {
-  for (auto loadOp :
-       llvm::make_early_inc_range(loopOp.getOps<PxaReadOpInterface>())) {
-    auto defOp = loadOp.getMemRef().getDefiningOp();
+  struct VectorizeMemOpsPlan {
+    // List of vector load\reduce ops that passed the checks for vectorization
+    std::list<Operation *> memOps;
+    // Index of the loop from which the mem op will be extracted and vectorized
+    BlockArgument blockArg;
+    // Subgroup size equals vector size of the vector op before modification
+    int64_t subgroupSize = 0;
+    // Loop size from which the extraction will take place
+    int64_t loopVectorSize = 0;
+    // Tile size in case there is a need for tiling
+    int64_t tileSize = 0;
+    // Index of the loop after tiling
+    Value tiledBlockArg;
+  };
 
-    // TODO: consider adding case with vload usage also, right now only support
-    // vector_loads
-    auto vectorLoad = dyn_cast<PxaVectorLoadOp>(loadOp.getOperation());
-    if (!vectorLoad) {
-      return;
-    }
-
+  // Apply checks for vector ops, qualify those for vectorization
+  template <typename T>
+  void checkMemOp(T memOp) {
+    auto defOp = memOp.getMemRef().getDefiningOp();
     // Check if vector_load reads from global memory. Currently it is not
     // allowed to use block ops on in-kernel memory
     if (defOp && std::find(globalAllocList.begin(), globalAllocList.end(),
                            defOp) == globalAllocList.end()) {
       return;
     }
-    IVLOG(3, "Load Op: " << debugString(*vectorLoad));
+    IVLOG(3, "Mem Op: " << debugString(*memOp));
 
     // Get strides
-    auto maybeSI = computeStrideInfo(vectorLoad);
+    auto maybeSI = computeStrideInfo(memOp);
     if (!maybeSI) {
       return;
     }
     IVLOG(3, "StrideInfo: " << debugString(*maybeSI));
 
     // Check if read op uses parallel op IV for a single dimension
-    SmallVector<BlockArgument, 4> blockArgs;
     for (auto ba : loopOp.getIVs()) {
       if (maybeSI->strides.count(ba)) {
-        blockArgs.push_back(ba);
+        orgBlockArgs.push_back(ba);
       }
     }
 
-    if (blockArgs.size() != 1) {
+    // Check if block number is not empty,
+    // In case it is bigger than one we will handle this upon tiling
+    if (orgBlockArgs.empty()) {
       return;
     }
 
@@ -105,7 +131,7 @@ void vectorizeReads(AffineParallelOp loopOp,
       return;
     }
 
-    auto argNum = blockArgs[0].getArgNumber();
+    auto argNum = orgBlockArgs[orgBlockArgs.size() - 1].getArgNumber();
     auto loopVectorSize = (*ranges)[argNum];
     IVLOG(3, "LoopVecSize: " << loopVectorSize);
 
@@ -127,7 +153,7 @@ void vectorizeReads(AffineParallelOp loopOp,
     // Get the current vector size for vector_load op, this is modelled
     // as subgroup size. With this pass it will be expanded to
     // mem op vector size x subgroup size.
-    auto vecShape = vectorLoad.getVectorType().getShape();
+    auto vecShape = memOp.getVectorType().getShape();
     if (vecShape.size() != 1)
       return;
     auto subgroupSize = vecShape[0];
@@ -135,7 +161,7 @@ void vectorizeReads(AffineParallelOp loopOp,
     // Check if data allows for the vectorized block read. Right now it is
     // modelled as an additional dimension that is being added on reaorder
     // layout pass. Thie minimum number of dimensions is 2.
-    auto memrefTypeShape = vectorLoad.getMemRefType().getShape();
+    auto memrefTypeShape = memOp.getMemRefType().getShape();
     if (memrefTypeShape.size() < 2)
       return;
 
@@ -143,16 +169,56 @@ void vectorizeReads(AffineParallelOp loopOp,
     if (memrefTypeShape[memrefTypeShape.size() - 2] != loopVectorSize)
       return;
 
-    // Finished with checks, now perform actual tiling if needed
-    Value tiledBlockArg;
-    if (tileSize != loopVectorSize) {
-      performTiling(loopOp, llvm::ArrayRef<int64_t>({tileSize}));
-      for (auto newLoopOp : loopOp.getOps<AffineParallelOp>()) {
-        blockArgs[0] = newLoopOp.getIVs()[0];
-        tiledBlockArg = loopOp.getIVs()[0];
-        loopOp = newLoopOp;
-      }
+    // Last checks for vectorReduceOp
+    auto vectorReduceOp =
+        dyn_cast_or_null<PxaVectorReduceOp>(memOp.getOperation());
+    if (vectorReduceOp &&
+        (vectorReduceOp.getAgg() != AtomicRMWKind::assign ||
+         loopOp.results().size() != 1 ||
+         (tileSize == loopVectorSize &&
+          loopOp.getParentOfType<AffineParallelOp>() &&
+          loopOp.getParentOfType<AffineParallelOp>().getResult(0).getType() !=
+              loopOp.getResult(0).getType()))) {
+      return;
     }
+
+    // Make sure we consider only ops with the same parameters.
+    // Fill the values for first read op, the others should be the same
+    // as previous ones to be valid.
+    if ((!memOpsPlan.loopVectorSize && !memOpsPlan.subgroupSize &&
+         !memOpsPlan.tileSize) ||
+        (memOpsPlan.blockArg == orgBlockArgs[orgBlockArgs.size() - 1] &&
+         memOpsPlan.loopVectorSize == loopVectorSize &&
+         memOpsPlan.subgroupSize == subgroupSize &&
+         memOpsPlan.tileSize == tileSize)) {
+      memOpsPlan.memOps.push_back(memOp);
+      memOpsPlan.blockArg = orgBlockArgs[orgBlockArgs.size() - 1];
+      memOpsPlan.loopVectorSize = loopVectorSize;
+      memOpsPlan.subgroupSize = subgroupSize;
+      memOpsPlan.tileSize = tileSize;
+    }
+  }
+
+  LogicalResult getWritesAndReads() {
+    // Starting with the vector load ops, as we mostly care about
+    // reads optimization that are more costly than writes
+    for (auto vectorLoadOp :
+         llvm::make_early_inc_range(loopOp.getOps<PxaVectorLoadOp>())) {
+      checkMemOp<PxaVectorLoadOp>(vectorLoadOp);
+    }
+    for (auto vectorReduceOp :
+         llvm::make_early_inc_range(loopOp.getOps<PxaVectorReduceOp>())) {
+      checkMemOp<PxaVectorReduceOp>(vectorReduceOp);
+    }
+    if (!memOpsPlan.memOps.size())
+      return failure();
+    return success();
+  }
+
+  // Helper function to replace argument of the loop in the operation
+  // that will be extracted
+  void replaceArgInLoop(Operation *memOp) {
+    auto blockArg = memOpsPlan.blockArg;
 
     // Create constant op of value 0, that would replace the actual IV of the
     // loop we are extracting from, in case the loop was not tiled.
@@ -164,16 +230,31 @@ void vectorizeReads(AffineParallelOp loopOp,
     // vector.extractelement later. In case of no tiling it would be 0,
     // if tiled then the outer parallel op IV.
     llvm::SmallPtrSet<Operation *, 8> idxNoChange;
-    for (auto user : blockArgs[0].getUsers()) {
-      if (user != loadOp)
+    for (auto user : blockArg.getUsers()) {
+      if (user != memOp)
         idxNoChange.insert(user);
     }
-    blockArgs[0].replaceAllUsesExcept(
-        tileSize != loopVectorSize ? tiledBlockArg : const0, idxNoChange);
+    blockArg.replaceAllUsesExcept(memOpsPlan.tileSize !=
+                                          memOpsPlan.loopVectorSize
+                                      ? memOpsPlan.tiledBlockArg
+                                      : const0,
+                                  idxNoChange);
+  }
 
+  void replaceVectorLoad(PxaVectorLoadOp vectorLoad) {
+    IVLOG(3, "PxaVectorLoadOp: " << debugString(*vectorLoad));
+    auto blockArg = memOpsPlan.blockArg;
+    auto loopVectorSize = memOpsPlan.loopVectorSize;
+    auto tileSize = memOpsPlan.tileSize;
+    auto tiledBlockArg = memOpsPlan.tiledBlockArg;
+
+    replaceArgInLoop(vectorLoad.getOperation());
+
+    OpBuilder builder(loopOp);
     // Create new vector that would be of subgroup size x loop size
-    auto vectorType = VectorType::get(
-        {subgroupSize * tileSize}, vectorLoad.getVectorType().getElementType());
+    auto vectorType =
+        VectorType::get({memOpsPlan.subgroupSize * tileSize},
+                        vectorLoad.getVectorType().getElementType());
 
     // Create new vector load with expanded vector size.
     // This op is extracted from the orginal loop.
@@ -188,15 +269,138 @@ void vectorizeReads(AffineParallelOp loopOp,
     builder.setInsertionPoint(vectorLoad);
     Value const1Result;
     if (tileSize != loopVectorSize) {
-      auto const1 = builder.create<SubIOp>(vectorLoad.getLoc(), blockArgs[0],
-                                           tiledBlockArg);
+      auto const1 =
+          builder.create<SubIOp>(vectorLoad.getLoc(), blockArg, tiledBlockArg);
       const1Result = const1.getResult();
     }
     auto newExtractMapOp = builder.create<vector::ExtractMapOp>(
         vectorLoad.getLoc(), newLoadOp.getResult(),
-        tileSize != loopVectorSize ? const1Result : blockArgs[0], tileSize);
+        tileSize != loopVectorSize ? const1Result : blockArg, tileSize);
     vectorLoad.getResult().replaceAllUsesWith(newExtractMapOp.getResult());
     vectorLoad.erase();
+  }
+
+  void replaceVectorReduce(PxaVectorReduceOp vectorReduce) {
+    IVLOG(3, "PxaVectorReduceOp: " << debugString(*vectorReduce));
+    auto blockArg = memOpsPlan.blockArg;
+    auto loopVectorSize = memOpsPlan.loopVectorSize;
+    auto tileSize = memOpsPlan.tileSize;
+    auto tiledBlockArg = memOpsPlan.tiledBlockArg;
+
+    replaceArgInLoop(vectorReduce.getOperation());
+
+    OpBuilder builder(loopOp);
+    // Create new vector that would be of subgroup size x loop size
+    auto vectorType =
+        VectorType::get({memOpsPlan.subgroupSize * tileSize},
+                        vectorReduce.getVectorType().getElementType());
+
+    auto nemMemrefType =
+        MemRefType::get(vectorType.getShape(), vectorType.getElementType());
+    auto newAllocOp = builder.create<AllocOp>(loopOp.getLoc(), nemMemrefType);
+    auto const0 = builder.create<ConstantIndexOp>(loopOp.getLoc(), 0);
+
+    llvm::SmallVector<AffineExpr, 1> expr;
+    auto outerDim = builder.getAffineDimExpr(0);
+    expr.push_back(outerDim);
+    auto emptyMap = AffineMap::get(1, 0, expr, vectorReduce.getContext());
+
+    builder.setInsertionPoint(vectorReduce);
+    Value const1Result;
+    if (tileSize != loopVectorSize) {
+      auto const1 = builder.create<SubIOp>(vectorReduce.getLoc(), blockArg,
+                                           tiledBlockArg);
+      const1Result = const1.getResult();
+    }
+
+    auto newInsertMapOp = builder.create<vector::InsertMapOp>(
+        vectorReduce.getLoc(), vectorReduce.vector(),
+        tileSize != loopVectorSize ? const1Result : blockArg, tileSize);
+
+    auto results = loopOp.results();
+    for (auto res : results) {
+      res.setType(nemMemrefType);
+    }
+    auto newReduceOp = builder.create<PxaVectorReduceOp>(
+        vectorReduce.getLoc(), AtomicRMWKind::assign,
+        newInsertMapOp.getResult(), newAllocOp, emptyMap,
+        ValueRange{const0.getResult()});
+    builder.setInsertionPointAfter(loopOp);
+    auto newLoadOp = builder.create<PxaVectorLoadOp>(
+        vectorReduce.getLoc(), vectorType, newAllocOp, emptyMap,
+        ValueRange{const0.getResult()});
+    auto newReduceOuterOp = builder.create<PxaVectorReduceOp>(
+        vectorReduce.getLoc(), AtomicRMWKind::assign, newLoadOp.getResult(),
+        vectorReduce.memref(), vectorReduce.getAffineMap(),
+        vectorReduce.idxs());
+    for (auto res : results) {
+      res.replaceAllUsesWith(newReduceOuterOp.getResult());
+    }
+    vectorReduce.getResult().replaceAllUsesWith(newReduceOp.getResult());
+    vectorReduce.erase();
+  }
+
+  void vectorizeOps() {
+    // Finished with checks, now perform actual tiling if needed.
+    // Do it only once, as we previously checked that tile and vector
+    // sizes are the same for all ops.
+    // If orgBlockArgs is not 1, the perform tiling anyway, this will
+    // help with extracting the mem op from the loop.
+    if (memOpsPlan.tileSize != memOpsPlan.loopVectorSize ||
+        orgBlockArgs.size() != 1) {
+      SmallVector<int64_t, 8> tileSizes;
+      // Set tile sizes, care only about the last dim, rest should be set to 1
+      // If there are multiple arguments used in the vector op, we still do
+      // tiling but only with 1's, as we need additional loop to extract from
+      for (auto i = 0; i < loopOp.getIVs().size(); i++) {
+        if (i == loopOp.getIVs().size() - 1 && memOpsPlan.tileSize != 0)
+          tileSizes.push_back(memOpsPlan.tileSize);
+        else
+          tileSizes.push_back(1);
+      }
+      performTiling(loopOp, tileSizes);
+      for (auto newLoopOp : loopOp.getOps<AffineParallelOp>()) {
+        memOpsPlan.blockArg = newLoopOp.getIVs()[newLoopOp.getIVs().size() - 1];
+        memOpsPlan.tiledBlockArg =
+            loopOp.getIVs()[newLoopOp.getIVs().size() - 1];
+        loopOp = newLoopOp;
+        // Now handle rest of the indices, where tiling was set to 1. It is
+        // needed to keep the old arguments instead of the new ones since the
+        // vector op will be extracted from the orginal loop.
+        if (loopOp.getIVs().size() > 1) {
+          for (auto i = 0; i < loopOp.getIVs().size() - 1; i++) {
+            loopOp.getIVs()[i].replaceAllUsesWith(orgBlockArgs[i]);
+          }
+        }
+      }
+    }
+
+    // Iterate over vectlo loads and reduce assigns at once, previously
+    // we checked that all the parameters for these match.
+    for (auto memOp : llvm::make_early_inc_range(memOpsPlan.memOps)) {
+      if (auto vectorLoad = dyn_cast<PxaVectorLoadOp>(memOp))
+        replaceVectorLoad(vectorLoad);
+      else if (auto vectorReduce = dyn_cast<PxaVectorReduceOp>(memOp))
+        replaceVectorReduce(vectorReduce);
+    }
+  }
+
+  // Analyzed loop
+  AffineParallelOp loopOp;
+  // Orginal block arguments. It is needed for replacing the indices
+  SmallVector<BlockArgument, 8> orgBlockArgs;
+  // Global memory list
+  std::list<Operation *> globalAllocList;
+  // Plan for the mem ops vectorization
+  VectorizeMemOpsPlan memOpsPlan;
+};
+
+void getGlobalMemory(FuncOp f, std::list<Operation *> &globalAllocList) {
+  for (auto allocOp : f.getOps<AllocOp>()) {
+    globalAllocList.push_back(allocOp.getOperation());
+  }
+  for (auto parallelOp : f.getOps<AffineParallelOp>()) {
+    globalAllocList.push_back(parallelOp.getOperation());
   }
 }
 
@@ -209,7 +413,10 @@ struct VectorizeMemPass : public VectorizeMemBase<VectorizeMemPass> {
     getGlobalMemory(f, globalAllocList);
 
     f.walk([&](AffineParallelOp loopOp) {
-      vectorizeReads(loopOp, globalAllocList);
+      VectorizeMemImpl vectorizeMemImpl(loopOp, globalAllocList);
+      if (failed(vectorizeMemImpl.getWritesAndReads()))
+        return;
+      vectorizeMemImpl.vectorizeOps();
     });
   }
 };

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -369,7 +369,8 @@ struct VectorizeMemImpl {
         // needed to keep the old arguments instead of the new ones since the
         // vector op will be extracted from the orginal loop.
         if (loopOp.getIVs().size() > 1) {
-          for (auto i = 0; i < loopOp.getIVs().size() - 1; i++) {
+          for (int i = 0; i < static_cast<int>(loopOp.getIVs().size()) - 1;
+               i++) {
             loopOp.getIVs()[i].replaceAllUsesWith(orgBlockArgs[i]);
           }
         }

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -104,17 +104,15 @@ def SubgroupBroadcastOp : StdX_Op<"subgroup_broadcast", [NoSideEffect, AllTypesM
   let verifier = ?;
 }
 
-def AnyVectorOrScalar : AnyTypeOf<[AnyStdScalar, AnyVector]> {} 
+def AnyVectorOrScalar : AnyTypeOf<[AnyStdScalar, AnyVector]> {}
+def SubgroupBlockReadOutputType : AnyTypeOf<[AnyStdScalar, AnyVector, AnyMemRef]> {}
 
-def SubgroupBlockReadINTELOp : StdX_Op<"subgroup_block_read_intel",
-     [TypesMatchWith<"result type matches element type of 'memref'",
-                     "memref", "result",
-                     "$_self.cast<mlir::MemRefType>().getElementType()">]> {
+def SubgroupBlockReadINTELOp : StdX_Op<"subgroup_block_read_intel", [NoSideEffect]> {
   let summary = "See intel_subgroups extension.";
   let arguments = (ins Arg<AnyMemRef, "the reference to subgroup block read from",
                            [MemRead]>:$memref,
                            Variadic<Index>:$indices);
-  let results = (outs AnyVectorOrScalar:$result);
+  let results = (outs SubgroupBlockReadOutputType:$result);
 
   let builders = [OpBuilder<
     "mlir::OpBuilder &, mlir::OperationState &result, mlir::Value memref,"
@@ -130,7 +128,7 @@ def SubgroupBlockReadINTELOp : StdX_Op<"subgroup_block_read_intel",
     operand_range getIndices() { return {operand_begin() + 1, operand_end()}; }
   }];
 
-  let assemblyFormat = "$memref `[` $indices `]` attr-dict `:` type($memref)";
+  let assemblyFormat = "$memref `[` $indices `]` attr-dict `:` type($memref)`,` type($result)";
 }
 
 def SubgroupBlockWriteINTELOp : StdX_Op<"subgroup_block_write_intel",

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -131,10 +131,7 @@ def SubgroupBlockReadINTELOp : StdX_Op<"subgroup_block_read_intel", [NoSideEffec
   let assemblyFormat = "$memref `[` $indices `]` attr-dict `:` type($memref)`,` type($result)";
 }
 
-def SubgroupBlockWriteINTELOp : StdX_Op<"subgroup_block_write_intel",
-     [TypesMatchWith<"type of 'value' matches element type of 'memref'",
-                     "memref", "value",
-                     "$_self.cast<mlir::MemRefType>().getElementType()">]> {
+def SubgroupBlockWriteINTELOp : StdX_Op<"subgroup_block_write_intel", [NoSideEffect]> {
   let summary = "See intel_subgroups extension.";
 
   let arguments = (ins AnyVectorOrScalar:$value,
@@ -160,7 +157,7 @@ def SubgroupBlockWriteINTELOp : StdX_Op<"subgroup_block_write_intel",
   }];
 
   let assemblyFormat = [{
-    $value `,` $memref `[` $indices `]` attr-dict `:` type($memref)
+    $value `,` $memref `[` $indices `]` attr-dict `:` type($value) `,` type($memref)
   }];
 }
 

--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/SPIRV/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/SPIRVOps.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -104,6 +105,7 @@ struct ParallelLoopToGpuPass
     target.addLegalDialect<AffineDialect>();
     target.addLegalDialect<gpu::GPUDialect>();
     target.addLegalDialect<scf::SCFDialect>();
+    target.addLegalOp<vector::InsertElementOp>();
     target.addIllegalOp<scf::ParallelOp>();
     if (failed(applyPartialConversion(getOperation(), target, patterns)))
       signalPassFailure();

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -11,9 +11,11 @@
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/DebugStringHelper.h"
 
 #include "pmlc/dialect/stdx/ir/ops.h"
 #include "pmlc/target/intel_gen/pass_detail.h"
+#include "pmlc/util/logging.h"
 #include "pmlc/util/tags.h"
 
 using namespace mlir; // NOLINT[build/namespaces]
@@ -34,7 +36,7 @@ public:
       : loop(loop), vectorSize(vectorSize), useBlockOps(useBlockOps) {}
 
   bool isVectorTypeValid(VectorType type) {
-    return type.getRank() == 1 && type.getDimSize(0) == vectorSize;
+    return type.getRank() == 1 && type.getDimSize(0) % vectorSize == 0;
   }
 
   template <typename T>
@@ -81,6 +83,7 @@ public:
   }
 
   LogicalResult devectorizeTransferRead(vector::TransferReadOp op) {
+    IVLOG(3, "Orginal Op: " << debugString(*op));
     if (!isVectorTypeValid(op.getVectorType()) || op.indices().size() < 1)
       return failure();
     OpBuilder builder(op);
@@ -97,16 +100,57 @@ public:
     // TODO: add additional requirements like mem alignment
     if (useBlockOps && !invalidMemScope &&
         isBlockOpTypeSupported<vector::TransferReadOp>(op)) {
-      auto newBlockReadOp =
-          builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
-              op.getLoc(), op.memref(), idxs);
-      devectorizeVectorOp(newBlockReadOp.getOperation());
-      op.replaceAllUsesWith(newBlockReadOp.getResult());
+      // Case1: vector size is the multiplication of subgroup size, in this case
+      // we use vector of size divided by subgroup size as output from
+      // SubgroupBlockReadINTELOp
+      if (op.getVectorType().getDimSize(0) > vectorSize) {
+        // Change vector dimension, we already checked earlier that dimsize %
+        // vecsize == 0
+        auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
+        auto vectorType = VectorType::get({newVectorSize},
+                                          op.getVectorType().getElementType());
+        SmallVector<int64_t, 1> newShape;
+        newShape.push_back(newVectorSize);
+        auto newMemrefType =
+            VectorType::get(newShape, op.getVectorType().getElementType());
+        auto newBlockReadOp =
+            builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
+                op.getLoc(), newMemrefType, op.memref(), idxs);
+
+        IVLOG(3, "Load Op: " << debugString(*newBlockReadOp));
+        op.replaceAllUsesWith(newBlockReadOp.getResult());
+        // Case2: output from SubgroupBlockReadINTELOp is scalar,
+        // In this case it is also needed to devectorize the operands afterwards
+      } else {
+        auto newBlockReadOp =
+            builder.create<dialect::stdx::SubgroupBlockReadINTELOp>(
+                op.getLoc(), op.memref(), idxs);
+        devectorizeVectorOp(newBlockReadOp.getOperation());
+        op.replaceAllUsesWith(newBlockReadOp.getResult());
+        IVLOG(3, "Load Op: " << debugString(*newBlockReadOp));
+      }
+      // Case3: Used buffer was allocated inside the kernel, no block reads
+      // allowed. Check if element type of the allocated memory is vector, if so
+      // then it is needed to use vector TransferReadOp for writing
+    } else if (auto allocVecType =
+                   dyn_cast<AllocOp>(op.memref().getDefiningOp())
+                       .getType()
+                       .getElementType()
+                       .dyn_cast<VectorType>()) {
+      auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
+      auto vectorType =
+          VectorType::get({newVectorSize}, op.getVectorType().getElementType());
+      auto newLoadOp = builder.create<vector::TransferReadOp>(
+          op.getLoc(), vectorType, op.memref(), idxs);
+      IVLOG(3, "Block read Op: " << debugString(*newLoadOp));
+      op.replaceAllUsesWith(newLoadOp.getResult());
+      // Case4: No block reads or vectors, use default devectorization
     } else {
       idxs.back() = builder.create<AddIOp>(op.getLoc(), idxs.back(), sid);
       auto newLoadOp = builder.create<LoadOp>(op.getLoc(), op.memref(), idxs);
       devectorizeVectorOp(newLoadOp.getOperation());
       op.replaceAllUsesWith(newLoadOp.getResult());
+      IVLOG(3, "Load Op: " << debugString(*newLoadOp));
     }
     op.erase();
     return success();
@@ -127,19 +171,32 @@ public:
     // TODO: Based on the HW caps we should accept these for certain data types
     // Right now we accept i16/fp16 and i32/fp32 for the block read extensions
     // TODO: add additional requirements like mem alignment
+    // Case1: Use block write
     if (useBlockOps && !invalidMemScope &&
         isBlockOpTypeSupported<vector::TransferWriteOp>(op)) {
       auto newBlockWriteOp =
           builder.create<dialect::stdx::SubgroupBlockWriteINTELOp>(
               op.getLoc(), op.vector(), op.memref(), idxs);
       devectorizeVectorOp(newBlockWriteOp.getOperation());
+      IVLOG(3, "Block Write Op: " << debugString(*newBlockWriteOp));
+      op.erase();
+      // Case2: TODO: Change this condition to include memref being vector,
+      // where it is needed to use vector write instead
+    } else if (dyn_cast<dialect::stdx::SubgroupBlockReadINTELOp>(
+                   op.vector().getDefiningOp())) {
+      auto newStoreOp = builder.create<vector::TransferWriteOp>(
+          op.getLoc(), op.vector(), op.memref(), idxs);
+      IVLOG(3, "Block Write Op: " << debugString(*newStoreOp));
+      op.erase();
+      // Case3: No block writes or vectors, use default devectorization
     } else {
       idxs.back() = builder.create<AddIOp>(op.getLoc(), idxs.back(), sid);
       auto newStoreOp =
           builder.create<StoreOp>(op.getLoc(), op.vector(), op.memref(), idxs);
       devectorizeVectorOp(newStoreOp.getOperation());
+      IVLOG(3, "Block Write Op: " << debugString(*newStoreOp));
+      op.erase();
     }
-    op.erase();
     return success();
   }
 
@@ -151,13 +208,48 @@ public:
       return success();
     }
     auto shape = vecType.getShape();
-    if (shape.size() != 1 || shape[0] != vectorSize) {
+    if (shape.size() != 1) {
       // Vector allocations must match the subgroup size
       return failure();
     }
-    auto newMemRefType = MemRefType::Builder(oldMemRefType)
-                             .setElementType(vecType.getElementType());
+
+    // Check if element type is vector, it should be of size multiplication
+    // of subgroup size or equal. If it is multiplication then divide it by
+    // subgroup size to create new Alloc
+    Type newElementType = vecType.getElementType();
+    if (shape[0] > vectorSize) {
+      auto newVectorSize = shape[0] / vectorSize;
+      newElementType =
+          VectorType::get({newVectorSize}, vecType.getElementType());
+    } else if (shape[0] != vectorSize) {
+      return failure();
+    }
+
+    auto newMemRefType =
+        MemRefType::Builder(oldMemRefType).setElementType(newElementType);
     op.getResult().setType(newMemRefType);
+    IVLOG(3, "Alloc Op: " << debugString(*op));
+    return success();
+  }
+
+  LogicalResult devectorizeExtractMap(vector::ExtractMapOp op) {
+    OpBuilder builder(op);
+    auto idVal = op.id();
+    IVLOG(3, "oldExtractOp: " << debugString(*op));
+    // It is needed to use i32 type for extract element index. Use cast in case
+    // it comes from index
+    if (op.id().getType().dyn_cast<IndexType>()) {
+      auto indexCast = builder.create<IndexCastOp>(op.getLoc(), idVal,
+                                                   builder.getIntegerType(32));
+      idVal = indexCast.getResult();
+    }
+
+    auto newExtractOp = builder.create<vector::ExtractElementOp>(
+        op.getLoc(), op.vector(), idVal);
+    op.replaceAllUsesWith(newExtractOp.getResult());
+    op.erase();
+
+    IVLOG(3, "newExtractOp: " << debugString(*newExtractOp));
     return success();
   }
 
@@ -191,6 +283,8 @@ public:
       return devectorizeTransferWrite(vecWriteOp);
     } else if (auto vecBroadcastOp = dyn_cast<vector::BroadcastOp>(op)) {
       return devectorizeBroadcast(vecBroadcastOp);
+    } else if (auto extractMapOp = dyn_cast<vector::ExtractMapOp>(op)) {
+      return devectorizeExtractMap(extractMapOp);
     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       for (auto &innerOp : llvm::make_early_inc_range(forOp.getOps())) {
         if (failed(devectorizeOperation(&innerOp))) {

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -130,11 +130,12 @@ public:
       // Case3: Used buffer was allocated inside the kernel, no block reads
       // allowed. Check if element type of the allocated memory is vector, if so
       // then it is needed to use vector TransferReadOp for writing
-    } else if (auto allocVecType =
-                   dyn_cast<AllocOp>(op.memref().getDefiningOp())
-                       .getType()
-                       .getElementType()
-                       .dyn_cast<VectorType>()) {
+    } else if (op.memref().getDefiningOp() &&
+               dyn_cast<AllocOp>(op.memref().getDefiningOp())
+                   .getType()
+                   .getElementType()
+                   .dyn_cast<VectorType>() &&
+               op.getVectorType().getDimSize(0) != vectorSize) {
       auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
       auto vectorType =
           VectorType::get({newVectorSize}, op.getVectorType().getElementType());

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -257,12 +257,11 @@ public:
       idVal = indexCast.getResult();
     }
 
-    // Assume that the user of insert_map of is TransferWriteOp,
+    // Assume that the user of insert_map is TransferWriteOp,
     // so the whole structure was modelled in the vectorizeMemPass
-    Operation *InsertMapUserOp;
-    for (auto user : op.getResult().getUsers())
-      InsertMapUserOp = user;
-    auto transferWriteOp = dyn_cast<vector::TransferWriteOp>(InsertMapUserOp);
+    auto &insertMapUser = *op.getResult().use_begin();
+    auto transferWriteOp =
+        dyn_cast<vector::TransferWriteOp>(insertMapUser.getOwner());
     if (!transferWriteOp)
       return failure();
     auto vecType = op.getResultType();

--- a/pmlc/target/intel_gen/subgroup_broadcast.cc
+++ b/pmlc/target/intel_gen/subgroup_broadcast.cc
@@ -107,8 +107,6 @@ public:
         // Change vector dimension, we already checked earlier that dimsize %
         // vecsize == 0
         auto newVectorSize = op.getVectorType().getDimSize(0) / vectorSize;
-        auto vectorType = VectorType::get({newVectorSize},
-                                          op.getVectorType().getElementType());
         SmallVector<int64_t, 1> newShape;
         newShape.push_back(newVectorSize);
         auto newMemrefType =

--- a/pmlc/target/intel_gen/tests/subgroup_block_ops.mlir
+++ b/pmlc/target/intel_gen/tests/subgroup_block_ops.mlir
@@ -15,7 +15,7 @@ func @subgroup_block_read_write(%arg0: memref<64xf32>, %arg1: memref<64xf32>) {
       %0 = vector.transfer_read %arg0[%i], %cst : memref<64xf32>, vector<8xf32>
       %1 = extract_element %0[%c1] : vector<8xf32>
       %2 = vector.broadcast %1 : f32 to vector<8xf32>
-      // CHECK: stdx.subgroup_block_write_intel %{{.*}}, %{{.*}}[%[[IDX]]] : memref<64xf32>
+      // CHECK: stdx.subgroup_block_write_intel %{{.*}}, %{{.*}}[%[[IDX]]] : f32, memref<64xf32>
       vector.transfer_write %2, %arg1[%i] : vector<8xf32>, memref<64xf32>
       scf.yield
     }  {tags = {gpuThread, subgroupSize=8}}

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -79,6 +79,11 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  pm.addPass(pxa::createVectorizeMemPass());
+  pm.addPass(pxa::createAffineNormalizePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   // Assign GPU blocks + threads to outermost loop
   pm.addPass(pmlc::dialect::pxa::createGPUThreadPass(/*maxThreads=*/64));
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -79,11 +79,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addPass(pxa::createVectorizeMemPass());
-  pm.addPass(pxa::createAffineNormalizePass());
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
-
   // Assign GPU blocks + threads to outermost loop
   pm.addPass(pmlc::dialect::pxa::createGPUThreadPass(/*maxThreads=*/64));
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
@@ -97,6 +92,19 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
+
+  // Data layout optimization.
+  pm.addPass(createIntelGenOclReorderLayoutsPass(/*maxThreads=*/64,
+                                                 /*allowReorder=*/false));
+  pm.addPass(pxa::createSimplifyWithConstraintsPass());
+  pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  // pm.addPass(pxa::createVectorizeMemPass());
+  // pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
+  // pm.addPass(createCanonicalizerPass());
+  // pm.addPass(createCSEPass());
 
   // Lower out of PXA memory semantics
   pm.addPass(pmlc::target::intel_gen::createLowerPXAToAffinePass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -109,6 +109,10 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  pm.addPass(createMemRefDataFlowOptPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   // Pack dims
   pm.addPass(pmlc::target::intel_gen::createAffineIndexPackPass());
   pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -109,10 +109,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addPass(createMemRefDataFlowOptPass());
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
-
   // Pack dims
   pm.addPass(pmlc::target::intel_gen::createAffineIndexPackPass());
   pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -93,14 +93,6 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  // Data layout optimization.
-  pm.addPass(createIntelGenOclReorderLayoutsPass(/*maxThreads=*/64,
-                                                 /*allowReorder=*/false));
-  pm.addPass(pxa::createSimplifyWithConstraintsPass());
-  pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
-
   // pm.addPass(pxa::createVectorizeMemPass());
   // pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
   // pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -105,6 +105,10 @@ void pipelineBuilder(OpPassManager &pm) {
   // pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
   // pm.addPass(createCanonicalizerPass());
   // pm.addPass(createCSEPass());
+  pm.addPass(pxa::createVectorizeMemPass());
+  pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
 
   // Lower out of PXA memory semantics
   pm.addPass(pmlc::target::intel_gen::createLowerPXAToAffinePass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -93,14 +93,11 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  // pm.addPass(pxa::createVectorizeMemPass());
-  // pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
-  // pm.addPass(createCanonicalizerPass());
-  // pm.addPass(createCSEPass());
-  pm.addPass(pxa::createVectorizeMemPass());
+  // TODO: uncomment this pass after llvm upstream update with dynamic vec ops
+  /*pm.addPass(pxa::createVectorizeMemPass());
   pm.addPass(pmlc::dialect::pxa::createAffineNormalizePass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(createCSEPass());*/
 
   // Lower out of PXA memory semantics
   pm.addPass(pmlc::target::intel_gen::createLowerPXAToAffinePass());

--- a/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/spirv_target.cc
@@ -25,7 +25,8 @@ public:
            spirv::Capability::Groups, spirv::Capability::SubgroupDispatch,
            spirv::Capability::Int64, spirv::Capability::Int16,
            spirv::Capability::Int8, spirv::Capability::Float64,
-           spirv::Capability::Float16, spirv::Capability::GroupNonUniformBallot,
+           spirv::Capability::Float16, spirv::Capability::Vector16,
+           spirv::Capability::GroupNonUniformBallot,
            spirv::Capability::SubgroupBufferBlockIOINTEL},
           mlir::ArrayRef<spirv::Extension>(
               spirv::Extension::SPV_INTEL_subgroups),


### PR DESCRIPTION
Things that are missing in llvm upstream, before we can have pull this in:

- New SPIRV Op OpVectorExtractDynamic and lowering of vector.extract_element to SPIRV (https://reviews.llvm.org/D90679)
- Updates to Vector size verification (https://reviews.llvm.org/D90683)

Currently only vector_load supported, WIP support for vector write as well