### PR TITLE
Disable tile.MulOp fold pattern with 0 when result() and rhs() have different datatypes

### DIFF
--- a/pmlc/dialect/tile/ir/eltwise.cc
+++ b/pmlc/dialect/tile/ir/eltwise.cc
@@ -64,6 +64,13 @@ OpFoldResult DivOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult MulOp::fold(ArrayRef<Attribute> operands) {
+  // mul(x, 0) -> 0
+  if (lhs().getType() == rhs().getType()) {
+    if (matchPattern(rhs(), m_Zero())) {
+      return rhs();
+    }
+  }
+
   // mul(x, 1) -> x
   if (matchPattern(rhs(), m_One())) {
     return lhs();

--- a/pmlc/dialect/tile/ir/eltwise.cc
+++ b/pmlc/dialect/tile/ir/eltwise.cc
@@ -70,7 +70,6 @@ OpFoldResult MulOp::fold(ArrayRef<Attribute> operands) {
       return rhs();
     }
   }
-
   // mul(x, 1) -> x
   if (matchPattern(rhs(), m_One())) {
     return lhs();

--- a/pmlc/dialect/tile/ir/eltwise.cc
+++ b/pmlc/dialect/tile/ir/eltwise.cc
@@ -64,10 +64,6 @@ OpFoldResult DivOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult MulOp::fold(ArrayRef<Attribute> operands) {
-  // mul(x, 0) -> 0
-  if (matchPattern(rhs(), m_Zero())) {
-    return rhs();
-  }
   // mul(x, 1) -> x
   if (matchPattern(rhs(), m_One())) {
     return lhs();

--- a/pmlc/dialect/tile/ir/eltwise.cc
+++ b/pmlc/dialect/tile/ir/eltwise.cc
@@ -65,8 +65,8 @@ OpFoldResult DivOp::fold(ArrayRef<Attribute> operands) {
 
 OpFoldResult MulOp::fold(ArrayRef<Attribute> operands) {
   // mul(x, 0) -> 0
-  if (lhs().getType() == rhs().getType()) {
-    if (matchPattern(rhs(), m_Zero())) {
+  if (matchPattern(rhs(), m_Zero())) {
+    if (result().getType() == rhs().getType()) {
       return rhs();
     }
   }


### PR DESCRIPTION
Sometimes we want the result of a Tensor multiple 0 to be still a Tensor such as in [a workaround for embedding bag offsets sum ](https://github.com/Flex-plaidml-team/openvino/pull/5/files#diff-4e93753e3ae0a26abb5bfdebfd81e3ccbddf047c1d89c6cefac41c840b1a5f8eR76).

The following test currently does not get compiled. 
I removed the corresponding MulOp fold pattern in this patch so we do not need the workaround in the example above. Please advice if there is a better way to fix this.

TEST_F(CppEdsl, MulZero) {
  auto I = Placeholder(DType::FLOAT32, {3, 3});
  auto O = I * 0;
  auto program = makeProgram("mul_zero", {I}, {O});
}