### PR TITLE
Add support for building benchmark_app

### DIFF
--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -62,5 +62,6 @@ pml_cc_library(
     plaidml::plaidml
 )
 
+add_subdirectory(benchmark_app)
 add_subdirectory(plugin)
 add_subdirectory(tests/functional)

--- a/plaidml/bridge/openvino/benchmark_app/CMakeLists.txt
+++ b/plaidml/bridge/openvino/benchmark_app/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(_SRC_DIR ${openvino_SOURCE_DIR}/inference-engine/samples/benchmark_app)
+set(_SRCS
+  ${_SRC_DIR}/inputs_filling.cpp
+  ${_SRC_DIR}/main.cpp
+  ${_SRC_DIR}/statistics_report.cpp
+  ${_SRC_DIR}/utils.cpp
+)
+
+pml_cc_binary(
+  NAME benchmark_app
+  SRCS ${_SRCS}
+  DEPS
+    IE::inference_engine
+    format_reader
+    gflags
+)


### PR DESCRIPTION
This avoids the need for special LD_LIBRARY_PATH settings. It also deposits the binary in the usual `bin/intel64/Release` directory.