### PR TITLE
Fix precision when IE/OV disagree

### DIFF
--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -31,6 +31,36 @@ ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngr
   }
 }
 
+plaidml::DType to_plaidml(const InferenceEngine::Precision& ie_type) {
+  switch (ie_type) {
+    case InferenceEngine::Precision::FP16:
+      return plaidml::DType::FLOAT16;
+    case InferenceEngine::Precision::FP32:
+      return plaidml::DType::FLOAT32;
+    case InferenceEngine::Precision::I8:
+      return plaidml::DType::INT8;
+    case InferenceEngine::Precision::I16:
+      return plaidml::DType::INT16;
+    case InferenceEngine::Precision::I32:
+      return plaidml::DType::INT32;
+    case InferenceEngine::Precision::I64:
+      return plaidml::DType::INT64;
+    case InferenceEngine::Precision::U8:
+      return plaidml::DType::UINT8;
+    case InferenceEngine::Precision::U16:
+      return plaidml::DType::UINT16;
+    case InferenceEngine::Precision::U32:
+      return plaidml::DType::UINT8;
+    case InferenceEngine::Precision::U64:
+      return plaidml::DType::UINT16;
+    case InferenceEngine::Precision::BOOL:
+      return plaidml::DType::BOOLEAN;
+    default:
+      // TODO: Verify these are the unsupported types
+      THROW_IE_EXCEPTION << "Unsupported element type";
+  }
+}
+
 plaidml::DType to_plaidml(const ngraph::element::Type& ng_type) {
   switch (ng_type) {
     case ngraph::element::Type_t::f16:

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -25,6 +25,7 @@ namespace PlaidMLPlugin {
 
 ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
 ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngraph::Node* layer);
+plaidml::DType to_plaidml(const InferenceEngine::Precision& ie_type);
 plaidml::DType to_plaidml(const ngraph::element::Type& ng_type);
 plaidml::op::AutoPadMode to_plaidml(const ngraph::op::PadType& ng_type);
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -12,8 +12,8 @@ using namespace ngraph::helpers;  // NOLINT[build/namespaces]
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::FP16,  //
 };
 
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -10,8 +10,8 @@ using LayerTestsDefinitions::BatchNormLayerTest;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::FP16,  //
 };
 
 const std::vector<double> epsilon = {1e-6, 1e-5, 1e-4};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
@@ -22,7 +22,7 @@ std::vector<std::vector<size_t>> bucketsShapes{{3}};
 // Output_type shall support i64 && i32, close i64 for openvino limitation
 std::vector<InferenceEngine::Precision> outputPrecision = {
     InferenceEngine::Precision::I32,
-    // InferenceEngine::Precision::I64,
+    InferenceEngine::Precision::I64,
 };
 std::vector<bool> withRightBound{true, false};
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
@@ -21,7 +21,7 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
 
 std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16  // TODO: Not yet supported
+    InferenceEngine::Precision::FP16,
 };
 
 INSTANTIATE_TEST_CASE_P(NoReshape, ConcatLayerTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
@@ -15,8 +15,8 @@ const std::vector<std::vector<size_t>> inShape = {{1, 2, 3, 4}};
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
     // InferenceEngine::Precision::FP16,
-    // InferenceEngine::Precision::U8,
-    // InferenceEngine::Precision::I8,
+    InferenceEngine::Precision::U8,
+    InferenceEngine::Precision::I8,
 };
 
 INSTANTIATE_TEST_CASE_P(smoke, ConvertLayerTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
@@ -14,7 +14,7 @@ const std::vector<std::vector<size_t>> inShape = {{1, 2, 3, 4}};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::U8,
     InferenceEngine::Precision::I8,
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16  // TODO: Not yet working
+    InferenceEngine::Precision::FP16,
 };
 
 /* ============= 2D Convolution ============= */

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
+    // InferenceEngine::Precision::FP16,  // TODO
 };
 
 /* ============= 2D Convolution ============= */

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<size_t> numOutChannels = {1, 5, 16};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
+    // InferenceEngine::Precision::FP16,  // TODO
 };
 
 const std::vector<size_t> numOutChannels = {1, 5, 16};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
@@ -14,8 +14,8 @@ using ngraph::opset3::DepthToSpace;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::U8,
-    // InferenceEngine::Precision::I16,
+    InferenceEngine::Precision::U8,
+    InferenceEngine::Precision::I16,
 };
 
 const std::vector<DepthToSpace::DepthToSpaceMode> modes = {DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space_smoke.cpp
@@ -15,8 +15,8 @@ using ngraph::opset3::DepthToSpace;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::U8,
-    // InferenceEngine::Precision::I16,
+    InferenceEngine::Precision::U8,
+    InferenceEngine::Precision::I16,
 };
 
 const std::vector<DepthToSpace::DepthToSpaceMode> modes = {DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -16,7 +16,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
 };
 
 const double alpha = 9.9e-05;

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -19,7 +19,7 @@ const std::vector<std::vector<std::vector<size_t>>> inShapes = {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<ngraph::helpers::MinMaxOpType> opType = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -11,7 +11,7 @@ using LayerTestsDefinitions::ReshapeLayerTest;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::FP32,  //
     InferenceEngine::Precision::I64    //
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -11,9 +11,9 @@ using LayerTestsDefinitions::ReshapeLayerTest;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
     // InferenceEngine::Precision::FP16,
-    // InferenceEngine::Precision::I64
+    InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::I64    //
 };
 
 INSTANTIATE_TEST_CASE_P(smoke, ReshapeLayerTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
@@ -11,7 +11,7 @@ using LayerTestsDefinitions::ReverseLayerTest;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::FP32,  //
     InferenceEngine::Precision::I64    //
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reverse.cpp
@@ -11,9 +11,9 @@ using LayerTestsDefinitions::ReverseLayerTest;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
     // InferenceEngine::Precision::FP16,
-    // InferenceEngine::Precision::I64
+    InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::I64    //
 };
 
 std::vector<std::vector<size_t>> shape_index{{4, 6, 5}, {3, 9, 2}, {1, 4, 2, 1, 1, 3}};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
@@ -10,9 +10,9 @@
 using LayerTestsDefinitions::SelectLayerTest;
 
 const std::vector<InferenceEngine::Precision> inputPrecision = {
-    // InferenceEngine::Precision::I8,    //
-    // InferenceEngine::Precision::I16,   // TODO: Investigate
-    // InferenceEngine::Precision::I64
+    InferenceEngine::Precision::I8,    //
+    InferenceEngine::Precision::I16,   //
+    InferenceEngine::Precision::I64,   //
     InferenceEngine::Precision::I32,   //
     InferenceEngine::Precision::FP32,  //
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
@@ -15,8 +15,8 @@ using ngraph::opset3::SpaceToDepth;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::U8,
-    // InferenceEngine::Precision::I16,
+    InferenceEngine::Precision::U8,
+    InferenceEngine::Precision::I16,
 };
 
 const std::vector<SpaceToDepth::SpaceToDepthMode> modes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP16,
 };
 
 INSTANTIATE_TEST_CASE_P(smoke, SplitLayerTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP16,
 };
 
 INSTANTIATE_TEST_CASE_P(smoke, VariadicSplitLayerTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -9,6 +9,17 @@
 
 std::vector<std::string> disabledTestPatterns() {
   return {
+      ".*Acos.*FP16.*",               // TODO
+      ".*Asin.*FP16.*",               // TODO
+      ".*Atan.*FP16.*",               // TODO
+      ".*Ceiling.*FP16.*",            // TODO
+      ".*Cosh.*FP16.*",               // TODO
+      ".*Erf.*FP16.*",                // TODO
+      ".*Floor.*FP16.*",              // TODO
+      ".*Lrn.*FP16.*",                // TODO
+      ".*Sinh.*FP16.*",               // TODO
+      ".*Tan.*FP16.*",                // TODO
+      ".*Convert.*targetPRC=FP16.*",  // TODO
 #ifdef SMOKE_TESTS_ONLY
       "^(?!smoke).*",
 #endif  // SMOKE_TESTS_ONLY


### PR DESCRIPTION
Fix the precision issues when InferenceEngine provides/requests an input/output precision different from the precision on the Parameter or Result node in nGraph. Marked as draft for now as it doesn't yet resolve the FP16 issues, but it does already fix the other single_layer_test precision issues we've seen.

@abialas1 I'm not sure what test case you were fixing in your branch https://github.com/plaidml/plaidml/tree/abialas/benchmark_app_gpu; does this address what you need for that? I'd also be happy to run your test(s) myself if you let me know what they are.