### PR TITLE
add Affine MemRefDataFlow pass

### DIFF
--- a/pmlc/target/intel_gen/pipeline.cc
+++ b/pmlc/target/intel_gen/pipeline.cc
@@ -179,6 +179,11 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  // Affine MemRefDataFlowOpt pass
+  pm.addPass(createMemRefDataFlowOptPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   // Pack dims
   pm.addPass(createAffineIndexPackPass());
   pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -129,6 +129,11 @@ void pipelineBuilder(OpPassManager &pm,
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  // Affine MemRefDataFlowOpt pass
+  pm.addPass(createMemRefDataFlowOptPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   // Pack dims
   pm.addPass(pmlc::target::intel_gen::createAffineIndexPackPass());
   pm.addPass(createCanonicalizerPass());


### PR DESCRIPTION
Clean up MemRef data flow after loop unrolling.  For example, from the ResNet50 layer 2a, branch 2a inner (convolution) loop:

Before MemRefDataFlowOpot:

```
          %25 = alloc() : memref<1x1x16x1xvector<16xf32>>
          %26 = affine.vector_load %arg1[0, 0, %arg6 * 16 + %c0, %arg5 * 16] : memref<1x1x64x64xf32>, vector<16xf32>
          affine.store %26, %25[0, 0, 0, 0] : memref<1x1x16x1xvector<16xf32>>

          affine.for %arg7 = 0 to 8 {
            %42 = affine.vector_load %arg0[0, %arg3, %arg4 * 8 + %arg7, %arg6 * 16] : memref<1x56x56x64xf32>, vector<16xf32>
            %43 = extract_element %42[%c0] : vector<16xf32>
            %44 = affine.load %25[0, 0, 0, 0] : memref<1x1x16x1xvector<16xf32>>
            %45 = vector.broadcast %43 : f32 to vector<16xf32>
            %46 = mulf %45, %44 : vector<16xf32>
            %47 = affine.load %0[0, 0, %arg7, 0] : memref<1x1x8x1xvector<16xf32>>
            %48 = addf %47, %46 : vector<16xf32>
            affine.store %48, %0[0, 0, %arg7, 0] : memref<1x1x8x1xvector<16xf32>>
```

After MemRefDataFlowOpot:

```
          %25 = affine.vector_load %arg1[0, 0, %arg6 * 16 + %c0, %arg5 * 16] : memref<1x1x64x64xf32>, vector<16xf32>

          affine.for %arg7 = 0 to 8 {
            %41 = affine.vector_load %arg0[0, %arg3, %arg4 * 8 + %arg7, %arg6 * 16] : memref<1x56x56x64xf32>, vector<16xf32>
            %42 = extract_element %41[%c0] : vector<16xf32>
            %43 = vector.broadcast %42 : f32 to vector<16xf32>
            %44 = mulf %43, %25 : vector<16xf32>
            %45 = affine.load %0[0, 0, %arg7, 0] : memref<1x1x8x1xvector<16xf32>>
            %46 = addf %45, %44 : vector<16xf32>
            affine.store %46, %0[0, 0, %arg7, 0] : memref<1x1x8x1xvector<16xf32>>
```

Accesses are registerized and redundant allocation / stores removed.  Slight performance improvement for ResNet50 on Gen9, OpenCL.  Note that this pass does not solve all issue with MemRef data flow.  For example, the "after" code goes on to execute this operation with no other load/store in between:

```
            %50 = affine.load %0[0, 0, %arg7, 0] : memref<1x1x8x1xvector<16xf32>>
```

This load can be replace with symbol %46 above.  More PRs to follow.