### PR TITLE
Remove src memref from comp.alloc

### DIFF
--- a/pmlc/conversion/comp_to_llvm/comp_to_ocl.cc
+++ b/pmlc/conversion/comp_to_llvm/comp_to_ocl.cc
@@ -208,8 +208,7 @@ void addOclFunctionDeclarations(mlir::ModuleOp &module) {
   if (!module.lookupSymbol(kOclAlloc)) {
     builder.create<LLVM::LLVMFuncOp>(
         loc, kOclAlloc,
-        LLVM::LLVMType::getFunctionTy(llvmInt8Ptr,
-                                      {llvmInt8Ptr, llvmInt32, llvmInt8Ptr},
+        LLVM::LLVMType::getFunctionTy(llvmInt8Ptr, {llvmInt8Ptr, llvmInt32},
                                       /*isVarArg=*/false));
   }
   if (!module.lookupSymbol(kOclDealloc)) {
@@ -375,18 +374,6 @@ ConvertAlloc::matchAndRewrite(comp::Alloc op,
       loc, LLVM::LLVMType::getInt32Ty(rewriter.getContext()),
       rewriter.getI32IntegerAttr(numElement * elementTypeSize));
   castOperands.push_back(bufferByteSize);
-  // Operand 2 - pointer to data on host or null.
-  if (operands.size() > 1) {
-    mlir::Value hostPtr = materializeConversion(rewriter, loc, operands[1]);
-    if (!hostPtr)
-      return mlir::failure();
-    castOperands.push_back(hostPtr);
-  } else {
-    LLVM::LLVMType llvmPointerType =
-        LLVM::LLVMType::getInt8PtrTy(rewriter.getContext());
-    mlir::Value nullPtr = rewriter.create<LLVM::NullOp>(loc, llvmPointerType);
-    castOperands.push_back(nullPtr);
-  }
 
   mlir::Type llvmResultType = convertType(op.getType());
   rewriter.replaceOpWithNewOp<LLVM::CallOp>(

--- a/pmlc/conversion/comp_to_llvm/tests/comp_to_ocl.mlir
+++ b/pmlc/conversion/comp_to_llvm/tests/comp_to_ocl.mlir
@@ -40,9 +40,7 @@ module {
   // CHECK-LABEL: func @alloc_dealloc
   //  CHECK-SAME:     %[[DEV:.*]]: !llvm.ptr<i8>
   //       CHECK:   %[[ENV:.*]] = llvm.call @oclCreate(%[[DEV]])
-  //       CHECK:   %[[CNT:.*]] = llvm.mlir.constant(1024
-  //       CHECK:   %[[NUL:.*]] = llvm.mlir.null
-  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %[[CNT]], %[[NUL]])
+  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %{{.*}})
   //       CHECK:   llvm.call @oclDealloc(%[[ENV]], %[[MEM]])
   //       CHECK:   llvm.call @oclDestroy(%[[ENV]])
   func @alloc_dealloc(%dev: !comp.device) {
@@ -61,8 +59,7 @@ module attributes {gpu.container_module} {
   //  CHECK-SAME:     %[[DEV:[a-zA-Z0-9]*]]: !llvm.ptr<i8>
   //  CHECK-SAME:     %{{[a-zA-Z0-9]*}}: memref<8x32xf32>
   //       CHECK:   %[[ENV:.*]] = llvm.call @oclCreate(%[[DEV]])
-  //       CHECK:   %[[CNT:.*]] = llvm.mlir.constant(1024
-  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %[[CNT]], %{{.*}})
+  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %{{.*}})
   //       CHECK:   %[[CST0:.*]] = llvm.mlir.constant(0
   //       CHECK:   %[[WEV:.*]] = llvm.call @oclWrite(%{{.*}}, %[[MEM]], %[[ENV]], %[[CST0]])
   //       CHECK:   %[[KRNL:.*]] = llvm.call @oclCreateKernel(%[[ENV]]
@@ -80,7 +77,7 @@ module attributes {gpu.container_module} {
     %c32 = constant 32 : index
     %c1 = constant 1 : index
     %env = comp.create_execenv %dev : (!comp.device) -> !comp.execenv<ocl:0,(11)>
-    %mem0 = comp.alloc %env %arg0 : (!comp.execenv<ocl:0,(11)>, memref<8x32xf32>) -> memref<8x32xf32, 11>
+    %mem0 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<8x32xf32, 11>
     %wev = comp.schedule_write %arg0 to %mem0 on %env : (memref<8x32xf32>, memref<8x32xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
     %fev = "comp.schedule_func"(%env, %wev) ( {
       "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %mem0) {kernel = @gpu_module::@zero} : (index, index, index, index, index, index, memref<8x32xf32, 11>) -> ()
@@ -139,8 +136,7 @@ module attributes {gpu.container_module} {
   //  CHECK-SAME:     %[[DEV:[a-zA-Z0-9]*]]: !llvm.ptr<i8>
   //  CHECK-SAME:     %{{[a-zA-Z0-9]*}}: memref<8x32xf16>
   //       CHECK:   %[[ENV:.*]] = llvm.call @oclCreate(%[[DEV]])
-  //       CHECK:   %[[CNT:.*]] = llvm.mlir.constant(512
-  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %[[CNT]], %{{.*}})
+  //       CHECK:   %[[MEM:.*]] = llvm.call @oclAlloc(%[[ENV]], %{{.*}})
   //       CHECK:   %[[CST0:.*]] = llvm.mlir.constant(0
   //       CHECK:   %[[WEV:.*]] = llvm.call @oclWrite(%{{.*}}, %[[MEM]], %[[ENV]], %[[CST0]])
   //       CHECK:   %[[KRNL:.*]] = llvm.call @oclCreateKernel(%[[ENV]]
@@ -158,7 +154,7 @@ module attributes {gpu.container_module} {
     %c32 = constant 32 : index
     %c1 = constant 1 : index
     %env = comp.create_execenv %dev : (!comp.device) -> !comp.execenv<ocl:0,(11)>
-    %mem0 = comp.alloc %env %arg0 : (!comp.execenv<ocl:0,(11)>, memref<8x32xf16>) -> memref<8x32xf16, 11>
+    %mem0 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<8x32xf16, 11>
     %wev = comp.schedule_write %arg0 to %mem0 on %env : (memref<8x32xf16>, memref<8x32xf16, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
     %fev = "comp.schedule_func"(%env, %wev) ( {
       "gpu.launch_func"(%c8, %c1, %c1, %c32, %c1, %c1, %mem0) {kernel = @gpu_module::@zero} : (index, index, index, index, index, index, memref<8x32xf16, 11>) -> ()

--- a/pmlc/conversion/gpu_to_comp/gpu_to_comp.cc
+++ b/pmlc/conversion/gpu_to_comp/gpu_to_comp.cc
@@ -148,8 +148,12 @@ mlir::LogicalResult RewriteLaunchFunc::allocateDeviceMemory(
             mlir::MemRefType::Builder(memRefType)
                 .setMemorySpace(execEnvType.getDefaultMemorySpace());
         auto allocOp =
-            rewriter.create<comp::Alloc>(loc, newMemRefType, execEnv, hostArg);
+            rewriter.create<comp::Alloc>(loc, newMemRefType, execEnv);
         newArg = allocOp.getResult();
+        comp::EventType eventType = execEnvType.getEventType();
+        mlir::Value event = rewriter.create<comp::ScheduleWrite>(
+            loc, eventType, hostArg, newArg, execEnv, mlir::ValueRange{});
+        rewriter.create<comp::Wait>(loc, event);
       }
     }
 

--- a/pmlc/conversion/gpu_to_comp/tests/gpu_to_comp.mlir
+++ b/pmlc/conversion/gpu_to_comp/tests/gpu_to_comp.mlir
@@ -6,7 +6,9 @@ module attributes {gpu.container_module} {
   //   CHECK-SAME:     %[[DEV:[a-zA-Z0-9]*]]:
   //   CHECK-SAME:     %[[ARGMEM:[a-zA-Z0-9]*]]:
   //        CHECK:   %[[ENV:.*]] = comp.create_execenv %[[DEV]]
-  //      SPACE11:   %[[MEM:.*]] = comp.alloc %[[ENV]] %[[ARGMEM]]
+  //      SPACE11:   %[[MEM:.*]] = comp.alloc %[[ENV]]
+  //      SPACE11:   %[[WEV:.*]] = comp.schedule_write %[[ARGMEM]] to %[[MEM]] on %[[ENV]]
+  //      SPACE11:   comp.wait %[[WEV]]
   //        CHECK:   %[[FEV:.*]] = "comp.schedule_func"(%[[ENV]])
   //   CHECK-NEXT:     gpu.launch_func
   //  SPACE0-SAME:       %[[ARGMEM]]
@@ -45,7 +47,9 @@ module attributes {gpu.container_module} {
   //   CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]*]]:
 
   //        CHECK:   %[[ENV0:.*]] = comp.create_execenv %[[DEV]]
-  //      SPACE11:   %[[MEM02:.*]] = comp.alloc %[[ENV0]] %[[ARG2]]
+  //      SPACE11:   %[[MEM02:.*]] = comp.alloc %[[ENV0]]
+  //      SPACE11:   %[[WEV02:.*]] = comp.schedule_write %[[ARG2]] to %[[MEM02]] on %[[ENV]]
+  //      SPACE11:   comp.wait %[[WEV02]]
   //        CHECK:   %[[FEV0:.*]] = "comp.schedule_func"(%[[ENV0]])
   //        CHECK:     gpu.launch_func
   //  SPACE0-SAME:       %[[ARG2]]
@@ -57,9 +61,15 @@ module attributes {gpu.container_module} {
   //        CHECK:   comp.destroy_execenv %[[ENV0]]
 
   //        CHECK:   %[[ENV1:.*]] = comp.create_execenv %[[DEV]]
-  //      SPACE11:   %[[MEM10:.*]] = comp.alloc %[[ENV1]] %[[ARG0]]
-  //      SPACE11:   %[[MEM11:.*]] = comp.alloc %[[ENV1]] %[[ARG1]]
-  //      SPACE11:   %[[MEM12:.*]] = comp.alloc %[[ENV1]] %[[ARG2]]
+  //      SPACE11:   %[[MEM10:.*]] = comp.alloc %[[ENV1]]
+  //      SPACE11:   %[[WEV10:.*]] = comp.schedule_write %[[ARG0]] to %[[MEM10]] on %[[ENV1]]
+  //      SPACE11:   comp.wait %[[WEV10]]
+  //      SPACE11:   %[[MEM11:.*]] = comp.alloc %[[ENV1]]
+  //      SPACE11:   %[[WEV11:.*]] = comp.schedule_write %[[ARG1]] to %[[MEM11]] on %[[ENV1]]
+  //      SPACE11:   comp.wait %[[WEV11]]
+  //      SPACE11:   %[[MEM12:.*]] = comp.alloc %[[ENV1]]
+  //      SPACE11:   %[[WEV12:.*]] = comp.schedule_write %[[ARG2]] to %[[MEM12]] on %[[ENV1]]
+  //      SPACE11:   comp.wait %[[WEV12]]
   //        CHECK:   %[[FEV1:.*]] = "comp.schedule_func"(%[[ENV1]])
   //        CHECK:     gpu.launch_func
   //  SPACE0-SAME:       %[[ARG0]], %[[ARG1]], %[[ARG2]]

--- a/pmlc/dialect/comp/analysis/mem_sync_tracker.cc
+++ b/pmlc/dialect/comp/analysis/mem_sync_tracker.cc
@@ -32,11 +32,7 @@ bool MemorySynchronizationTracker::handleTransferOp(
   return syncMemory(src, dst);
 }
 
-bool MemorySynchronizationTracker::handleAllocOp(Alloc op) {
-  if (mlir::Value hostMem = op.hostMem())
-    return syncMemory(hostMem, op.getResult());
-  return false;
-}
+bool MemorySynchronizationTracker::handleAllocOp(Alloc op) { return false; }
 
 bool MemorySynchronizationTracker::handleGeneralOp(mlir::Operation *op) {
   bool changed = false;

--- a/pmlc/dialect/comp/ir/dialect.cc
+++ b/pmlc/dialect/comp/ir/dialect.cc
@@ -33,22 +33,6 @@ static LogicalResult verify(ScheduleFunc op) {
   return success();
 }
 
-static LogicalResult verify(Alloc op) {
-  Type deviceMemType = op.deviceMem().getType();
-
-  if (op.hostMem()) {
-    auto hostMemType = op.hostMem().getType();
-    if (deviceMemType.cast<::mlir::ShapedType>().getShape() !=
-        hostMemType.cast<::mlir::ShapedType>().getShape())
-      return op.emitOpError("host and device memory shapes must match");
-    if (getElementTypeOrSelf(deviceMemType) !=
-        getElementTypeOrSelf(hostMemType))
-      return op.emitOpError("host and device memory element types must match");
-  }
-
-  return success();
-}
-
 // Interface implementations
 ::mlir::Value ScheduleWrite::getSource() { return hostMem(); }
 ::mlir::Value ScheduleWrite::getDestination() { return deviceMem(); }

--- a/pmlc/dialect/comp/ir/ops.td
+++ b/pmlc/dialect/comp/ir/ops.td
@@ -144,21 +144,13 @@ def COMP_Submit : COMP_Op<"submit",
 def COMP_Alloc : COMP_Op<"alloc", [MemoryEffects<[MemAlloc<DefaultResource>]>,
                                    COMP_ExecEnvSupportsMemTrait<"execEnv", "deviceMem">,
                                    DeclareOpInterfaceMethods<COMP_ExecEnvOpInterface>]>
-               , Arguments<(ins COMP_AnyExecEnv:$execEnv,
-                                Optional<AnyMemRef>:$hostMem)>
+               , Arguments<(ins COMP_AnyExecEnv:$execEnv)>
                , Results<(outs AnyMemRef:$deviceMem)> {
   let summary = "Allocates memory for use in execution environment.";
 
-  let description = [{
-    Optionally accepts host memory, in which case there is guarantee that
-    after allocation new device memory will contain the same data.
-  }];
-
   let assemblyFormat = [{
-     $execEnv ($hostMem^)? attr-dict `:` functional-type(operands, results)
+     $execEnv attr-dict `:` functional-type(operands, results)
   }];
-
-  let verifier = [{ return ::verify(*this); }];
 }
 
 def COMP_Dealloc : COMP_Op<"dealloc", [MemoryEffects<[MemFree<DefaultResource>]>,

--- a/pmlc/dialect/comp/ir/types.cc
+++ b/pmlc/dialect/comp/ir/types.cc
@@ -23,7 +23,7 @@ bool ExecEnvType::supportsMemorySpace(unsigned requestedSpace) const {
   return memSpaceSupported;
 }
 
-EventType ExecEnvType::getEventType() {
+EventType ExecEnvType::getEventType() const {
   return EventType::get(getContext(), *this);
 }
 

--- a/pmlc/dialect/comp/ir/types.h
+++ b/pmlc/dialect/comp/ir/types.h
@@ -156,7 +156,7 @@ public:
   /// Returns whether `requestedSpace` is supported memory space.
   bool supportsMemorySpace(unsigned requestedSpace) const;
   /// Returns EventType with matching runtime.
-  EventType getEventType();
+  EventType getEventType() const;
 };
 
 // ============================================================================

--- a/pmlc/dialect/comp/tests/minimize_allocations.mlir
+++ b/pmlc/dialect/comp/tests/minimize_allocations.mlir
@@ -20,18 +20,22 @@ func @two_wo_host(%env: !comp.execenv<ocl:0,(11)>) {
 // CHECK-LABEL: func @two_with_host
 //  CHECK-SAME:     %[[ENV:[a-zA-Z0-9]*]]: !comp.execenv
 //  CHECK-SAME:     %[[ARG:[a-zA-Z0-9]*]]: memref
-//       CHECK:   %[[MEM:.*]] = comp.alloc %[[ENV]] %[[ARG]]
-//  CHECK-NEXT:   "op1"(%[[MEM]])
+//       CHECK:   %[[MEM:.*]] = comp.alloc %[[ENV]]
+//       CHECK:   "op1"(%[[MEM]])
 //  CHECK-NEXT:   %[[WEV:.*]] = comp.schedule_write %[[ARG]] to %[[MEM]]
 //  CHECK-NEXT:   comp.wait %[[WEV]]
 //  CHECK-NEXT:   "op2"(%[[MEM]])
 //  CHECK-NEXT:   comp.dealloc %[[ENV]] %[[MEM]]
 func @two_with_host(%env: !comp.execenv<ocl:0,(11)>, %arg: memref<2x3xf32>) {
-  %mem1 = comp.alloc %env %arg : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem1 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %w1 = comp.schedule_write %arg to %mem1 on %env : (memref<2x3xf32>, memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
+  comp.wait %w1 : !comp.event<ocl>
   "op1"(%mem1) : (memref<2x3xf32, 11>) -> ()
   comp.dealloc %env %mem1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
 
-  %mem2 = comp.alloc %env %arg : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem2 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %w2 = comp.schedule_write %arg to %mem2 on %env : (memref<2x3xf32>, memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
+  comp.wait %w2 : !comp.event<ocl>
   "op2"(%mem2) : (memref<2x3xf32, 11>) -> ()
   comp.dealloc %env %mem2 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
   return
@@ -63,19 +67,19 @@ func @three_overlaping(%env: !comp.execenv<ocl:0,(11)>) {
 //       CHECK:   "op1"(%[[MEM1]])
 //       CHECK:   %[[MEM2:.*]] = comp.alloc %[[ENV]]
 //   CHECK-NOT:   comp.schedule_write
-//       CHECK:   "op2"(%[[MEM2]], %[[MEM1]])
-//       CHECK:   comp.dealloc %[[ENV]] %[[MEM2]]
+//       CHECK:   "op2"(%[[MEM1]], %[[MEM2]])
 //       CHECK:   comp.dealloc %[[ENV]] %[[MEM1]]
+//       CHECK:   comp.dealloc %[[ENV]] %[[MEM2]]
 func @prioritize_in_sync(%env: !comp.execenv<ocl:0,(11)>) {
   %host1 = alloc() : memref<2x3xf32>
   %host2 = alloc() : memref<2x3xf32>
-  %mem1 = comp.alloc %env %host1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem1 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
   "op1"(%mem1) : (memref<2x3xf32, 11>) -> ()
   %ev = comp.schedule_read %host1 from %mem1 on %env : (memref<2x3xf32>, memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
   comp.wait %ev : !comp.event<ocl>
   comp.dealloc %env %mem1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
-  %mem2 = comp.alloc %env %host2  : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
-  %mem3 = comp.alloc %env %host1 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem2 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %mem3 = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
   "op2"(%mem2, %mem3) : (memref<2x3xf32, 11>, memref<2x3xf32, 11>) -> ()
   comp.dealloc %env %mem2 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()
   comp.dealloc %env %mem3 : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32, 11>) -> ()

--- a/pmlc/dialect/comp/tests/remove_redundant_rw.mlir
+++ b/pmlc/dialect/comp/tests/remove_redundant_rw.mlir
@@ -22,9 +22,13 @@ func @write_read_wait(%env: !comp.execenv<ocl:0,(11)>, %mem: memref<2x3xf32, 11>
 
 // CHECK-LABEL: func @alloc_read_wait
 //  CHECK-NEXT:   comp.alloc
+//  CHECK-NEXT:   comp.schedule_write
+//  CHECK-NEXT:   comp.wait
 //  CHECK-NEXT:   return
 func @alloc_read_wait(%env: !comp.execenv<ocl:0,(11)>, %host: memref<2x3xf32>) {
-  %mem = comp.alloc %env %host : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %w = comp.schedule_write %host to %mem on %env : (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
+  comp.wait %w : !comp.event<ocl>
   %ev = comp.schedule_read %host from %mem on %env : (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
   comp.wait %ev : !comp.event<ocl>
   return
@@ -44,7 +48,9 @@ func @write_read_barrier(%env: !comp.execenv<ocl:0,(11)>, %mem: memref<2x3xf32, 
 // CHECK-LABEL: func @return_event
 //       CHECK:   comp.schedule_read
 func @return_event(%env: !comp.execenv<ocl:0,(11)>, %host: memref<2x3xf32>) -> !comp.event<ocl> {
-  %mem = comp.alloc %env %host : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %w = comp.schedule_write %host to %mem on %env : (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
+  comp.wait %w : !comp.event<ocl>
   // expected-remark@+2 {{could not remove redundant operation - unknown replacement semantic}}
   // expected-note@+2 {{see user: return}}
   %ev = comp.schedule_read %host from %mem on %env : (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
@@ -54,9 +60,13 @@ func @return_event(%env: !comp.execenv<ocl:0,(11)>, %host: memref<2x3xf32>) -> !
 // CHECK-LABEL: func @return_event_replace
 //  CHECK-SAME:     %[[EV1:[a-zA-Z0-9]*]]: !comp.event
 //  CHECK-NEXT:   comp.alloc
+//  CHECK-NEXT:   comp.schedule_write
+//  CHECK-NEXT:   comp.wait
 //  CHECK-NEXT:   return %[[EV1]]
 func @return_event_replace(%env: !comp.execenv<ocl:0,(11)>, %host: memref<2x3xf32>, %ev1: !comp.event<ocl>) -> !comp.event<ocl> {
-  %mem = comp.alloc %env %host : (!comp.execenv<ocl:0,(11)>, memref<2x3xf32>) -> memref<2x3xf32, 11>
+  %mem = comp.alloc %env : (!comp.execenv<ocl:0,(11)>) -> memref<2x3xf32, 11>
+  %w = comp.schedule_write %host to %mem on %env wait for %ev1: (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
+  comp.wait %w : !comp.event<ocl>
   %ev2 = comp.schedule_read %host from %mem on %env wait for %ev1 : (memref<2x3xf32>,  memref<2x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
   return %ev2 : !comp.event<ocl>
 }

--- a/pmlc/rt/opencl/opencl_invocation.cc
+++ b/pmlc/rt/opencl/opencl_invocation.cc
@@ -118,12 +118,8 @@ OpenCLInvocation::~OpenCLInvocation() {
   device->execTimeInMS = fp_milliseconds(totalExecuteTime).count();
 }
 
-OpenCLMemory *OpenCLInvocation::allocateMemory(size_t bytes, void *data) {
-  cl_mem_flags flags = CL_MEM_READ_WRITE;
-  if (data)
-    flags |= CL_MEM_COPY_HOST_PTR;
-
-  cl::Buffer buffer(device->getOclContext(), flags, bytes, data);
+OpenCLMemory *OpenCLInvocation::allocateMemory(size_t bytes) {
+  cl::Buffer buffer(device->getOclContext(), CL_MEM_READ_WRITE, bytes, nullptr);
   return new OpenCLMemory(buffer, bytes);
 }
 

--- a/pmlc/rt/opencl/opencl_invocation.h
+++ b/pmlc/rt/opencl/opencl_invocation.h
@@ -94,8 +94,7 @@ public:
   ~OpenCLInvocation();
 
   /// Allocates memory on OpenCL device with specified size in bytes.
-  /// If data is not NULL, then its content is copied to allocated memory.
-  OpenCLMemory *allocateMemory(size_t bytes, void *data = NULL);
+  OpenCLMemory *allocateMemory(size_t bytes);
   /// Releases memory obtained from `allocateMemory` call.
   /// Any further use of `memory` is invalid.
   void deallocateMemory(OpenCLMemory *memory);

--- a/pmlc/rt/opencl/opencl_wrappers.cc
+++ b/pmlc/rt/opencl/opencl_wrappers.cc
@@ -19,9 +19,8 @@ void oclDestroy(void *invocation) {
   delete static_cast<OpenCLInvocation *>(invocation);
 }
 
-void *oclAlloc(void *invocation, uint32_t bytes, void *hostPtr) {
-  return static_cast<OpenCLInvocation *>(invocation)
-      ->allocateMemory(bytes, hostPtr);
+void *oclAlloc(void *invocation, size_t bytes) {
+  return static_cast<OpenCLInvocation *>(invocation)->allocateMemory(bytes);
 }
 
 void oclDealloc(void *invocation, void *memory) {


### PR DESCRIPTION
Combining the copy and the alloc prevents us from hoisting the alloc, and doesn't get us a synchronization event for the data copy.  If this optimization turns out to be important, I think it'd be better handled as part of the lowering to LLVM.