### PR TITLE
Sync latest OV op changes

### DIFF
--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT InferenceEngineDeveloperPackage_FOUND)
   FetchContent_Declare(
     openvino
     GIT_REPOSITORY https://github.com/plaidml/openvino.git
-    GIT_TAG        507de2630fb341b4732ace986af22cc6f71ca459
+    GIT_TAG        02c1b88ca69553ab90ad15b18328e6e3169ae205
   )
   if(LOCAL_OPENVINO_DIR)
     set(openvino_SOURCE_DIR ${LOCAL_OPENVINO_DIR})

--- a/plaidml/bridge/openvino/ops/embedding_bag_offsets_sum.cpp
+++ b/plaidml/bridge/openvino/ops/embedding_bag_offsets_sum.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace {
+
+template <typename T>
+std::vector<T> cast_constant_operand(size_t operand_idx, ngraph::Node* layer) {
+  auto* ngraph_const = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
+  if (ngraph_const) {
+    return ngraph_const->cast_vector<T>();
+  } else {
+    THROW_IE_EXCEPTION
+        << "Dynamic slicing not currently supported by PlaidML plugin; all of indices, offsets and default index"
+           "must be Constants.";
+  }
+}
+
+}  // namespace
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("EmbeddingBagOffsetsSum", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset4::EmbeddingBagOffsetsSum>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() >= 3);
+  IE_ASSERT(ctx.operands.size() <= 5);
+  auto I = ctx.operands.at(0);
+  auto indices = ctx.operands.at(1);
+  IE_ASSERT(indices.rank() == 1);
+  auto num_indices = indices.compute_shape().sizes()[0];
+  auto offsets = cast_constant_operand<int32_t>(2, layer);
+  int32_t default_index = -1;
+  edsl::Tensor per_sample_weights;
+  bool with_weights = false;
+
+  if (ctx.operands.size() >= 4) {
+    auto default_index_vec = cast_constant_operand<int32_t>(3, layer);
+    default_index = default_index_vec[0];
+    if (ctx.operands.size() == 5) {
+      per_sample_weights = ctx.operands.at(4);
+      with_weights = true;
+    }
+  }
+
+  auto batch = offsets.size();
+  offsets.push_back(num_indices);
+
+  auto I_gathered = gather(I, indices);
+
+  auto ndims = I_gathered.rank();
+  std::vector<edsl::TensorDim> I_dims(ndims);
+  std::vector<edsl::TensorIndex> I_idxs(ndims);
+  std::vector<edsl::Tensor> slices, Os;
+  I_gathered.bind_dims(I_dims);
+  auto O_dims = I_dims;
+  auto O_idxs = I_idxs;
+
+  O_dims[0] = edsl::TensorDim(1);
+  for (size_t i = 0; i < num_indices; ++i) {
+    O_idxs[0] = I_idxs[0] - i;
+    auto slice = edsl::Contraction(O_dims, O_idxs).sum(I_gathered(I_idxs)).build();
+    if (with_weights == true) {
+      edsl::Tensor weight = op::slice(per_sample_weights).add_dim(i, i + 1);
+      slice = slice * weight;
+    }
+    slices.push_back(slice);
+  }
+
+  for (uint32_t l = 0; l < batch; ++l) {
+    if (offsets[l + 1] == offsets[l]) {
+      if (default_index == -1) {
+        auto zero = cast(edsl::Tensor{0}, slices[0].dtype());
+        auto slice_shape = slices[0].compute_shape().sizes();
+        std::vector<int> target_shape(begin(slice_shape), end(slice_shape));
+        std::vector<int> target_axes = {};
+        Os.push_back(op::broadcast(zero, target_shape, target_axes));
+      } else {
+        O_idxs[0] = I_idxs[0] - default_index;
+        Os.push_back(edsl::Contraction(O_dims, O_idxs).sum(I(I_idxs)));
+      }
+    } else {
+      edsl::Tensor t = slices[offsets[l]];
+      for (uint32_t i = offsets[l] + 1; i < offsets[l + 1]; ++i) {
+        t = t + slices[i];
+      }
+      Os.push_back(t);
+    }
+  }
+
+  auto O = op::concatenate(Os, 0);
+  return edsl::make_tuple(O);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/embedding_bag_packed_sum.cpp
+++ b/plaidml/bridge/openvino/ops/embedding_bag_packed_sum.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+using namespace plaidml::edsl;
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("EmbeddingBagPackedSum", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset4::EmbeddingBagPackedSum>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 2 || ctx.operands.size() == 3);
+  auto I = ctx.operands.at(0);
+  auto indices = ctx.operands.at(1);
+  IE_ASSERT(indices.rank() == 2);
+
+  Tensor per_sample_weights;
+  bool with_weights = false;
+
+  if (ctx.operands.size() == 3) {
+    per_sample_weights = ctx.operands.at(2);
+    IE_ASSERT(per_sample_weights.rank() == 2);
+    with_weights = true;
+  }
+
+  auto I_gathered = gather(I, indices);
+  if (with_weights) {
+    std::vector<int64_t> unsqueeze_axes;
+    for (int64_t i = per_sample_weights.rank(); i < I_gathered.rank(); i++) {
+      unsqueeze_axes.push_back(i);
+    }
+    auto weights_expanded = op::unsqueeze(per_sample_weights, unsqueeze_axes);
+    I_gathered = I_gathered * weights_expanded;
+  }
+  auto reduced = op::sum(I_gathered, edsl::make_tuple(1), false);
+  return edsl::make_tuple(reduced);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/extract_image_patches.cpp
+++ b/plaidml/bridge/openvino/ops/extract_image_patches.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset3.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace {
+
+template <typename T>
+edsl::Tensor create_kernel_tensor(const int64_t& filter_row, const int64_t& filter_col,
+                                  const edsl::Tensor& input_tensor) {
+  auto input_type = input_tensor.dtype();
+  auto input_shape = input_tensor.compute_shape().sizes();
+
+  // Ops need Tensor order have to be "NCHW".
+  auto input_channel = input_shape[1];
+
+  // build kernel Tensor dims.
+  auto depths = filter_row * filter_col * input_channel;
+  std::vector<int64_t> kernel_dims{
+      /*output channels*/ depths,
+      /*input channels*/ input_channel,
+      /*filter width*/ filter_row,
+      /*filter height*/ filter_col,
+  };
+
+  // kernel tensor element size.
+  size_t kernel_sum = 1;
+  for (auto dim : kernel_dims) {
+    kernel_sum *= dim;
+  }
+
+  // build kernel Tensor buffer.
+  std::vector<T> data(kernel_sum, 0);
+  int64_t channel_index = 0;
+  for (int64_t depth = 0; depth < depths; depth++) {
+    auto index = depth * kernel_dims[1] * kernel_dims[2] * kernel_dims[3] +
+                 channel_index * kernel_dims[2] * kernel_dims[3] +
+                 (depth / input_channel) / filter_col * kernel_dims[3] + (depth / input_channel) % filter_col;
+    data[index] = 1;
+    if (++channel_index == input_channel) {
+      channel_index = 0;
+    }
+  }
+
+  // build one-zero kernel Tensor.
+  TensorShape shape(input_type, kernel_dims);
+  Buffer buffer(shape);
+  buffer.copy_from(data.data());
+  return edsl::Constant(buffer, "Kernel");
+}
+
+}  // namespace
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("ExtractImagePatches", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset3::ExtractImagePatches>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 1);
+
+  auto input_tensor = ctx.operands.at(0);
+  auto filter_row = layer->get_sizes()[0];
+  auto filter_col = layer->get_sizes()[1];
+
+  edsl::Tensor kernel_tensor;
+  switch (input_tensor.dtype()) {
+    case DType::FLOAT32:
+      kernel_tensor = create_kernel_tensor<float>(filter_row, filter_col, input_tensor);
+      break;
+    case DType::INT32:
+      kernel_tensor = create_kernel_tensor<int>(filter_row, filter_col, input_tensor);
+      break;
+  }
+
+  std::vector<size_t> strides;
+  for (auto stride : layer->get_strides()) {
+    strides.push_back(stride);
+  }
+
+  std::vector<size_t> dilations;
+  for (auto dilation : layer->get_rates()) {
+    dilations.push_back(dilation);
+  }
+
+  auto autopad_mode = to_plaidml(layer->get_auto_pad());
+  if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
+    THROW_IE_EXCEPTION << "only valid or auto_pad(same_upper or same_lower) "
+                          "PadType is accepted";
+  }
+
+  auto result = op::convolution(input_tensor, kernel_tensor)
+                    .strides(strides)
+                    .dilations(dilations)
+                    .autopad_mode(autopad_mode)
+                    .input_layout(plaidml::op::TensorLayout::NCX)
+                    .filter_layout(plaidml::op::TensorLayout::KCX);
+  return edsl::make_tuple(result);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/gelu.cpp
+++ b/plaidml/bridge/openvino/ops/gelu.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset1.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("gelu", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 1);
+  auto I = ctx.operands.at(0);
+  auto O = I * 0.5 * (1 + edsl::erf(I / sqrt(2)));
+  return edsl::make_tuple(O);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/gru_cell.cpp
+++ b/plaidml/bridge/openvino/ops/gru_cell.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <limits>
+
+#include "ngraph/opsets/opset4.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("grucell", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 5);
+  auto Xt = ctx.operands.at(0);    // input tensor
+  auto Ht_1 = ctx.operands.at(1);  // hidden state tensor
+  auto W = ctx.operands.at(2);     // weight tensor [3*hidden_size, input_size]
+  auto R = ctx.operands.at(3);     // recurrence weight tensor [3*hidden_size, input_size]
+  auto B = ctx.operands.at(4);     // bias tensor linear_before_reset ? [4*hidden_size] : [3*hidden_size]
+
+  auto input_size = Xt.compute_shape().sizes().back();
+  auto* layer = ngraph::as_type<ngraph::opset4::GRUCell>(ctx.layer);
+  auto hidden_size = layer->get_hidden_size();
+
+  auto activations = layer->get_activations();
+  auto activation_f = activations.at(0);
+  auto activation_g = activations.at(1);
+
+  // TODO: activation_alpha and activation_beta are not used
+  auto activations_alpha = layer->get_activations_alpha();
+  auto activations_beta = layer->get_activations_beta();
+
+  auto clip = layer->get_clip();
+  auto should_clip = (clip > 0.f) && (clip != std::numeric_limits<float>::infinity());
+
+  auto linear_before_reset = layer->get_linear_before_reset();
+
+  auto Wz = op::slice(W).add_dim(0, hidden_size).add_dim(0, input_size);
+  auto Rz = op::slice(R).add_dim(0, hidden_size).add_dim(0, hidden_size);
+  auto Bz = op::slice(B).add_dim(0, hidden_size);
+  auto Tz = op::dot(Xt, op::transpose(Wz)) + op::dot(Ht_1, op::transpose(Rz)) + Bz;
+  auto zt = clip_activation(activation_f, should_clip, clip, Tz);
+
+  auto Wr = op::slice(W).add_dim(hidden_size, 2 * hidden_size).add_dim(0, input_size);
+  auto Rr = op::slice(R).add_dim(hidden_size, 2 * hidden_size).add_dim(0, hidden_size);
+  auto Br = op::slice(B).add_dim(hidden_size, 2 * hidden_size);
+  auto Tr = op::dot(Xt, op::transpose(Wr)) + op::dot(Ht_1, op::transpose(Rr)) + Br;
+  auto rt = clip_activation(activation_f, should_clip, clip, Tr);
+
+  auto Wh = op::slice(W).add_dim(2 * hidden_size, 3 * hidden_size).add_dim(0, input_size);
+  auto Rh = op::slice(R).add_dim(2 * hidden_size, 3 * hidden_size).add_dim(0, hidden_size);
+  edsl::Tensor Th;
+  if (linear_before_reset) {
+    auto Bhw = op::slice(B).add_dim(2 * hidden_size, 3 * hidden_size);
+    auto Bhr = op::slice(B).add_dim(3 * hidden_size, 4 * hidden_size);
+    Th = op::dot(Xt, op::transpose(Wh)) + rt * (op::dot(Ht_1, op::transpose(Rh)) + Bhr) + Bhw;
+  } else {
+    auto Bh = op::slice(B).add_dim(2 * hidden_size, 3 * hidden_size);
+    Th = op::dot(Xt, op::transpose(Wh)) + op::dot(rt * Ht_1, op::transpose(Rh) + Bh);
+  }
+  auto ht_tilde = clip_activation(activation_g, should_clip, clip, Th);
+  auto Ht = (1 - zt) * ht_tilde + zt * Ht_1;
+
+  return edsl::make_tuple(Ht);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/hswish.cpp
+++ b/plaidml/bridge/openvino/ops/hswish.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("hswish", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 1);
+  auto I = ctx.operands.at(0);
+  return edsl::make_tuple(I * op::relu(I + 3).max_value(edsl::Tensor(6)) / 6);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/ops/lstm_cell.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <limits>
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("lstmcell", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 6);
+  auto Xt = ctx.operands.at(0);    // input tensor
+  auto Ht_1 = ctx.operands.at(1);  // hidden state tensor
+  auto Ct_1 = ctx.operands.at(2);  // cell state tensor
+  auto W = ctx.operands.at(3);     // weight tensor [4 * hidden_size, input_size]
+  auto R = ctx.operands.at(4);     // recurrence weight tensor [4 * hidden_size, input_size]
+  auto B = ctx.operands.at(5);     // bias tensor [4 * hidden_size]
+
+  auto input_size = Xt.compute_shape().sizes().back();
+  auto* layer = ngraph::as_type<ngraph::opset4::LSTMCell>(ctx.layer);
+  auto hidden_size = layer->get_hidden_size();
+
+  auto activations = layer->get_activations();
+  auto activation_f = activations.at(0);
+  auto activation_g = activations.at(1);
+  auto activation_h = activations.at(2);
+
+  // TODO: activation_alpha and activation_beta are not used
+  auto activation_alpha = layer->get_activations_alpha();
+  auto activation_beta = layer->get_activations_beta();
+
+  auto clip = layer->get_clip();
+  auto should_clip = (clip > 0.f) && (clip != std::numeric_limits<float>::infinity());
+
+  auto Wf = op::slice(W).add_dim(0, hidden_size).add_dim(0, input_size);
+  auto Rf = op::slice(R).add_dim(0, hidden_size).add_dim(0, hidden_size);
+  auto Bf = op::slice(B).add_dim(0, hidden_size);
+  auto Tf = op::dot(Xt, op::transpose(Wf)) + op::dot(Ht_1, op::transpose(Rf)) + Bf;
+  auto ft = clip_activation(activation_f, should_clip, clip, Tf);
+
+  auto Wi = op::slice(W).add_dim(hidden_size, 2 * hidden_size).add_dim(0, input_size);
+  auto Ri = op::slice(R).add_dim(hidden_size, 2 * hidden_size).add_dim(0, hidden_size);
+  auto Bi = op::slice(B).add_dim(hidden_size, 2 * hidden_size);
+  auto Ti = op::dot(Xt, op::transpose(Wi)) + op::dot(Ht_1, op::transpose(Ri)) + Bi;
+  auto it = clip_activation(activation_f, should_clip, clip, Ti);
+
+  auto Wc = op::slice(W).add_dim(2 * hidden_size, 3 * hidden_size).add_dim(0, input_size);
+  auto Rc = op::slice(R).add_dim(2 * hidden_size, 3 * hidden_size).add_dim(0, hidden_size);
+  auto Bc = op::slice(B).add_dim(2 * hidden_size, 3 * hidden_size);
+  auto Tc = op::dot(Xt, op::transpose(Wc)) + op::dot(Ht_1, op::transpose(Rc)) + Bc;
+  auto ct = clip_activation(activation_g, should_clip, clip, Tc);
+
+  auto Wo = op::slice(W).add_dim(3 * hidden_size, 4 * hidden_size).add_dim(0, input_size);
+  auto Ro = op::slice(R).add_dim(3 * hidden_size, 4 * hidden_size).add_dim(0, hidden_size);
+  auto Bo = op::slice(B).add_dim(3 * hidden_size, 4 * hidden_size);
+  auto To = op::dot(Xt, op::transpose(Wo)) + op::dot(Ht_1, op::transpose(Ro)) + Bo;
+  auto ot = clip_activation(activation_f, should_clip, clip, To);
+
+  auto Ct = ft * Ct_1 + it * ct;
+  auto Ht = ot * clip_activation(activation_h, should_clip, clip, Ct);
+
+  return edsl::make_tuple(Ct, Ht);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/reorg_yolo.cpp
+++ b/plaidml/bridge/openvino/ops/reorg_yolo.cpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("reorgYolo", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset4::ReorgYolo>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 1);
+  auto I = ctx.operands.at(0);
+  // as openvino op request, the strides have to be divisible by 'H' and 'W'.
+  auto strides = layer->get_strides()[0];
+  return edsl::make_tuple(op::reorg_yolo(I, strides, false));
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/reverse.cpp
+++ b/plaidml/bridge/openvino/ops/reverse.cpp
@@ -24,7 +24,9 @@ ngraph::AxisSet cast_constant_axis_mask(size_t operand_idx, ngraph::Node* layer)
   auto bool_mask = ngraph_const->cast_vector<bool>();
   ngraph::AxisSet axis_set{};
   for (size_t i = 0; i < static_cast<size_t>(bool_mask.size()); ++i) {
-    if (bool_mask[i]) axis_set.emplace(i);
+    if (bool_mask[i]) {
+      axis_set.emplace(i);
+    }
   }
   return axis_set;
 }

--- a/plaidml/bridge/openvino/ops/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/ops/rnn_cell.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <limits>
+
+#include "ngraph/opsets/opset4.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("rnncell", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 5);
+  auto Xt = ctx.operands.at(0);    // input tensor
+  auto Ht_1 = ctx.operands.at(1);  // hidden state tensor
+  auto Wi = ctx.operands.at(2);    // weight tensor [hidden_size, input_size]
+  auto Ri = ctx.operands.at(3);    // recurrence weight tensor [hidden_size, input_size]
+  auto Bi = ctx.operands.at(4);    // bias tensor [hidden_size]
+
+  auto input_size = Xt.compute_shape().sizes().back();
+  auto* layer = ngraph::as_type<ngraph::opset4::RNNCell>(ctx.layer);
+  auto hidden_size = layer->get_hidden_size();
+
+  auto activations = layer->get_activations();
+  auto activation = activations.at(0);
+
+  // TODO: activation_alpha and activation_beta are not used
+  auto activations_alpha = layer->get_activations_alpha();
+  auto activations_beta = layer->get_activations_beta();
+
+  auto clip = layer->get_clip();
+  auto should_clip = (clip > 0.f) && (clip != std::numeric_limits<float>::infinity());
+
+  auto Ti = op::dot(Xt, op::transpose(Wi)) + op::dot(Ht_1, op::transpose(Ri)) + Bi;
+  auto Ht = clip_activation(activation, should_clip, clip, Ti);
+
+  return edsl::make_tuple(Ht);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/shuffle_channels.cpp
+++ b/plaidml/bridge/openvino/ops/shuffle_channels.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset3.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("shuffleChannels", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset3::ShuffleChannels>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 1);
+  auto I = ctx.operands.at(0);
+  auto group = layer->get_group();
+  auto axis = layer->get_axis();
+  if (axis < 0) {
+    axis = axis + 4;
+  }
+
+  std::vector<edsl::TensorDim> original_dims(I.rank());
+  I.bind_dims(original_dims);
+
+  std::vector<edsl::TensorDim> channel_group_dims(original_dims);
+  channel_group_dims[axis] = original_dims[axis] / group;
+  channel_group_dims.emplace(channel_group_dims.begin() + axis, group);
+  auto reshape_I = edsl::reshape(I, channel_group_dims);
+
+  std::vector<edsl::Value> order(channel_group_dims.size());
+  for (size_t i = 0; i < order.size(); i++) {
+    order[i] = edsl::Value(i);
+  }
+  std::swap(order[axis], order[axis + 1]);
+  auto transpose_I = op::transpose(reshape_I, edsl::Value(order));
+
+  auto O = edsl::reshape(transpose_I, original_dims);
+  return edsl::make_tuple(O);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/ops/space_to_batch.cpp
+++ b/plaidml/bridge/openvino/ops/space_to_batch.cpp
@@ -1,0 +1,100 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset2.hpp"
+#include "plaidml/op/op.h"
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("SpaceToBatch", [](const Context& ctx) {
+  IE_ASSERT(ctx.operands.size() == 4);
+  auto I = ctx.operands.at(0);
+  auto block_shape = get_shape_from_constant_operand(1, ctx.layer);
+  if (block_shape.size() != I.rank()) {
+    THROW_IE_EXCEPTION << "block_shape and tensor dims have to equal!";
+  }
+  if (block_shape[0] != 1) {
+    THROW_IE_EXCEPTION << "block_shape[0] is expected to be one.";
+  }
+  auto crops_begin = get_coords_from_constant_operand(2, ctx.layer);
+  auto crops_end = get_coords_from_constant_operand(3, ctx.layer);
+
+  /** According to openvino op spec, follow below operate step:
+   *
+   *  Zero-pad the start and end of dimensions [D_0, ..., D_{N - 1}] of the input according to `pads_begin` and
+   *`pads_end`: x = [batch + P_0, D_1 + P_1, D_2 + P_2, ..., D_{N - 1} + P_{N - 1}], where P_i = pads_begin[i] +
+   *pads_end[i]
+   **/
+  std::vector<int> lo_pads;
+  for (auto pad : crops_begin) {
+    lo_pads.push_back(pad);
+  }
+  std::vector<int> hi_pads;
+  for (auto pad : crops_end) {
+    hi_pads.push_back(pad);
+  }
+  if (lo_pads[0] || hi_pads[0]) {
+    THROW_IE_EXCEPTION << "batch dim pad have to be zero!";
+  }
+  edsl::Tensor padding_I = op::explicit_padding(I, lo_pads, hi_pads).padval(edsl::Constant(0));
+
+  /** reshape padding tensor
+   *  x' = reshape(x, [batch, (D_1 + P_1) / B_1, B_1, (D_2 + P_2) / B_2, B_2, ..., (D_{N - 1} + P_{N - 1}) / B_{N - 1},
+   *                  B_{N - 1}]), where B_i = block_shape[i]
+   */
+  std::vector<edsl::TensorDim> I_dims(padding_I.rank());
+  padding_I.bind_dims(I_dims);
+
+  std::vector<edsl::TensorDim> temp_dims;
+  temp_dims.push_back(I_dims[0]);
+  for (size_t i = 1; i < block_shape.size(); i++) {
+    temp_dims.emplace_back(I_dims[i] / block_shape[i]);
+    temp_dims.emplace_back(block_shape[i]);
+  }
+  auto reshape_I = edsl::reshape(padding_I, temp_dims);
+
+  /** transpose reshape tensor.
+   *  x'' = transpose(x',  [2, 4, ..., (N - 1) + (N - 1), 0, 1, 3, ..., N + (N - 1)])
+   **/
+  // setup the sort dims
+  std::vector<size_t> reshape_dims(reshape_I.rank());
+  auto dims_size = reshape_dims.size();
+  auto mid_dim = dims_size / 2;
+  reshape_dims[mid_dim] = 0;
+  for (size_t i = 0; i < mid_dim; i++) {
+    reshape_dims[i] = 2 * (i + 1);
+    reshape_dims[i + mid_dim + 1] = 2 * i + 1;
+  }
+  std::vector<edsl::Value> dims_wrapper;
+  for (auto dim : reshape_dims) {
+    dims_wrapper.emplace_back(dim);
+  }
+  auto transpose_I = op::transpose(reshape_I, edsl::Value(dims_wrapper));
+
+  /** reshape to the final tensor.
+   *  y = reshape(x'', [batch * B_1 * ... * B_{N - 1}, (D_1 + P_1) / B_1, (D_2 + P_2) / B_2, ... ,
+   *              (D_{N - 1} + P_{N - 1}) / B_{N - 1}])
+   */
+  size_t total_block_size = 1;
+  for (size_t i = 0; i < block_shape.size(); i++) {
+    total_block_size *= block_shape[i];
+  }
+  for (size_t i = 0; i < I_dims.size(); i++) {
+    if (i == 0) {
+      I_dims[i] = I_dims[i] * total_block_size;
+    }
+    I_dims[i] = I_dims[i] / block_shape[i];
+  }
+  edsl::Tensor O = edsl::reshape(transpose_I, I_dims);
+
+  return edsl::make_tuple(O);
+});
+
+}  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -6,6 +6,9 @@
 
 #include "ngraph/op/constant.hpp"
 
+#include "plaidml/edsl/edsl.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
 using namespace InferenceEngine;  // NOLINT[build/namespaces]
 
 namespace PlaidMLPlugin {
@@ -109,6 +112,24 @@ ngraph::Coordinate get_coords_from_constant_operand(size_t operand_idx, ngraph::
     return coord_ngraph_op->get_coordinate_val();
   } else {
     THROW_IE_EXCEPTION << "Dynamic coordinates not currently supported by PlaidML plugin";
+  }
+}
+
+edsl::Tensor clip_activation(const std::string& func_name, bool should_clip, float clip, const edsl::Tensor& T) {
+  edsl::Tensor T_clipped;
+  if (should_clip) {
+    T_clipped = op::clip(T, edsl::Tensor(-clip), edsl::Tensor(clip));
+  } else {
+    T_clipped = T;
+  }
+  if (func_name == "relu") {
+    return op::relu(T_clipped);
+  } else if (func_name == "sigmoid") {
+    return op::sigmoid(T_clipped);
+  } else if (func_name == "tanh") {
+    return edsl::tanh(T_clipped);
+  } else {
+    THROW_IE_EXCEPTION << "Unsupported activation function";
   }
 }
 

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "ie_layouts.h"  // NOLINT[build/include_subdir]
 #include "ie_precision.hpp"
 
@@ -15,19 +18,22 @@
 #include "ngraph/shape.hpp"
 #include "ngraph/type/element_type.hpp"
 
-#include "plaidml/core/core.h"
+#include "plaidml/edsl/edsl.h"
 #include "plaidml/op/op.h"
 
 namespace PlaidMLPlugin {
 
 ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
 ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
-
 plaidml::DType to_plaidml(const ngraph::element::Type& ng_type);
 plaidml::op::AutoPadMode to_plaidml(const ngraph::op::PadType& ng_type);
+
 plaidml::op::PadMode to_plaidml(const ngraph::op::PadMode& ng_type);
 
 ngraph::Shape get_shape_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
 ngraph::Coordinate get_coords_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
+
+plaidml::edsl::Tensor clip_activation(const std::string& func_name, bool should_clip, float clip,
+                                      const plaidml::edsl::Tensor& T);
 
 }  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/tests/functional/CMakeLists.txt
+++ b/plaidml/bridge/openvino/tests/functional/CMakeLists.txt
@@ -15,10 +15,21 @@ addIeTargetTest(
   LABELS ${_LABEL} test
 )
 
+addIeTargetTest(
+  NAME ${_TARGET}Smoke
+  ROOT ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDENCIES plaidmlPlugin
+  DEFINES SMOKE_TESTS_ONLY
+  LINK_LIBRARIES IE::funcSharedTests
+  ADD_CPPLINT
+  LABELS ${_LABEL} smoke
+)
+
 add_custom_target(check-bridge-openvino
   COMMAND ${CMAKE_CTEST_COMMAND} -L ${_LABEL}
   USES_TERMINAL
 )
 
 add_dependencies(check-bridge-openvino ${_TARGET})
+add_dependencies(check-smoke ${_TARGET}Smoke)
 add_dependencies(check-test ${_TARGET})

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -43,7 +43,7 @@ const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes
     {Ceiling, {{}}},
     {Swish, {{1.0f}}},
     // {Mish,        {{}}},
-    // {HSwish, {{}}}
+    {HSwish, {{}}}
     // {SoftPlus,    {{}}}
 };
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -76,11 +76,11 @@ const auto basicCases = ::testing::Combine(::testing::ValuesIn(CommonTestUtils::
 //         ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)
 // );
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
-// INSTANTIATE_TEST_CASE_P(Activation_Basic_Prelu, ActivationLayerTest, basicPreluCases,
+INSTANTIATE_TEST_CASE_P(smoke, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+// INSTANTIATE_TEST_CASE_P(smoke_Prelu, ActivationLayerTest, basicPreluCases,
 // ActivationLayerTest::getTestCaseName);
 
-// INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationParamLayerTest, basicPreluCases,
+// INSTANTIATE_TEST_CASE_P(smoke_Prelu_Param, ActivationParamLayerTest, basicPreluCases,
 // ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -28,7 +28,7 @@ const auto batchNormParams = testing::Combine(testing::ValuesIn(epsilon),       
                                               testing::ValuesIn(inputShapes),    //
                                               testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-INSTANTIATE_TEST_CASE_P(BatchNorm,                           //
+INSTANTIATE_TEST_CASE_P(smoke,                               //
                         BatchNormLayerTest,                  //
                         batchNormParams,                     //
                         BatchNormLayerTest::getTestCaseName  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
@@ -25,7 +25,7 @@ batchToSpaceParamsTuple bts_only_test_cases[] = {
                             InferenceEngine::Precision::FP32, CommonTestUtils::DEVICE_PLAIDML),
 };
 
-INSTANTIATE_TEST_CASE_P(Smoke, BatchToSpaceLayerTest, ::testing::ValuesIn(bts_only_test_cases),
+INSTANTIATE_TEST_CASE_P(smoke, BatchToSpaceLayerTest, ::testing::ValuesIn(bts_only_test_cases),
                         BatchToSpaceLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/binary_convolution.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/binary_convolution.cpp
@@ -105,4 +105,46 @@ INSTANTIATE_TEST_CASE_P(Convolution3D_AutoPadValid, BinaryConvolutionLayerTest,
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         BinaryConvolutionLayerTest::getTestCaseName);
 
+/* ============= Smoke ============= */
+const std::vector<std::vector<size_t>> kernel_smoke = {{3, 5, 3}};
+const std::vector<std::vector<ptrdiff_t>> padding_smoke = {{0, 2, 0}};
+
+const std::vector<std::vector<size_t>> strides_smoke = {{1, 2, 1}};
+const std::vector<std::vector<size_t>> dilations_smoke = {{1, 2, 1}};
+
+const auto convSmokeParams_ExplicitPadding =
+    ::testing::Combine(::testing::ValuesIn(kernel_smoke),                                                           //
+                       ::testing::ValuesIn(strides_smoke),                                                          //
+                       ::testing::ValuesIn(padding_smoke),                                                          //
+                       ::testing::ValuesIn(padding_smoke),                                                          //
+                       ::testing::ValuesIn(dilations_smoke),                                                        //
+                       ::testing::Values(5),                                                                        //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT),                                            //
+                       ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT),  //
+                       ::testing::Values(0.0));                                                                     //
+const auto convSmokeParams_AutoPadValid =
+    ::testing::Combine(::testing::ValuesIn(kernel_smoke),                                                           //
+                       ::testing::ValuesIn(strides_smoke),                                                          //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 1, 0})),                                        //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 1, 0})),                                        //
+                       ::testing::ValuesIn(dilations_smoke),                                                        //
+                       ::testing::Values(5),                                                                        //
+                       ::testing::Values(ngraph::op::PadType::VALID),                                               //
+                       ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT),  //
+                       ::testing::Values(0.0));                                                                     //
+
+INSTANTIATE_TEST_CASE_P(smoke_ExplicitPadding, BinaryConvolutionLayerTest,
+                        ::testing::Combine(convSmokeParams_ExplicitPadding,                             //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_AutoPadValid, BinaryConvolutionLayerTest,
+                        ::testing::Combine(convSmokeParams_AutoPadValid,                                //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
@@ -26,7 +26,7 @@ std::vector<InferenceEngine::Precision> outputPrecision = {
 };
 std::vector<bool> withRightBound{true, false};
 
-INSTANTIATE_TEST_CASE_P(BucketizeCheckIndex, BucketizeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, BucketizeLayerTest,
                         ::testing::Combine(::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::ValuesIn(inputShapes),                            //
                                            ::testing::ValuesIn(bucketsShapes),                          //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
@@ -31,4 +31,12 @@ INSTANTIATE_TEST_CASE_P(NoReshape, ConcatLayerTest,
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConcatLayerTest::getTestCaseName);
 
+INSTANTIATE_TEST_CASE_P(smoke, ConcatLayerTest,
+                        ::testing::Combine(::testing::Values(2),  //
+                                           ::testing::Values(std::vector<std::vector<size_t>>({{4, 8, 4, 2},
+                                                                                               {4, 8, 3, 2}})),  //
+                                           ::testing::ValuesIn(netPrecisions),                                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConcatLayerTest::getTestCaseName);
+
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
@@ -19,7 +19,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     // InferenceEngine::Precision::I8,
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ConvertLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, ConvertLayerTest,
                         ::testing::Combine(::testing::Values(inShape),          //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(netPrecisions),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
@@ -44,14 +44,14 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(ke
                                                           ::testing::Values(ngraph::op::PadType::VALID)       //
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(conv2DParams_ExplicitPadding,                            //
                                            ::testing::ValuesIn(netPrecisions),                      //
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(conv2DParams_AutoPadValid,  //
                                            ::testing::ValuesIn(netPrecisions),
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
@@ -81,14 +81,14 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(ke
                                                           ::testing::Values(ngraph::op::PadType::VALID)          //
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(conv3DParams_ExplicitPadding,                                //
                                            ::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(conv3DParams_AutoPadValid,                                   //
                                            ::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
@@ -118,14 +118,14 @@ const auto convbprop2DParams_AutoPadValid = ::testing::Combine(::testing::Values
                                                                ::testing::ValuesIn(numOutChannels),                //
                                                                ::testing::Values(ngraph::op::PadType::VALID));
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(convbprop2DParams_ExplicitPadding,   //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(inputShapes2D),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(convbprop2DParams_AutoPadValid,      //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(inputShapes2D),  //
@@ -155,14 +155,14 @@ const auto convbrop3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesI
                                                               ::testing::ValuesIn(numOutChannels),                   //
                                                               ::testing::Values(ngraph::op::PadType::VALID));
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(convbprop3DParams_ExplicitPadding,   //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(inputShapes3D),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(convbrop3DParams_AutoPadValid,       //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(inputShapes3D),  //
@@ -194,14 +194,14 @@ const auto groupConvBackpropData2DParams_AutoPadValid =
                        ::testing::ValuesIn(numGroups),                     //
                        ::testing::Values(ngraph::op::PadType::VALID));     //
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(groupConvBackpropData2DParams_ExplicitPadding,        //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::ValuesIn(groupInputShapes2D),              //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         GroupConvBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_AutoPadValid, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData2D_AutoPadValid, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(groupConvBackpropData2DParams_AutoPadValid,           //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::ValuesIn(groupInputShapes2D),              //
@@ -229,14 +229,14 @@ const auto groupConvBackpropData3DParams_AutoPadValid =
                        ::testing::ValuesIn(numGroups),                        //
                        ::testing::Values(ngraph::op::PadType::VALID));        //
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(groupConvBackpropData3DParams_ExplicitPadding,        //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::ValuesIn(inputShapes3D),                   //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         GroupConvBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_AutoPadValid, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData3D_AutoPadValid, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(groupConvBackpropData3DParams_AutoPadValid,           //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::ValuesIn(inputShapes3D),                   //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_smoke.cpp
@@ -1,0 +1,246 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/convolution.hpp"
+#include "single_layer_tests/convolution_backprop_data.hpp"
+#include "single_layer_tests/group_convolution_backprop_data.hpp"
+
+using LayerTestsDefinitions::ConvolutionBackpropDataLayerTest;
+using LayerTestsDefinitions::ConvolutionLayerTest;
+using LayerTestsDefinitions::GroupConvBackpropDataLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+/* ============= 2D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels = {{3, 5}};
+const std::vector<std::vector<size_t>> strides = {{1, 3}};
+const std::vector<std::vector<ptrdiff_t>> padBegins = {{0, 3}};
+const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations = {{3, 1}};
+const std::vector<size_t> numOutChannels = {5};
+
+const auto conv2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels),                     //
+                                                             ::testing::ValuesIn(strides),                     //
+                                                             ::testing::ValuesIn(padBegins),                   //
+                                                             ::testing::ValuesIn(padEnds),                     //
+                                                             ::testing::ValuesIn(dilations),                   //
+                                                             ::testing::ValuesIn(numOutChannels),              //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels),                       //
+                                                          ::testing::ValuesIn(strides),                       //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::ValuesIn(dilations),                     //
+                                                          ::testing::ValuesIn(numOutChannels),                //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)       //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_ExplicitPadding, ConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_ExplicitPadding,                            //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_2D_AutoPadValid, ConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_AutoPadValid,  //
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ConvolutionLayerTest::getTestCaseName);
+/* ============= 3D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels3d = {{3, 5, 3}};
+const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 2, 0}};
+
+const std::vector<std::vector<size_t>> strides3d = {{1, 2, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 2, 1}};
+
+const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
+                                                             ::testing::ValuesIn(strides3d),                   //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(dilations3d),                 //
+                                                             ::testing::Values(5),                             //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
+                                                          ::testing::ValuesIn(strides3d),                        //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::ValuesIn(dilations3d),                      //
+                                                          ::testing::Values(5),                                  //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_ExplicitPadding, ConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_ExplicitPadding,                                //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution_Smoke_3D_AutoPadValid, ConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_AutoPadValid,                                   //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        ConvolutionLayerTest::getTestCaseName);
+
+/* ============= 2D ConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t>> inputShapes2D = {{1, 3, 30, 30}};
+const std::vector<std::vector<size_t>> kernels2D = {{3, 5}};
+const std::vector<std::vector<size_t>> strides2D = {{1, 3}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{1, 1}};
+const std::vector<std::vector<size_t>> dilations2D = {{1, 2}};
+
+const auto convbprop2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels2D),       //
+                                                                  ::testing::ValuesIn(strides2D),       //
+                                                                  ::testing::ValuesIn(padBegins2D),     //
+                                                                  ::testing::ValuesIn(padEnds2D),       //
+                                                                  ::testing::ValuesIn(dilations2D),     //
+                                                                  ::testing::ValuesIn(numOutChannels),  //
+                                                                  ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto convbprop2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                                                               ::testing::ValuesIn(strides2D),                     //
+                                                               ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                               ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                               ::testing::ValuesIn(dilations2D),                   //
+                                                               ::testing::ValuesIn(numOutChannels),                //
+                                                               ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop2DParams_ExplicitPadding,   //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop2DParams_AutoPadValid,      //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes2D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D ConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t>> inputShapes3D = {{1, 16, 5, 5, 5}};
+const std::vector<std::vector<size_t>> kernels3D = {{3, 3, 3}};
+const std::vector<std::vector<size_t>> strides3D = {{1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3D = {{2, 2, 2}};
+
+const auto convbprop3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3D),       //
+                                                                  ::testing::ValuesIn(strides3D),       //
+                                                                  ::testing::ValuesIn(padBegins3D),     //
+                                                                  ::testing::ValuesIn(padEnds3D),       //
+                                                                  ::testing::ValuesIn(dilations3D),     //
+                                                                  ::testing::ValuesIn(numOutChannels),  //
+                                                                  ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto convbrop3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3D),                        //
+                                                              ::testing::ValuesIn(strides3D),                        //
+                                                              ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                              ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                              ::testing::ValuesIn(dilations3D),                      //
+                                                              ::testing::ValuesIn(numOutChannels),                   //
+                                                              ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbprop3DParams_ExplicitPadding,   //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_Smoke_3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(convbrop3DParams_AutoPadValid,       //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputShapes3D),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+
+const std::vector<size_t> groupNumOutChannels = {16};
+const std::vector<size_t> numGroups = {8};
+
+/* ============= 2D GroupConvolution ============= */
+const std::vector<std::vector<size_t>> groupInputShapes2D = {{1, 32, 10, 10}};
+
+const auto groupConvBackpropData2DParams_ExplicitPadding =
+    ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                       ::testing::ValuesIn(strides2D),                     //
+                       ::testing::ValuesIn(padBegins2D),                   //
+                       ::testing::ValuesIn(padEnds2D),                     //
+                       ::testing::ValuesIn(dilations2D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT));  //
+const auto groupConvBackpropData2DParams_AutoPadValid =
+    ::testing::Combine(::testing::ValuesIn(kernels2D),                     //
+                       ::testing::ValuesIn(strides2D),                     //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                       ::testing::ValuesIn(dilations2D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::VALID));     //
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData2DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(groupInputShapes2D),              //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_2D_AutoPadValid, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData2DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(groupInputShapes2D),              //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D GroupConvolution ============= */
+
+const auto groupConvBackpropData3DParams_ExplicitPadding =
+    ::testing::Combine(::testing::ValuesIn(kernels3D),                     //
+                       ::testing::ValuesIn(strides3D),                     //
+                       ::testing::ValuesIn(padBegins3D),                   //
+                       ::testing::ValuesIn(padEnds3D),                     //
+                       ::testing::ValuesIn(dilations3D),                   //
+                       ::testing::ValuesIn(groupNumOutChannels),           //
+                       ::testing::ValuesIn(numGroups),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT));  //
+const auto groupConvBackpropData3DParams_AutoPadValid =
+    ::testing::Combine(::testing::ValuesIn(kernels3D),                        //
+                       ::testing::ValuesIn(strides3D),                        //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                       ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                       ::testing::ValuesIn(dilations3D),                      //
+                       ::testing::ValuesIn(groupNumOutChannels),              //
+                       ::testing::ValuesIn(numGroups),                        //
+                       ::testing::Values(ngraph::op::PadType::VALID));        //
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData3DParams_ExplicitPadding,        //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(inputShapes3D),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(GroupConvBackpropData_Smoke_3D_AutoPadValid, GroupConvBackpropDataLayerTest,
+                        ::testing::Combine(groupConvBackpropData3DParams_AutoPadValid,           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(inputShapes3D),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GroupConvBackpropDataLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/test_constants.hpp"
+#include <ngraph/opsets/opset3.hpp>
+#include <vector>  // NOLINT(build/include_order)  // TODO: Fix include order issues
+
+#include "single_layer_tests/depth_to_space.hpp"
+
+using LayerTestsDefinitions::DepthToSpaceLayerTest;
+using ngraph::opset3::DepthToSpace;
+
+namespace {
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::U8,
+    // InferenceEngine::Precision::I16,
+};
+
+const std::vector<DepthToSpace::DepthToSpaceMode> modes = {DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST,
+                                                           DepthToSpace::DepthToSpaceMode::DEPTH_FIRST};
+
+const std::vector<std::vector<size_t>> inputShapesBS2 = {
+    {1, 4, 1, 1},    {1, 4, 2, 2},    {1, 4, 3, 3},    {2, 32, 3, 3},    {2, 16, 5, 4},
+    {1, 8, 1, 1, 1}, {1, 8, 2, 2, 2}, {1, 8, 3, 3, 3}, {2, 32, 3, 3, 3}, {2, 16, 5, 4, 6}};
+
+const auto DepthToSpaceBS2 = ::testing::Combine(::testing::ValuesIn(inputShapesBS2),   //
+                                                ::testing::ValuesIn(inputPrecisions),  //
+                                                ::testing::ValuesIn(modes),            //
+                                                ::testing::Values(2),                  //
+                                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(DepthToSpaceBS2, DepthToSpaceLayerTest, DepthToSpaceBS2,
+                        DepthToSpaceLayerTest::getTestCaseName);
+
+const std::vector<std::vector<size_t>> inputShapesBS3 = {
+    {1, 9, 1, 1},     {1, 9, 2, 2},     {1, 9, 3, 3},     {2, 36, 3, 3},     {2, 27, 5, 4},
+    {1, 27, 1, 1, 1}, {1, 27, 2, 2, 2}, {1, 27, 3, 3, 3}, {2, 108, 3, 3, 3}, {2, 54, 5, 4, 6}};
+
+const auto DepthToSpaceBS3 = ::testing::Combine(::testing::ValuesIn(inputShapesBS3),   //
+                                                ::testing::ValuesIn(inputPrecisions),  //
+                                                ::testing::ValuesIn(modes),            //
+                                                ::testing::Values(3),                  //
+                                                ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(DepthToSpaceBS3, DepthToSpaceLayerTest, DepthToSpaceBS3,
+                        DepthToSpaceLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space_smoke.cpp
@@ -32,6 +32,6 @@ const auto DepthToSpace = ::testing::Combine(::testing::ValuesIn(inputShapes),  
                                              ::testing::Values(3),                  //
                                              ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-INSTANTIATE_TEST_CASE_P(DepthToSpaceSmoke, DepthToSpaceLayerTest, DepthToSpace, DepthToSpaceLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke, DepthToSpaceLayerTest, DepthToSpace, DepthToSpaceLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -53,5 +53,5 @@ const auto multiply_params = ::testing::Combine(::testing::ValuesIn(inShapes),  
                                                 ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),  //
                                                 ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -32,8 +32,22 @@ const auto embBagOffsetSumArgSet = ::testing::Combine(::testing::ValuesIn(embTab
                                                       ::testing::ValuesIn(withWeights),    //
                                                       ::testing::ValuesIn(withDefaultIndex));
 
-INSTANTIATE_TEST_CASE_P(smoke, EmbeddingBagOffsetsSumLayerTest,
+const auto smokeArgSet = ::testing::Combine(::testing::Values(std::vector<size_t>({5, 6})),                          //
+                                            ::testing::Values(std::vector<size_t>({1, 2, 1, 2, 1, 2, 1, 2, 1, 2})),  //
+                                            ::testing::Values(std::vector<size_t>({0, 2})),                          //
+                                            ::testing::Values(4),                                                    //
+                                            ::testing::ValuesIn(withWeights),                                        //
+                                            ::testing::ValuesIn(withDefaultIndex));
+
+INSTANTIATE_TEST_CASE_P(EmbeddingBagOffsetsSum, EmbeddingBagOffsetsSumLayerTest,
                         ::testing::Combine(embBagOffsetSumArgSet,               //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(indPrecisions),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        EmbeddingBagOffsetsSumLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, EmbeddingBagOffsetsSumLayerTest,
+                        ::testing::Combine(smokeArgSet,                         //
                                            ::testing::ValuesIn(netPrecisions),  //
                                            ::testing::ValuesIn(indPrecisions),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/embedding_bag_offsets_sum.hpp"
+
+using LayerTestsDefinitions::EmbeddingBagOffsetsSumLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+};
+
+const std::vector<InferenceEngine::Precision> indPrecisions = {InferenceEngine::Precision::I32};
+
+const std::vector<std::vector<size_t>> embTableShape = {{5, 6}, {10, 35}, {5, 4, 16}};
+const std::vector<std::vector<size_t>> indices = {{0, 1, 2, 2, 3}, {4, 4, 3, 1, 0}, {1, 2, 1, 2, 1, 2, 1, 2, 1, 2}};
+const std::vector<std::vector<size_t>> offsets = {{0, 2}, {0, 0, 2, 2}, {2, 4}};
+const std::vector<size_t> defaultIndex = {0, 4};
+const std::vector<bool> withWeights = {true, false};
+const std::vector<bool> withDefaultIndex = {true, false};
+
+const auto embBagOffsetSumArgSet = ::testing::Combine(::testing::ValuesIn(embTableShape),  //
+                                                      ::testing::ValuesIn(indices),        //
+                                                      ::testing::ValuesIn(offsets),        //
+                                                      ::testing::ValuesIn(defaultIndex),   //
+                                                      ::testing::ValuesIn(withWeights),    //
+                                                      ::testing::ValuesIn(withDefaultIndex));
+
+INSTANTIATE_TEST_CASE_P(smoke, EmbeddingBagOffsetsSumLayerTest,
+                        ::testing::Combine(embBagOffsetSumArgSet,               //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(indPrecisions),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        EmbeddingBagOffsetsSumLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/embedding_bag_packed_sum.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+};
+
+const std::vector<InferenceEngine::Precision> indPrecisions = {InferenceEngine::Precision::I32};
+
+const std::vector<std::vector<size_t>> embTableShape = {{5, 6}, {10, 35}, {5, 4, 16}};
+const std::vector<std::vector<std::vector<size_t>>> indices = {
+    {{0, 1}, {2, 2}, {3, 4}}, {{4, 4, 3}, {1, 0, 2}}, {{1, 2, 1, 2}, {1, 2, 1, 2}}};
+const std::vector<bool> withWeights = {false, true};
+
+const auto embBagPackedSumArgSet = ::testing::Combine(::testing::ValuesIn(embTableShape),  //
+                                                      ::testing::ValuesIn(indices),        //
+                                                      ::testing::ValuesIn(withWeights));
+
+const auto smokeArgSet = ::testing::Combine(::testing::Values(std::vector<size_t>{5, 6}),
+                                            ::testing::Values(std::vector<std::vector<size_t>>{{4, 4, 3}, {1, 0, 2}}),
+                                            ::testing::ValuesIn(withWeights));
+
+INSTANTIATE_TEST_CASE_P(EmbeddingBagPackedSum, EmbeddingBagPackedSumLayerTest,
+                        ::testing::Combine(embBagPackedSumArgSet,               //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(indPrecisions),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        EmbeddingBagPackedSumLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, EmbeddingBagPackedSumLayerTest,
+                        ::testing::Combine(smokeArgSet,                         //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(indPrecisions),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        EmbeddingBagPackedSumLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -34,4 +34,14 @@ INSTANTIATE_TEST_CASE_P(ExtractImagePatches2D_AutoTestCheck, ExtractImagePatches
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
                         ExtractImagePatchesTest::getTestCaseName);
 
+INSTANTIATE_TEST_CASE_P(smoke, ExtractImagePatchesTest,
+                        ::testing::Combine(::testing::Values(std::vector<size_t>({1, 3, 10, 10})),  //
+                                           ::testing::Values(std::vector<size_t>({3, 5})),          //
+                                           ::testing::Values(std::vector<size_t>({5, 5})),          //
+                                           ::testing::Values(std::vector<size_t>({1, 2})),          //
+                                           ::testing::ValuesIn(padTypes),                           //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ExtractImagePatchesTest::getTestCaseName);
+
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/extract_image_patches.hpp"
+
+using LayerTestsDefinitions::ExtractImagePatchesTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::FP32,
+};
+
+const std::vector<std::vector<size_t>> kernels = {{3, 3}, {5, 5}};
+const std::vector<std::vector<size_t>> strides = {{5, 5}, {1, 1}};
+const std::vector<std::vector<size_t>> rates = {{1, 1}, {2, 2}};
+const std::vector<ngraph::op::PadType> padTypes = {
+    ngraph::op::PadType::VALID,       //
+    ngraph::op::PadType::SAME_UPPER,  //
+    ngraph::op::PadType::SAME_LOWER,  //
+};
+
+INSTANTIATE_TEST_CASE_P(ExtractImagePatches2D_AutoTestCheck, ExtractImagePatchesTest,
+                        ::testing::Combine(::testing::Values(std::vector<size_t>({1, 3, 10, 10})),  //
+                                           ::testing::ValuesIn(kernels),                            //
+                                           ::testing::ValuesIn(strides),                            //
+                                           ::testing::ValuesIn(rates),                              //
+                                           ::testing::ValuesIn(padTypes),                           //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        ExtractImagePatchesTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
@@ -13,7 +13,7 @@ using LayerTestsDefinitions::GrnLayerTest;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(GrnCheck1, GrnLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, GrnLayerTest,
                         ::testing::Combine(::testing::Values(InferenceEngine::Precision::FP32),        //
                                            ::testing::Values(std::vector<std::size_t>({4, 3, 3, 6})),  //
                                            ::testing::Values(0.01),                                    //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -41,14 +41,14 @@ const auto groupConv2DParams_AutoPadValid = ::testing::Combine(::testing::Values
                                                                ::testing::Values(ngraph::op::PadType::VALID)       //
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(groupConv2DParams_ExplicitPadding,                        //
                                            ::testing::ValuesIn(netPrecisions),                       //
                                            ::testing::Values(std::vector<size_t>({1, 16, 30, 30})),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),      //
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(groupConv2DParams_AutoPadValid,                           //
                                            ::testing::ValuesIn(netPrecisions),                       //
                                            ::testing::Values(std::vector<size_t>({1, 16, 30, 30})),  //
@@ -81,14 +81,14 @@ const auto groupConv3DParams_AutoPadValid = ::testing::Combine(::testing::Values
                                                                ::testing::Values(ngraph::op::PadType::VALID)          //
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(groupConv3DParams_ExplicitPadding,                           //
                                            ::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::Values(std::vector<size_t>({1, 4, 10, 10, 10})),  //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(groupConv3DParams_AutoPadValid,                              //
                                            ::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::Values(std::vector<size_t>({1, 4, 10, 10, 10})),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/gru_cell.hpp"
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using LayerTestsDefinitions::GRUCellTest;
+
+namespace {
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+const bool shouldDecompose = true;  // false will let all test cases fail
+const std::vector<size_t> batches = {1, 4};
+const std::vector<size_t> hiddenSizes = {64, 128};
+const std::vector<size_t> inputSizes = {16, 32};
+const std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh"}, {"sigmoid", "relu"}};
+const std::vector<float> clips = {std::numeric_limits<float>::infinity(), 1.0f};
+const std::vector<bool> linearBeforeResets = {false, true};
+
+INSTANTIATE_TEST_CASE_P(RNNCell, GRUCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                   //
+                                           ::testing::ValuesIn(batches),                         //
+                                           ::testing::ValuesIn(hiddenSizes),                     //
+                                           ::testing::ValuesIn(inputSizes),                      //
+                                           ::testing::ValuesIn(activations),                     //
+                                           ::testing::ValuesIn(clips),                           //
+                                           ::testing::ValuesIn(linearBeforeResets),              //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GRUCellTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -23,13 +23,25 @@ const std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh"}, 
 const std::vector<float> clips = {std::numeric_limits<float>::infinity(), 1.0f};
 const std::vector<bool> linearBeforeResets = {false, true};
 
-INSTANTIATE_TEST_CASE_P(RNNCell, GRUCellTest,
+INSTANTIATE_TEST_CASE_P(GRU, GRUCellTest,
                         ::testing::Combine(::testing::Values(shouldDecompose),                   //
                                            ::testing::ValuesIn(batches),                         //
                                            ::testing::ValuesIn(hiddenSizes),                     //
                                            ::testing::ValuesIn(inputSizes),                      //
                                            ::testing::ValuesIn(activations),                     //
                                            ::testing::ValuesIn(clips),                           //
+                                           ::testing::ValuesIn(linearBeforeResets),              //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        GRUCellTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, GRUCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                   //
+                                           ::testing::Values(3),                                 //
+                                           ::testing::Values(32),                                //
+                                           ::testing::Values(16),                                //
+                                           ::testing::ValuesIn(activations),                     //
+                                           ::testing::Values(1.0f),                              //
                                            ::testing::ValuesIn(linearBeforeResets),              //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -24,7 +24,7 @@ const double beta = 2;
 const double bias = 1.0;
 const size_t size = 5;
 
-INSTANTIATE_TEST_CASE_P(LrnCheck, LrnLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, LrnLayerTest,
                         ::testing::Combine(::testing::Values(alpha),                                //
                                            ::testing::Values(beta),                                 //
                                            ::testing::Values(bias),                                 //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/lstm_cell.hpp"
+
+#include <limits>
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using LayerTestsDefinitions::LSTMCellTest;
+
+namespace {
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+const bool shouldDecompose = true;  // false will let all test cases fail
+const std::vector<size_t> batches = {1, 4};
+const std::vector<size_t> hiddenSizes = {128, 512};
+const std::vector<size_t> inputSizes = {16, 64};
+const std::vector<std::vector<std::string>> activations = {
+    {"sigmoid", "tanh", "tanh"}, {"sigmoid", "sigmoid", "sigmoid"}, {"sigmoid", "relu", "relu"}};
+const std::vector<float> clips = {std::numeric_limits<float>::infinity(), 1.0f};
+
+INSTANTIATE_TEST_CASE_P(LSTMCell_default, LSTMCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                   //
+                                           ::testing::ValuesIn(batches),                         //
+                                           ::testing::ValuesIn(hiddenSizes),                     //
+                                           ::testing::ValuesIn(inputSizes),                      //
+                                           ::testing::ValuesIn(activations),                     //
+                                           ::testing::ValuesIn(clips),                           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        LSTMCellTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -34,4 +34,15 @@ INSTANTIATE_TEST_CASE_P(LSTMCell_default, LSTMCellTest,
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         LSTMCellTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, LSTMCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                         //
+                                           ::testing::Values(3),                                       //
+                                           ::testing::Values(64),                                      //
+                                           ::testing::Values(32),                                      //
+                                           ::testing::ValuesIn(activations),                           //
+                                           ::testing::Values(std::numeric_limits<float>::infinity()),  //
+                                           ::testing::ValuesIn(netPrecisions),                         //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),        //
+                        LSTMCellTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -32,7 +32,7 @@ const std::vector<ngraph::helpers::InputLayerType> inputType = {
     ngraph::helpers::InputLayerType::PARAMETER,
 };
 
-INSTANTIATE_TEST_CASE_P(maximum, MaxMinLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, MaxMinLayerTest,
                         ::testing::Combine(::testing::ValuesIn(inShapes),       //
                                            ::testing::ValuesIn(opType),         //
                                            ::testing::ValuesIn(netPrecisions),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/minimum_maximum.hpp"
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using LayerTestsDefinitions::MaxMinLayerTest;
+
+namespace {
+
+const std::vector<std::vector<std::vector<size_t>>> inShapes = {
+    {{2}, {1}},          {{1, 1, 1, 3}, {1}},    {{1, 2, 4}, {1}},          {{1, 4, 4}, {1}},
+    {{1, 4, 4, 1}, {1}}, {{256, 56}, {256, 56}}, {{8, 1, 6, 1}, {7, 1, 5}},
+};
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::FP16,
+};
+
+const std::vector<ngraph::helpers::MinMaxOpType> opType = {
+    ngraph::helpers::MinMaxOpType::MINIMUM,
+    ngraph::helpers::MinMaxOpType::MAXIMUM,
+};
+
+const std::vector<ngraph::helpers::InputLayerType> inputType = {
+    ngraph::helpers::InputLayerType::CONSTANT,
+    ngraph::helpers::InputLayerType::PARAMETER,
+};
+
+INSTANTIATE_TEST_CASE_P(maximum, MaxMinLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(inShapes),       //
+                                           ::testing::ValuesIn(opType),         //
+                                           ::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::ValuesIn(inputType),      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        MaxMinLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mvn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mvn.cpp
@@ -36,13 +36,20 @@ const std::vector<bool> normalizeVariance = {
 
 const std::vector<double> epsilon = {0.000000001};
 
-const std::vector<std::map<std::string, std::string>> Configs = {{}};
+const auto MvnCases = ::testing::Combine(::testing::ValuesIn(inputShapes),                     //
+                                         ::testing::Values(InferenceEngine::Precision::FP32),  //
+                                         ::testing::ValuesIn(acrossChannels),                  //
+                                         ::testing::ValuesIn(normalizeVariance),               //
+                                         ::testing::ValuesIn(epsilon),                         //
+                                         ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-const auto MvnCases =
-    ::testing::Combine(::testing::ValuesIn(inputShapes),                                             //
-                       ::testing::Values(InferenceEngine::Precision::FP32),                          //
-                       ::testing::ValuesIn(acrossChannels), ::testing::ValuesIn(normalizeVariance),  //
-                       ::testing::ValuesIn(epsilon),                                                 //
-                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+const auto SmokeCases = ::testing::Combine(::testing::Values(std::vector<size_t>({3, 7, 16, 6})),  //
+                                           ::testing::Values(InferenceEngine::Precision::FP32),    //
+                                           ::testing::ValuesIn(acrossChannels),                    //
+                                           ::testing::ValuesIn(normalizeVariance),                 //
+                                           ::testing::ValuesIn(epsilon),                           //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-INSTANTIATE_TEST_CASE_P(smoke_PlaidML_TestsMVN, MvnLayerTest, MvnCases, MvnLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(MVN, MvnLayerTest, MvnCases, MvnLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, MvnLayerTest, SmokeCases, MvnLayerTest::getTestCaseName);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -36,7 +36,7 @@ const auto MaxPoolSmokeParams =
                        ::testing::Values(ngraph::op::PadType::EXPLICIT),       //
                        ::testing::Values(false));  // placeholder value - exclude pad not applicable for max pooling
 
-INSTANTIATE_TEST_CASE_P(MaxPool_Smoke, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool, PoolingLayerTest,
                         ::testing::Combine(MaxPoolSmokeParams,                                      //
                                            ::testing::ValuesIn(netPrecisions),                      //
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
@@ -56,7 +56,7 @@ const auto avgPoolSmokeParams =
                        ::testing::Values(ngraph::op::PadType::EXPLICIT),                         //
                        ::testing::Values(true, false));                                          //
 
-INSTANTIATE_TEST_CASE_P(AvgPool_Smoke, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool, PoolingLayerTest,
                         ::testing::Combine(avgPoolSmokeParams,                                      //
                                            ::testing::ValuesIn(netPrecisions),                      //
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
@@ -76,7 +76,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
     ::testing::Values(ngraph::op::PadType::VALID),  //
     ::testing::Values(false));                      // placeholder value - exclude pad not applicable for max pooling
 
-INSTANTIATE_TEST_CASE_P(BothPool_Smoke, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_BothPool, PoolingLayerTest,
                         ::testing::Combine(allPools_ValidPad_Params,                                //
                                            ::testing::ValuesIn(netPrecisions),                      //
                                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/reorg_yolo.hpp"
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using LayerTestsDefinitions::reorgYoloLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::FP32,
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+    {10, 10, 10, 10},  //
+    {1, 3, 30, 30}     //
+};
+
+INSTANTIATE_TEST_CASE_P(reorgYoloCheck, reorgYoloLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(inputShapes),                     //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(std::vector<size_t>({1, 2, 5})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        reorgYoloLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
@@ -22,7 +22,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
     {1, 3, 30, 30}     //
 };
 
-INSTANTIATE_TEST_CASE_P(reorgYoloCheck, reorgYoloLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, reorgYoloLayerTest,
                         ::testing::Combine(::testing::ValuesIn(inputShapes),                     //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::ValuesIn(std::vector<size_t>({1, 2, 5})),  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     // InferenceEngine::Precision::I64
 };
 
-INSTANTIATE_TEST_CASE_P(ReshapeCheck, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, ReshapeLayerTest,
                         ::testing::Combine(::testing::Values(true),                                     //
                                            ::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),    //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
@@ -22,7 +22,7 @@ std::vector<std::vector<size_t>> axes_index{{0}, {1}, {0, 2}};
 std::vector<std::vector<size_t>> shape_mask{{4, 6, 5}, {3, 9, 2}, {1, 4, 2}};
 std::vector<std::vector<size_t>> axes_mask{{1, 0, 0}, {0, 1, 0}, {1, 0, 1}};
 
-INSTANTIATE_TEST_CASE_P(ReverseCheckIndex, ReverseLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReverseCheckIndex, ReverseLayerTest,
                         ::testing::Combine(::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::ValuesIn(shape_index),                            //
                                            ::testing::ValuesIn(axes_index),                             //
@@ -31,7 +31,7 @@ INSTANTIATE_TEST_CASE_P(ReverseCheckIndex, ReverseLayerTest,
                                            ::testing::Values(std::map<std::string, std::string>({}))),  //
                         ReverseLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ReverseCheckMask, ReverseLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReverseCheckMask, ReverseLayerTest,
                         ::testing::Combine(::testing::ValuesIn(netPrecisions),                          //
                                            ::testing::ValuesIn(shape_mask),                             //
                                            ::testing::ValuesIn(axes_mask),                              //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/rnn_cell.hpp"
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using LayerTestsDefinitions::RNNCellTest;
+
+namespace {
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+const bool shouldDecompose = true;  // false will let all test cases fail
+const std::vector<size_t> batches = {1, 4};
+const std::vector<size_t> hiddenSizes = {128, 256};
+const std::vector<size_t> inputSizes = {16, 64};
+const std::vector<std::vector<std::string>> activations = {{"tanh"}, {"sigmoid"}, {"relu"}};
+const std::vector<float> clips = {std::numeric_limits<float>::infinity(), 1.0f};
+
+INSTANTIATE_TEST_CASE_P(RNNCell, RNNCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                   //
+                                           ::testing::ValuesIn(batches),                         //
+                                           ::testing::ValuesIn(hiddenSizes),                     //
+                                           ::testing::ValuesIn(inputSizes),                      //
+                                           ::testing::ValuesIn(activations),                     //
+                                           ::testing::ValuesIn(clips),                           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        RNNCellTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -32,4 +32,15 @@ INSTANTIATE_TEST_CASE_P(RNNCell, RNNCellTest,
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         RNNCellTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, RNNCellTest,
+                        ::testing::Combine(::testing::Values(shouldDecompose),                   //
+                                           ::testing::Values(3),                                 //
+                                           ::testing::Values(64),                                //
+                                           ::testing::Values(32),                                //
+                                           ::testing::ValuesIn(activations),                     //
+                                           ::testing::ValuesIn(clips),                           //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        RNNCellTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/select.hpp"
+
+using LayerTestsDefinitions::SelectLayerTest;
+
+const std::vector<InferenceEngine::Precision> inputPrecision = {
+    // InferenceEngine::Precision::I8,    //
+    // InferenceEngine::Precision::I16,   // TODO: Investigate
+    // InferenceEngine::Precision::I64
+    InferenceEngine::Precision::I32,   //
+    InferenceEngine::Precision::FP32,  //
+};
+
+const std::vector<std::vector<std::vector<size_t>>> noneShapes = {
+    {{1}, {1}, {1}},                                     //
+    {{8}, {8}, {8}},                                     //
+    {{4, 5}, {4, 5}, {4, 5}},                            //
+    {{3, 4, 5}, {3, 4, 5}, {3, 4, 5}},                   //
+    {{2, 3, 4, 5}, {2, 3, 4, 5}, {2, 3, 4, 5}},          //
+    {{2, 3, 4, 5, 6}, {2, 3, 4, 5, 6}, {2, 3, 4, 5, 6}}  //
+};
+
+const auto noneCases = ::testing::Combine(::testing::ValuesIn(noneShapes),                         //
+                                          ::testing::ValuesIn(inputPrecision),                     //
+                                          ::testing::Values(ngraph::op::AutoBroadcastSpec::NONE),  //
+                                          ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)       //
+);
+
+const std::vector<std::vector<std::vector<size_t>>> numpyShapes = {
+    {{1}, {1}, {1}},                                   //
+    {{1}, {16}, {1}},                                  //
+    {{1}, {1}, {16}},                                  //
+    {{1}, {8}, {8}},                                   //
+    {{8}, {1}, {8}},                                   //
+    {{8}, {8}, {8}},                                   //
+    {{4, 1}, {1}, {4, 8}},                             //
+    {{3, 8}, {8}, {3, 1}},                             //
+    {{8, 1}, {8, 1}, {8, 1}},                          //
+    {{1}, {5, 8}, {5, 8}},                             //
+    {{8, 1, 1}, {8, 1, 1}, {2, 5}},                    //
+    {{8, 1}, {6, 8, 1}, {6, 1, 1}},                    //
+    {{5, 1}, {8, 1, 7}, {5, 7}},                       //
+    {{2, 8, 1}, {2, 8, 9}, {2, 1, 9}},                 //
+    {{1, 4}, {8, 1, 1, 1}, {4}},                       //
+    {{5, 4, 1}, {8, 5, 1, 1}, {4, 1}},                 //
+    {{1, 4}, {6, 1, 8, 1}, {6, 1, 8, 4}},              //
+    {{7, 3, 1, 8}, {7, 1, 1, 8}, {3, 2, 8}},           //
+    {{1, 3, 1}, {8, 2, 3, 1}, {3, 9}},                 //
+    {{5, 1, 8}, {2, 1, 9, 8}, {2, 5, 9, 8}},           //
+    {{6, 1, 1, 8}, {6, 7, 1, 8}, {2, 1}},              //
+    {{5, 1, 1, 1}, {5, 7, 8, 6}, {1, 8, 6}},           //
+    {{8, 1, 5}, {8, 1, 1, 1, 1}, {8, 7, 5}},           //
+    {{8, 1, 1, 9}, {4, 8, 1, 1, 1}, {1, 1, 9}},        //
+    {{5, 1, 2, 1}, {8, 1, 9, 1, 1}, {5, 1, 2, 1}},     //
+    {{8, 1}, {2, 1, 1, 8, 1}, {9, 1, 1}},              //
+    {{8, 5, 5, 5, 1}, {8, 1, 1, 1, 8}, {5, 5, 5, 8}},  //
+    {{4}, {8, 5, 6, 1, 1}, {2, 4}},                    //
+    {{9, 9, 2, 8, 1}, {9, 1, 2, 8, 1}, {9, 1, 1, 1}},  //
+    {{5, 3, 3}, {8, 1, 1, 3, 3}, {5, 1, 3}},           //
+    {{5, 1, 8, 1}, {5, 5, 1, 8, 1}, {1}},              //
+    {{3}, {6, 8, 1, 1, 3}, {6, 1, 5, 3, 3}},           //
+    {{5, 1}, {3, 1, 4, 1, 8}, {1, 4, 5, 8}},           //
+    {{2, 1, 5}, {8, 6, 2, 3, 1}, {5}},                 //
+    {{6}, {2, 1, 9, 8, 6}, {2, 4, 9, 8, 6}},           //
+    {{5, 7, 1, 8, 1}, {5, 7, 1, 8, 4}, {8, 1}},        //
+    {{7, 6, 5, 8}, {4, 7, 6, 5, 8}, {6, 1, 8}}         //
+};
+
+const auto numpyCases = ::testing::Combine(::testing::ValuesIn(numpyShapes),                         //
+                                           ::testing::ValuesIn(inputPrecision),                      //
+                                           ::testing::Values(ngraph::op::AutoBroadcastSpec::NUMPY),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)        //
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_PlaidML_TestsSelect_none, SelectLayerTest, noneCases, SelectLayerTest::getTestCaseName);
+
+// TODO figure out the removed cases
+
+// INSTANTIATE_TEST_CASE_P(smoke_PlaidML_TestsSelect_numpy, SelectLayerTest, numpyCases,
+//                          SelectLayerTest::getTestCaseName);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/shuffle_channels.hpp"
+using LayerTestsDefinitions::ShuffleChannelsLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::FP32,
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+    // tensor order 'NCHW'
+    {5, 12, 10, 10},
+    {1, 18, 16, 16}};
+
+const std::vector<shuffleChannelsSpecificParams> shuffleChannelOneParams = {{1, 2},  //
+                                                                            {1, 6},  //
+                                                                            {-3, 3}};
+
+INSTANTIATE_TEST_CASE_P(smokeChannelOne, ShuffleChannelsLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(shuffleChannelOneParams),         //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(inputShapes),                     //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        ShuffleChannelsLayerTest::getTestCaseName);
+
+const std::vector<std::vector<size_t>> diffOrderInputShape = {
+    // tensor order 'NHWC'
+    {5, 10, 10, 6},
+    {1, 16, 16, 12}};
+
+const std::vector<shuffleChannelsSpecificParams> shuffleChannelThirdParams = {{3, 2},  //
+                                                                              {3, 6},  //
+                                                                              {-1, 3}};
+
+INSTANTIATE_TEST_CASE_P(smokeChannelThree, ShuffleChannelsLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(shuffleChannelThirdParams),       //
+                                           ::testing::ValuesIn(netPrecisions),                   //
+                                           ::testing::ValuesIn(diffOrderInputShape),             //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
+                        ShuffleChannelsLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/softmax.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/softmax.cpp
@@ -35,7 +35,7 @@ const auto params2D = testing::Combine(testing::ValuesIn(netPrecisions),        
                                        testing::Values(std::map<std::string, std::string>())  //
 );
 
-INSTANTIATE_TEST_CASE_P(SoftMax2D, SoftMaxLayerTest, params2D, SoftMaxLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smokeSoftMax2D, SoftMaxLayerTest, params2D, SoftMaxLayerTest::getTestCaseName);
 
 const std::vector<InferenceEngine::SizeVector> inputShapes4D = {
     InferenceEngine::SizeVector{1, 100, 1, 1},
@@ -53,6 +53,16 @@ const auto params4D = testing::Combine(testing::ValuesIn(netPrecisions),        
                                        testing::Values(std::map<std::string, std::string>())  //
 );
 
+const auto params_smoke4D = testing::Combine(testing::ValuesIn(netPrecisions),                          //
+                                             testing::Values(InferenceEngine::Layout::NCHW),            //
+                                             testing::Values(InferenceEngine::SizeVector{3, 4, 5, 2}),  //
+                                             testing::Values(2),                                        //
+                                             testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+                                             testing::Values(std::map<std::string, std::string>())      //
+);
+
 INSTANTIATE_TEST_CASE_P(SoftMax4D, SoftMaxLayerTest, params4D, SoftMaxLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smokeSoftMax4D, SoftMaxLayerTest, params_smoke4D, SoftMaxLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/space_to_batch.hpp"
+
+using LayerTestsDefinitions::SpaceToBatchLayerTest;
+using LayerTestsDefinitions::spaceToBatchParamsTuple;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+};
+
+const std::vector<std::vector<size_t>> blockShapes = {{1, 2, 2, 1}};
+
+const std::vector<std::vector<size_t>> pads_begins = {{0, 0, 0, 0}, {0, 2, 2, 0}, {0, 4, 0, 0}};
+
+const std::vector<std::vector<size_t>> pads_ends = {
+    {0, 0, 0, 0},
+    {0, 2, 2, 0},
+    {0, 0, 4, 0},
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+    {1, 8, 8, 1},  //
+    {3, 4, 4, 1},  //
+};
+
+INSTANTIATE_TEST_CASE_P(SpaceToBatchSmokeCheck, SpaceToBatchLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(blockShapes),      //
+                                           ::testing::ValuesIn(pads_begins),      //
+                                           ::testing::ValuesIn(pads_ends),        //
+                                           ::testing::ValuesIn(inputShapes),      //
+                                           ::testing::ValuesIn(inputPrecisions),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        SpaceToBatchLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(SpaceToBatchTfCaseCheck, SpaceToBatchLayerTest,
+                        ::testing::Combine(::testing::Values(std::vector<size_t>({1, 2, 2, 1})),
+                                           ::testing::Values(std::vector<size_t>({0, 1, 1, 0})),
+                                           ::testing::Values(std::vector<size_t>({0, 1, 1, 0})),
+                                           ::testing::Values(std::vector<size_t>({2, 2, 4, 1})),
+                                           ::testing::ValuesIn(inputPrecisions),
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        SpaceToBatchLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
@@ -32,7 +32,16 @@ const std::vector<std::vector<size_t>> inputShapes = {
     {3, 4, 4, 1},  //
 };
 
-INSTANTIATE_TEST_CASE_P(SpaceToBatchSmokeCheck, SpaceToBatchLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_SpaceToBatchCheck, SpaceToBatchLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(blockShapes),                    //
+                                           ::testing::Values(std::vector<size_t>{0, 2, 2, 0}),  //
+                                           ::testing::Values(std::vector<size_t>{0, 0, 4, 0}),  //
+                                           ::testing::Values(std::vector<size_t>{3, 4, 4, 1}),  //
+                                           ::testing::ValuesIn(inputPrecisions),                //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        SpaceToBatchLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(SpaceToBatchCoreCheck, SpaceToBatchLayerTest,
                         ::testing::Combine(::testing::ValuesIn(blockShapes),      //
                                            ::testing::ValuesIn(pads_begins),      //
                                            ::testing::ValuesIn(pads_ends),        //
@@ -41,7 +50,7 @@ INSTANTIATE_TEST_CASE_P(SpaceToBatchSmokeCheck, SpaceToBatchLayerTest,
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         SpaceToBatchLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(SpaceToBatchTfCaseCheck, SpaceToBatchLayerTest,
+INSTANTIATE_TEST_CASE_P(smokeSpaceToBatchTfCaseCheck, SpaceToBatchLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>({1, 2, 2, 1})),
                                            ::testing::Values(std::vector<size_t>({0, 1, 1, 0})),
                                            ::testing::Values(std::vector<size_t>({0, 1, 1, 0})),

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
@@ -24,6 +24,14 @@ const std::vector<SpaceToDepth::SpaceToDepthMode> modes = {
     SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST    //
 };
 
+INSTANTIATE_TEST_CASE_P(smoke, SpaceToDepthLayerTest,
+                        ::testing::Combine(::testing::Values(std::vector<size_t>{2, 1, 6, 12, 6}),  //
+                                           ::testing::ValuesIn(inputPrecisions),                    //
+                                           ::testing::ValuesIn(modes),                              //
+                                           ::testing::ValuesIn(std::vector<size_t>{2, 3}),          //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        SpaceToDepthLayerTest::getTestCaseName);
+
 const std::vector<std::vector<size_t>> inputShapesBS2 = {
     {1, 1, 2, 2},      //
     {1, 1, 4, 4},      //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
@@ -16,11 +16,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     // InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NumSplitsCheck, SplitLayerTest,
-                        ::testing::Combine(::testing::Values(1, 2),                                   //
-                                           ::testing::Values(0, 1, 2, 3),                             //
-                                           ::testing::ValuesIn(netPrecisions),                        //
-                                           ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),  //
-                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),       //
+INSTANTIATE_TEST_CASE_P(smoke, SplitLayerTest,
+                        ::testing::Combine(::testing::Values(1, 2),                                 //
+                                           ::testing::Values(0, 1, 2, 3),                           //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({6, 30, 12, 6})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
                         SplitLayerTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squared_difference.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squared_difference.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cstddef>
+#include <map>
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/squared_difference.hpp"
+
+using LayerTestsDefinitions::SquaredDifferenceLayerTest;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+const std::vector<std::vector<std::size_t>> inputShapes = {{1, 30}, {1, 10, 30}};
+
+INSTANTIATE_TEST_CASE_P(smoke, SquaredDifferenceLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(netPrecisions),  //
+                                           ::testing::Values(inputShapes),      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        SquaredDifferenceLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -181,7 +181,7 @@ std::vector<StridedSliceParams> ss_only_test_cases = {
                        {}},
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_PlaidML, StridedSliceLayerTest, ::testing::ValuesIn(ss_only_test_cases),
+INSTANTIATE_TEST_CASE_P(smoke, StridedSliceLayerTest, ::testing::ValuesIn(ss_only_test_cases),
                         StridedSliceLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/tile.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/tile.cpp
@@ -19,7 +19,7 @@ const std::vector<std::vector<size_t>> repeats = {
     {2, 2, 2},
 };
 
-INSTANTIATE_TEST_CASE_P(Tile, TileLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, TileLayerTest,
                         ::testing::Combine(::testing::ValuesIn(repeats),                         //
                                            ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::Values(std::vector<size_t>({2, 3, 4})),    //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/transpose.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/transpose.cpp
@@ -30,6 +30,6 @@ const auto params = testing::Combine(testing::ValuesIn(inputOrder),             
                                      testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-INSTANTIATE_TEST_CASE_P(Transpose, TransposeLayerTest, params, TransposeLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke, TransposeLayerTest, params, TransposeLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
@@ -16,6 +16,14 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     // InferenceEngine::Precision::FP16
 };
 
+INSTANTIATE_TEST_CASE_P(smoke, VariadicSplitLayerTest,
+                        ::testing::Combine(::testing::Values(std::vector<int32_t>{2, 3, 1, -1}),   //
+                                           ::testing::Values(0, 1, 2, 3),                          //
+                                           ::testing::ValuesIn(netPrecisions),                     //
+                                           ::testing::Values(std::vector<size_t>({7, 8, 11, 7})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),    //
+                        VariadicSplitLayerTest::getTestCaseName);
+
 // Sum of elements numSplits = inputShapes[Axis]
 const std::vector<std::vector<int32_t>> numSplits = {
     {1, 16, 5, 8},  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -8,6 +8,9 @@
 #include "functional_test_utils/skip_tests_config.hpp"
 
 std::vector<std::string> disabledTestPatterns() {
-  // TODO: Move test skips to here
-  return {};
+  return {
+#ifdef SMOKE_TESTS_ONLY
+      "^(?!smoke).*",
+#endif  // SMOKE_TESTS_ONLY
+  };
 }

--- a/plaidml/edsl/ffi.cc
+++ b/plaidml/edsl/ffi.cc
@@ -232,7 +232,7 @@ plaidml_expr* plaidml_expr_constant(  //
   return ffi_wrap<plaidml_expr*>(err, nullptr, [&] {
     IVLOG(3, "plaidml_expr_constant");
     auto node = std::make_shared<ast::ExprNodeConstTensor>(buffer->buffer, name);
-    LayerContext::get()->addNode(node);
+    // Constants cannot be added to layers, so no LayerContext line
     return new plaidml_expr{node};
   });
 }


### PR DESCRIPTION
Get the changes made to the OV repo sync'd into this repo. This should be up to date with commit ~`3b8b1a36c`~`02c1b88` on that repo.

~This is currently a draft because this increases testing time by a factor of 3-4x. I'm investigating options to address this. It is otherwise ready for review.~ This adds a new target `PlaidMLFuncTestsSmoke` which is run in `check-smoke`. The longer tests remain in `PlaidMLFuncTests` which is run in `check-test`.

In a followup, I want to examine why the headers of `depth_to_space.cpp` need to be included in a lint-failing order.