### PR TITLE
Add buffer transfer optimization to gpu_to_comp pass 

### DIFF
--- a/pmlc/conversion/comp_to_llvm/comp_to_vulkan.cc
+++ b/pmlc/conversion/comp_to_llvm/comp_to_vulkan.cc
@@ -36,51 +36,14 @@ static constexpr const char *kVkCreateLaunchKernelAction =
     "vkCreateLaunchKernelAction";
 static constexpr const char *kVkSetLaunchKernelAction =
     "vkSetLaunchKernelAction";
-static constexpr const char *kVkCreateMemoryTransferAction =
-    "vkCreateMemoryTransferAction";
 static constexpr const char *kVkWait = "vkWait";
 static constexpr const char *kVkScheduleFunc = "vkScheduleFunc";
-
-static constexpr const char *kBindBufferBFloat16 = "bindBufferBFloat16";
-static constexpr const char *kBindBufferFloat16 = "bindBufferFloat16";
-static constexpr const char *kBindBufferFloat32 = "bindBufferFloat32";
-static constexpr const char *kBindBufferFloat64 = "bindBufferFloat64";
-static constexpr const char *kBindBufferInteger8 = "bindBufferInteger8";
-static constexpr const char *kBindBufferInteger16 = "bindBufferInteger16";
-static constexpr const char *kBindBufferInteger32 = "bindBufferInteger32";
-static constexpr const char *kBindBufferInteger64 = "bindBufferInteger64";
-static constexpr const int kByteBits = 8;
+static constexpr const char *kVkAlloc = "vkAlloc";
+static constexpr const char *kVkDealloc = "vkDealloc";
+static constexpr const char *kVkRead = "vkRead";
+static constexpr const char *kVkWrite = "vkWrite";
 
 namespace {
-
-const char *getBufferBindingFunc(mlir::Type elementType) {
-  if (elementType.isInteger(8)) {
-    return kBindBufferInteger8;
-  }
-  if (elementType.isInteger(16)) {
-    return kBindBufferInteger16;
-  }
-  if (elementType.isInteger(32)) {
-    return kBindBufferInteger32;
-  }
-  if (elementType.isInteger(64)) {
-    return kBindBufferInteger64;
-  }
-  if (elementType.isBF16()) {
-    return kBindBufferBFloat16;
-  }
-  if (elementType.isF16()) {
-    return kBindBufferFloat16;
-  }
-  if (elementType.isF32()) {
-    return kBindBufferFloat32;
-  }
-  if (elementType.isF64()) {
-    return kBindBufferFloat64;
-  }
-  return nullptr;
-}
-
 class ConvertCompToVulkanCall
     : public ConvertCompToVulkanCallBase<ConvertCompToVulkanCall> {
 public:
@@ -153,6 +116,35 @@ struct ConvertToFuncCallPattern : ConvertCompToVkBasePattern<Op> {
 using ConvertToInitVulkan = ConvertToFuncCallPattern<comp::CreateExecEnv>;
 using ConvertToDeinitVulkan = ConvertToFuncCallPattern<comp::DestroyExecEnv>;
 using ConvertWait = ConvertToFuncCallPattern<comp::Wait>;
+using ConvertDealloc = ConvertToFuncCallPattern<comp::Dealloc>;
+
+/// Template pattern common for both comp::ScheduleRead and
+/// comp::ScheduleWrite.
+template <class Op>
+struct ConvertScheduleReadWrite : ConvertCompToVkBasePattern<Op> {
+  ConvertScheduleReadWrite(mlir::StringRef funcName,
+                           mlir::TypeConverter &typeConverter,
+                           mlir::MLIRContext *context)
+      : ConvertCompToVkBasePattern<Op>(typeConverter, context),
+        funcName(funcName) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(Op op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const override;
+
+  mlir::StringRef funcName;
+};
+
+using ConvertScheduleRead = ConvertScheduleReadWrite<comp::ScheduleRead>;
+using ConvertScheduleWrite = ConvertScheduleReadWrite<comp::ScheduleWrite>;
+
+struct ConvertAlloc : ConvertCompToVkBasePattern<comp::Alloc> {
+  using ConvertCompToVkBasePattern<comp::Alloc>::ConvertCompToVkBasePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(comp::Alloc op, mlir::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const override;
+};
 
 struct ConvertScheduleFunc : ConvertCompToVkBasePattern<comp::ScheduleFunc> {
   ConvertScheduleFunc(const BinaryModulesMap &modulesMap,
@@ -202,6 +194,10 @@ void populateCompToVkPatterns(mlir::MLIRContext *context,
                                        typeConverter, context);
   patterns.insert<ConvertWait>(kVkWait, typeConverter, context,
                                /*varArg=*/true, /*nonVarArgs=*/0);
+  patterns.insert<ConvertAlloc>(typeConverter, context);
+  patterns.insert<ConvertDealloc>(kVkDealloc, typeConverter, context);
+  patterns.insert<ConvertScheduleRead>(kVkRead, typeConverter, context);
+  patterns.insert<ConvertScheduleWrite>(kVkWrite, typeConverter, context);
 }
 
 void addVkFunctionDeclarations(mlir::ModuleOp &module) {
@@ -211,7 +207,6 @@ void addVkFunctionDeclarations(mlir::ModuleOp &module) {
   LLVM::LLVMType llvmInt8Ptr = LLVM::LLVMType::getInt8PtrTy(context);
   LLVM::LLVMType llvmVoid = LLVM::LLVMType::getVoidTy(context);
   LLVM::LLVMType llvmInt32 = LLVM::LLVMType::getInt32Ty(context);
-  LLVM::LLVMType llvmInt64Type = LLVM::LLVMType::getInt64Ty(context);
 
   builder.create<LLVM::LLVMFuncOp>(
       loc, kVkInit,
@@ -223,8 +218,8 @@ void addVkFunctionDeclarations(mlir::ModuleOp &module) {
       LLVM::LLVMType::getFunctionTy(llvmVoid,
                                     {llvmInt8Ptr, llvmInt8Ptr, llvmInt32,
                                      llvmInt8Ptr, llvmInt32, llvmInt32,
-                                     llvmInt32},
-                                    /*isVarArg=*/false));
+                                     llvmInt32, llvmInt32},
+                                    /*isVarArg=*/true));
 
   builder.create<LLVM::LLVMFuncOp>(
       loc, kVkSetLaunchKernelAction,
@@ -252,31 +247,107 @@ void addVkFunctionDeclarations(mlir::ModuleOp &module) {
                                     /*isVarArg=*/true));
 
   builder.create<LLVM::LLVMFuncOp>(
-      loc, kVkCreateMemoryTransferAction,
-      LLVM::LLVMType::getFunctionTy(llvmVoid,
-                                    {llvmInt8Ptr, llvmInt64Type, llvmInt64Type,
-                                     llvmInt64Type, llvmInt64Type},
+      loc, kVkAlloc,
+      LLVM::LLVMType::getFunctionTy(llvmInt8Ptr,
+                                    {llvmInt8Ptr, llvmInt32, llvmInt8Ptr},
                                     /*isVarArg=*/false));
+  builder.create<LLVM::LLVMFuncOp>(
+      loc, kVkWrite,
+      LLVM::LLVMType::getFunctionTy(
+          llvmInt8Ptr, {llvmInt8Ptr, llvmInt8Ptr, llvmInt8Ptr, llvmInt32},
+          /*isVarArg=*/true));
 
-  std::vector<std::pair<const char *, mlir::Type>> bindType{
-      {kBindBufferFloat16, builder.getF16Type()},
-      {kBindBufferFloat32, builder.getF32Type()},
-      {kBindBufferFloat64, builder.getF32Type()},
-      {kBindBufferInteger8, builder.getIntegerType(8)},
-      {kBindBufferInteger16, builder.getIntegerType(16)},
-      {kBindBufferInteger32, builder.getI32Type()},
-      {kBindBufferInteger64, builder.getI64Type()}};
+  builder.create<LLVM::LLVMFuncOp>(
+      loc, kVkRead,
+      LLVM::LLVMType::getFunctionTy(
+          llvmInt8Ptr, {llvmInt8Ptr, llvmInt8Ptr, llvmInt8Ptr, llvmInt32},
+          /*isVarArg=*/true));
 
-  for (auto func : bindType) {
-    builder.create<mlir::FuncOp>(
-        loc, func.first,
-        mlir::FunctionType::get(
-            {mlir::ArrayRef<mlir::Type>{
-                llvmInt8Ptr, llvmInt32, llvmInt32, llvmInt32,
-                mlir::UnrankedMemRefType::get(func.second, /*memorySpace=*/0)}},
-            {}, context),
-        mlir::ArrayRef<std::pair<mlir::Identifier, mlir::Attribute>>());
+  builder.create<LLVM::LLVMFuncOp>(
+      loc, kVkDealloc,
+      LLVM::LLVMType::getFunctionTy(llvmVoid, {llvmInt8Ptr, llvmInt8Ptr},
+                                    /*isVarArg=*/false));
+}
+
+template <class Op>
+mlir::LogicalResult ConvertScheduleReadWrite<Op>::matchAndRewrite(
+    Op op, mlir::ArrayRef<mlir::Value> operands,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  if (!this->isMatchingRuntime(op)) {
+    return mlir::failure();
   }
+
+  constexpr unsigned nonVarArgs = 3;
+  mlir::SmallVector<mlir::Value, nonVarArgs + 2> castOperands(
+      operands.begin(), operands.begin() + nonVarArgs);
+
+  // Convert host memref to pointer.
+  mlir::Value hostPtr =
+      this->materializeConversion(rewriter, op.getLoc(), operands[0]);
+  if (!hostPtr) {
+    return mlir::failure();
+  }
+  castOperands[0] = hostPtr;
+
+  // Add event dependencies as variadic operands.
+  LLVM::LLVMType llvmInt32Ty =
+      LLVM::LLVMType::getInt32Ty(rewriter.getContext());
+  mlir::Value eventsCnt = rewriter.create<LLVM::ConstantOp>(
+      op.getLoc(), llvmInt32Ty,
+      rewriter.getI32IntegerAttr(operands.size() - nonVarArgs));
+  castOperands.push_back(eventsCnt);
+  castOperands.insert(castOperands.end(), operands.begin() + nonVarArgs,
+                      operands.end());
+
+  mlir::Type llvmEventType = this->convertType(op.getType());
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(), mlir::ArrayRef<mlir::Type>{llvmEventType},
+      rewriter.getSymbolRefAttr(funcName), castOperands);
+  return mlir::success();
+}
+
+mlir::LogicalResult
+ConvertAlloc::matchAndRewrite(comp::Alloc op,
+                              mlir::ArrayRef<mlir::Value> operands,
+                              mlir::ConversionPatternRewriter &rewriter) const {
+  if (!isMatchingRuntime(op))
+    return mlir::failure();
+
+  mlir::Location loc = op.getLoc();
+  mlir::MemRefType resultType = op.getType().cast<mlir::MemRefType>();
+
+  mlir::SmallVector<mlir::Value, 3> castOperands;
+  // Operand 0 - execution environment.
+  castOperands.push_back(operands[0]);
+  // Operand 1 - size of allocated memory in bytes.
+  auto shape = resultType.getShape();
+  uint32_t numElement = 1;
+  for (auto dim : shape)
+    numElement *= dim;
+  uint32_t elementTypeSize =
+      llvm::divideCeil(resultType.getElementTypeBitWidth(), 8);
+  mlir::Value bufferByteSize = rewriter.create<LLVM::ConstantOp>(
+      loc, LLVM::LLVMType::getInt32Ty(rewriter.getContext()),
+      rewriter.getI32IntegerAttr(numElement * elementTypeSize));
+  castOperands.push_back(bufferByteSize);
+  // Operand 2 - pointer to data on host or null.
+  if (operands.size() > 1) {
+    mlir::Value hostPtr = materializeConversion(rewriter, loc, operands[1]);
+    if (!hostPtr)
+      return mlir::failure();
+    castOperands.push_back(hostPtr);
+  } else {
+    LLVM::LLVMType llvmPointerType =
+        LLVM::LLVMType::getInt8PtrTy(rewriter.getContext());
+    mlir::Value nullPtr = rewriter.create<LLVM::NullOp>(loc, llvmPointerType);
+    castOperands.push_back(nullPtr);
+  }
+
+  mlir::Type llvmResultType = convertType(op.getType());
+  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+      op.getOperation(), mlir::ArrayRef<mlir::Type>{llvmResultType},
+      rewriter.getSymbolRefAttr(kVkAlloc), castOperands);
+  return mlir::success();
 }
 
 template <class Op>
@@ -319,162 +390,120 @@ mlir::LogicalResult ConvertToFuncCallPattern<Op>::matchAndRewrite(
 mlir::LogicalResult ConvertScheduleFunc::matchAndRewrite(
     comp::ScheduleFunc op, mlir::ArrayRef<mlir::Value> operands,
     mlir::ConversionPatternRewriter &rewriter) const {
+
   if (!isMatchingRuntime(op)) {
     return mlir::failure();
   }
 
-  mlir::Location loc = op.getLoc();
-  auto launchOp = mlir::cast<gpu::LaunchFuncOp>(op.body().front().front());
-  std::string binaryName = launchOp.getKernelModuleName().str();
-  std::string kernelName = launchOp.getKernelName().str();
-
-  // Create kernel from serialized binary.
-  if (modulesMap.count(binaryName) == 0) {
-    return mlir::failure();
-  }
-  if (modulesMap.at(binaryName).kernelsNameMap.count(kernelName) == 0) {
-    return mlir::failure();
-  }
-
-  // containing all the args for kCreateVulkanLaunchKernelAction.
-  std::vector<mlir::Value> createActionOperands{operands[0]};
-  mlir::Value binaryPtr, binaryBytes;
-  getPtrToBinaryModule(rewriter, loc, modulesMap.at(binaryName), binaryPtr,
-                       binaryBytes);
-  createActionOperands.push_back(binaryPtr);
-  createActionOperands.push_back(binaryBytes);
-  mlir::Value namePtr = getPtrToGlobalString(
-      rewriter, loc, modulesMap.at(binaryName).kernelsNameMap.at(kernelName));
-  createActionOperands.push_back(namePtr);
-
-  LLVM::LLVMType llvmInt32Type =
-      LLVM::LLVMType::getInt32Ty(rewriter.getContext());
-
-  auto gSize = launchOp.getGridSizeOperandValues();
-  auto x = gSize.x.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
-  auto y = gSize.y.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
-  auto z = gSize.z.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
-  mlir::Value gx = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, x);
-  mlir::Value gy = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, y);
-  mlir::Value gz = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, z);
-  createActionOperands.push_back(gx);
-  createActionOperands.push_back(gy);
-  createActionOperands.push_back(gz);
-
-  // transform mapped vulkan buffer to launch kernel.
-  std::vector<mlir::Value> bufferOperands;
-  for (unsigned argI = 0; argI < launchOp.getNumKernelOperands(); ++argI) {
-    mlir::Value remappedArg =
-        rewriter.getRemappedValue(launchOp.getKernelOperand(argI));
-    bufferOperands.push_back(remappedArg);
+  // Collect all following ScheduleFunc ops to a vector and later schedule a
+  // Vulkan commandBuffer for them.
+  auto &opList = op.getOperation()->getBlock()->getOperations();
+  std::vector<comp::ScheduleFunc> scheduleFuncOps;
+  for (size_t i = 0; i < opList.size(); i++) {
+    auto currOp = std::next(opList.begin(), i);
+    if (mlir::isa<comp::ScheduleFunc>(currOp) &&
+        op == mlir::cast<comp::ScheduleFunc>(*currOp)) {
+      for (size_t j = i; j < opList.size(); j++) {
+        auto nextOp = std::next(opList.begin(), j);
+        if (!mlir::isa<comp::ScheduleFunc>(nextOp)) {
+          break;
+        }
+        scheduleFuncOps.push_back(mlir::cast<comp::ScheduleFunc>(*nextOp));
+      }
+      break;
+    }
   }
 
-  LLVM::LLVMType llvmInt32Ty =
-      LLVM::LLVMType::getInt32Ty(rewriter.getContext());
-  LLVM::LLVMType llvmInt64Type =
-      LLVM::LLVMType::getInt64Ty(rewriter.getContext());
+  for (auto &scheduleFuncOp : scheduleFuncOps) {
+    mlir::Location loc = scheduleFuncOp.getLoc();
+    auto launchOp =
+        mlir::cast<gpu::LaunchFuncOp>(scheduleFuncOp.body().front().front());
+    std::string binaryName = launchOp.getKernelModuleName().str();
+    std::string kernelName = launchOp.getKernelName().str();
 
-  // Create LLVM constant for the descriptor set index.
-  // Bind all memrefs to the `0` descriptor set, the same way as `GPUToSPIRV`
-  // pass does.
-  mlir::Value descriptorSet = rewriter.create<LLVM::ConstantOp>(
-      loc, llvmInt32Ty, rewriter.getI32IntegerAttr(0));
-
-  // Bind all buffers to Vulkan LaunchKernelAction.
-  for (uint32_t bindIndex = 0; bindIndex < bufferOperands.size(); bindIndex++) {
-    auto buffer = bufferOperands[bindIndex];
-    // Create LLVM constant for the descriptor binding index.
-    mlir::Value descriptorBinding = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmInt32Ty, rewriter.getI32IntegerAttr(bindIndex));
-
-    auto memRefType = buffer.getType().dyn_cast_or_null<mlir::MemRefType>();
-    if (!memRefType) {
+    // Create kernel from serialized binary.
+    if (modulesMap.count(binaryName) == 0) {
+      return mlir::failure();
+    }
+    if (modulesMap.at(binaryName).kernelsNameMap.count(kernelName) == 0) {
       return mlir::failure();
     }
 
-    auto shape = memRefType.getShape();
-    uint32_t numElement = 1;
-    for (auto dim : shape) {
-      numElement *= dim;
+    // containing all the args for kCreateVulkanLaunchKernelAction.
+    std::vector<mlir::Value> createActionOperands{operands[0]};
+    mlir::Value binaryPtr, binaryBytes;
+    getPtrToBinaryModule(rewriter, loc, modulesMap.at(binaryName), binaryPtr,
+                         binaryBytes);
+    createActionOperands.push_back(binaryPtr);
+    createActionOperands.push_back(binaryBytes);
+    mlir::Value namePtr = getPtrToGlobalString(
+        rewriter, loc, modulesMap.at(binaryName).kernelsNameMap.at(kernelName));
+    createActionOperands.push_back(namePtr);
+
+    LLVM::LLVMType llvmInt32Type =
+        LLVM::LLVMType::getInt32Ty(rewriter.getContext());
+
+    auto gSize = launchOp.getGridSizeOperandValues();
+    auto x = gSize.x.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
+    auto y = gSize.y.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
+    auto z = gSize.z.getDefiningOp()->getAttrOfType<mlir::IntegerAttr>("value");
+    mlir::Value gx = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, x);
+    mlir::Value gy = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, y);
+    mlir::Value gz = rewriter.create<LLVM::ConstantOp>(loc, llvmInt32Type, z);
+    createActionOperands.push_back(gx);
+    createActionOperands.push_back(gy);
+    createActionOperands.push_back(gz);
+
+    // transform mapped vulkan buffer to launch kernel.
+    std::vector<mlir::Value> bufferOperands;
+    for (unsigned argI = 0; argI < launchOp.getNumKernelOperands(); ++argI) {
+      mlir::Value remappedArg =
+          rewriter.getRemappedValue(launchOp.getKernelOperand(argI));
+      bufferOperands.push_back(remappedArg);
     }
 
-    auto elementType = memRefType.getElementType();
-    uint32_t elementTypeSize =
-        llvm::divideCeil(elementType.getIntOrFloatBitWidth(), kByteBits);
-    mlir::Value bufferByteSize = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmInt32Ty,
-        rewriter.getI32IntegerAttr(numElement * elementTypeSize));
-    mlir::Value unrankedBuffer = rewriter.create<mlir::MemRefCastOp>(
-        loc, buffer, mlir::UnrankedMemRefType::get(elementType, 0));
-    rewriter.create<mlir::CallOp>(
+    LLVM::LLVMType llvmInt32Ty =
+        LLVM::LLVMType::getInt32Ty(rewriter.getContext());
+
+    mlir::Value bufferNum = rewriter.create<LLVM::ConstantOp>(
+        loc, llvmInt32Type, rewriter.getI32IntegerAttr(bufferOperands.size()));
+    createActionOperands.push_back(bufferNum);
+
+    createActionOperands.insert(createActionOperands.end(),
+                                bufferOperands.begin(), bufferOperands.end());
+
+    rewriter.create<LLVM::CallOp>(
         loc, mlir::ArrayRef<mlir::Type>{},
-        rewriter.getSymbolRefAttr(getBufferBindingFunc(elementType)),
-        mlir::ArrayRef<mlir::Value>{operands[0], descriptorSet,
-                                    descriptorBinding, bufferByteSize,
-                                    unrankedBuffer});
-  }
+        rewriter.getSymbolRefAttr(kVkCreateLaunchKernelAction),
+        createActionOperands);
 
-  rewriter.create<LLVM::CallOp>(
-      loc, mlir::ArrayRef<mlir::Type>{},
-      rewriter.getSymbolRefAttr(kVkCreateLaunchKernelAction),
-      createActionOperands);
-
-  // Get subgroup size
-  int64_t subgroupSize = 1;
-  if (pmlc::hasIntegerTag(launchOp, "subgroupSize"))
-    subgroupSize = pmlc::getIntegerTag(launchOp, "subgroupSize", 1);
-  if (subgroupSize != 1) {
-    IVLOG(2, "Subgroup size = " << subgroupSize);
-  }
-
-  mlir::Value subgroupSizeVal = rewriter.create<LLVM::ConstantOp>(
-      loc, llvmInt32Ty, rewriter.getI32IntegerAttr(subgroupSize));
-
-  rewriter.create<LLVM::CallOp>(
-      loc, mlir::ArrayRef<mlir::Type>{},
-      rewriter.getSymbolRefAttr(kVkSetLaunchKernelAction),
-      mlir::ArrayRef<mlir::Value>{operands[0], subgroupSizeVal});
-
-  // Create Vulkan MemoryTransferAction
-  auto &bufferMap = *pBufferMap;
-  auto &scheduleFuncIndex = *pScheduleFuncIndex;
-  for (size_t i = 0; i < bufferOperands.size(); i++) {
-    for (auto pair : bufferMap) {
-      if (pair.first == bufferOperands[i]) {
-        mlir::Value dst_index = rewriter.create<LLVM::ConstantOp>(
-            loc, llvmInt64Type,
-            rewriter.getI64IntegerAttr(*pScheduleFuncIndex));
-        mlir::Value dst_binding = rewriter.create<LLVM::ConstantOp>(
-            loc, llvmInt64Type, rewriter.getI64IntegerAttr(i));
-        mlir::Value src_index = rewriter.create<LLVM::ConstantOp>(
-            loc, llvmInt64Type, rewriter.getI64IntegerAttr(pair.second[0]));
-        mlir::Value src_binding = rewriter.create<LLVM::ConstantOp>(
-            loc, llvmInt64Type, rewriter.getI64IntegerAttr(pair.second[1]));
-        rewriter.create<LLVM::CallOp>(
-            loc, mlir::ArrayRef<mlir::Type>{},
-            rewriter.getSymbolRefAttr(kVkCreateMemoryTransferAction),
-            mlir::ArrayRef<mlir::Value>{operands[0], src_index, src_binding,
-                                        dst_index, dst_binding});
-      }
+    // Get subgroup size
+    int64_t subgroupSize = 1;
+    if (pmlc::hasIntegerTag(launchOp, "subgroupSize"))
+      subgroupSize = pmlc::getIntegerTag(launchOp, "subgroupSize", 1);
+    if (subgroupSize != 1) {
+      IVLOG(2, "Subgroup size = " << subgroupSize);
     }
-    llvm::SmallVector<uint64_t, 2> second;
-    second.append({scheduleFuncIndex, i});
-    bufferMap[bufferOperands[i]] = second;
+
+    mlir::Value subgroupSizeVal = rewriter.create<LLVM::ConstantOp>(
+        loc, llvmInt32Ty, rewriter.getI32IntegerAttr(subgroupSize));
+
+    rewriter.create<LLVM::CallOp>(
+        loc, mlir::ArrayRef<mlir::Type>{},
+        rewriter.getSymbolRefAttr(kVkSetLaunchKernelAction),
+        mlir::ArrayRef<mlir::Value>{operands[0], subgroupSizeVal});
+
+    mlir::Type llvmEventType = this->convertType(scheduleFuncOp.getType());
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+        scheduleFuncOp.getOperation(),
+        mlir::ArrayRef<mlir::Type>{llvmEventType},
+        rewriter.getSymbolRefAttr(kVkScheduleFunc),
+        mlir::ArrayRef<mlir::Value>{operands[0]});
   }
 
-  mlir::Type llvmEventType = this->convertType(op.getType());
-  rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-      op.getOperation(), mlir::ArrayRef<mlir::Type>{llvmEventType},
-      rewriter.getSymbolRefAttr(kVkScheduleFunc),
-      mlir::ArrayRef<mlir::Value>{operands[0]});
-
-  if (scheduleFuncIndex == scheduleFuncNum - 1) {
-    rewriter.create<LLVM::CallOp>(loc, mlir::ArrayRef<mlir::Type>{},
-                                  rewriter.getSymbolRefAttr(kVkRun),
-                                  mlir::ArrayRef<mlir::Value>{operands[0]});
-  }
-
-  scheduleFuncIndex++;
+  rewriter.create<LLVM::CallOp>(op.getLoc(), mlir::ArrayRef<mlir::Type>{},
+                                rewriter.getSymbolRefAttr(kVkRun),
+                                mlir::ArrayRef<mlir::Value>{operands[0]});
   return mlir::success();
 }
 

--- a/pmlc/conversion/gpu_to_comp/BUILD
+++ b/pmlc/conversion/gpu_to_comp/BUILD
@@ -20,6 +20,23 @@ gentbl(
     ],
 )
 
+gentbl(
+    name = "enums-gen",
+    tbl_outs = [
+        (
+            "-gen-enum-decls",
+            "enums.h.inc",
+        ),
+        (
+            "-gen-enum-defs",
+            "enums.cc.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "enums.td",
+    td_srcs = ["@llvm-project//mlir:OpBaseTdFiles"],
+)
+
 plaidml_cc_library(
     name = "gpu_to_comp",
     srcs = [
@@ -31,6 +48,7 @@ plaidml_cc_library(
     ],
     deps = [
         ":gen-pass",
+        ":enums-gen",
         "//pmlc/dialect/comp/ir",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",

--- a/pmlc/conversion/gpu_to_comp/enums.td
+++ b/pmlc/conversion/gpu_to_comp/enums.td
@@ -1,0 +1,21 @@
+#ifndef __PML_GPU_TO_COMP_ENUMS__
+#define __PML_GPU_TO_COMP_ENUMS__
+
+#ifndef OP_BASE
+include "mlir/IR/OpBase.td"
+#endif
+
+def BufferCopyMode : BitEnumAttr<
+    "BufferCopyMode",
+    "Modes that control buffer copy between host and device",
+    [
+      BitEnumAttrCase<"NoCopy", 0x0000>,
+      BitEnumAttrCase<"HostToDevice", 0x0001>,
+      BitEnumAttrCase<"DeviceToHost", 0x0002>,
+    ]> {
+  let cppNamespace = "pmlc::conversion::gpu_to_comp";
+  let returnType = "BufferCopyMode";
+  let convertFromStorage = "static_cast<" # returnType # ">($_self.getValue().getZExtValue())";
+}
+
+#endif // __PML_GPU_TO_COMP_ENUMS__

--- a/pmlc/conversion/gpu_to_comp/gpu_to_comp.cc
+++ b/pmlc/conversion/gpu_to_comp/gpu_to_comp.cc
@@ -1,22 +1,36 @@
 // Copyright 2020, Intel Corporation
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallSet.h"
 
 #include "pmlc/conversion/gpu_to_comp/pass_detail.h"
 #include "pmlc/conversion/gpu_to_comp/passes.h"
 #include "pmlc/dialect/comp/ir/dialect.h"
+
+#include "pmlc/conversion/gpu_to_comp/enums.h.inc"
 
 namespace pmlc::conversion::gpu_to_comp {
 
 namespace comp = pmlc::dialect::comp;
 namespace gpu = mlir::gpu;
 
+using pmlc::conversion::gpu_to_comp::BufferCopyMode;
+
 namespace {
+
+struct valueComparator {
+  bool operator()(const mlir::Value a, const mlir::Value b) const {
+    return a.getAsOpaquePointer() < b.getAsOpaquePointer();
+  }
+};
 
 /// Rewrites gpu.launch_func operation to be contained inside
 /// comp.schedule_func. Creates new execution environment before function,
@@ -33,25 +47,30 @@ struct RewriteLaunchFunc : public mlir::OpRewritePattern<gpu::LaunchFuncOp> {
   matchAndRewrite(gpu::LaunchFuncOp op,
                   mlir::PatternRewriter &rewriter) const override;
 
+  mlir::LogicalResult allocateDeviceMemory(
+      mlir::PatternRewriter &rewriter, mlir::Location location,
+      mlir::Value execEnv, gpu::LaunchFuncOp &op,
+      std::vector<mlir::Value> &device,
+      std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool) const;
   mlir::LogicalResult
-  allocateDeviceMemory(mlir::PatternRewriter &rewriter, mlir::Location location,
-                       mlir::Value execEnv, const mlir::ValueRange &host,
-                       std::vector<mlir::Value> &device) const;
-  mlir::LogicalResult createScheduleFuncOp(mlir::PatternRewriter &rewriter,
-                                           mlir::Location loc,
-                                           mlir::Value execEnv,
-                                           gpu::LaunchFuncOp op,
-                                           const mlir::ValueRange &operands,
-                                           mlir::Value &event) const;
-  mlir::LogicalResult readDeviceMemory(mlir::PatternRewriter &rewriter,
-                                       mlir::Location loc, mlir::Value execEnv,
-                                       const mlir::ValueRange &hostArgs,
-                                       const mlir::ValueRange &deviceArgs,
-                                       mlir::Value dependency) const;
-  mlir::LogicalResult
-  deallocateDeviceMemory(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                         mlir::Value execEnv, const mlir::ValueRange &hostArgs,
-                         const mlir::ValueRange &deviceArgs) const;
+  createScheduleFuncOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                       mlir::Value execEnv, std::vector<gpu::LaunchFuncOp> &ops,
+                       const std::vector<std::vector<mlir::Value>> &operands,
+                       mlir::Value &event) const;
+  mlir::LogicalResult readDeviceMemory(
+      mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
+      mlir::Value dependency,
+      std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool,
+      gpu::LaunchFuncOp &op) const;
+  mlir::LogicalResult deallocateDeviceMemory(
+      mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
+      std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool) const;
+
+  bool isInternalOperation(mlir::Operation *op) const;
+  llvm::SmallSet<mlir::Operation *, 4>
+  getExternalDependentOperations(mlir::Value value) const;
+  BufferCopyMode getBufferCopyMode(mlir::Operation *op,
+                                   mlir::Value buffer) const;
 
   comp::ExecEnvType execEnvType;
   comp::EventType eventType;
@@ -90,6 +109,70 @@ public:
   void runOnOperation();
 };
 
+llvm::SmallSet<mlir::Operation *, 4>
+RewriteLaunchFunc::getExternalDependentOperations(mlir::Value value) const {
+  llvm::SmallSet<mlir::Operation *, 4> operations;
+  llvm::SetVector<mlir::OpOperand *> uses;
+
+  operations.insert(value.getDefiningOp());
+  for (auto &use : value.getUses()) {
+    uses.insert(&use);
+  }
+  while (!uses.empty()) {
+    auto owner = uses.back()->getOwner();
+    operations.insert(owner);
+    uses.pop_back();
+    for (auto opResult : owner->getOpResults()) {
+      for (auto &use : opResult.getUses()) {
+        uses.insert(&use);
+      }
+    }
+  }
+
+  for (auto operation : operations) {
+    if (isInternalOperation(operation)) {
+      operations.erase(operation);
+    }
+  }
+  return operations;
+}
+
+bool RewriteLaunchFunc::isInternalOperation(mlir::Operation *op) const {
+  auto allocOp = llvm::dyn_cast<mlir::AllocOp>(op);
+  auto memRefCastOp = llvm::dyn_cast<mlir::MemRefCastOp>(op);
+  if (allocOp || memRefCastOp) {
+    return true;
+  }
+  return false;
+}
+
+BufferCopyMode RewriteLaunchFunc::getBufferCopyMode(mlir::Operation *op,
+                                                    mlir::Value buffer) const {
+  BufferCopyMode copyMode = BufferCopyMode::NoCopy;
+  if (buffer.isa<mlir::BlockArgument>()) {
+    copyMode = copyMode |
+               (BufferCopyMode::HostToDevice | BufferCopyMode::DeviceToHost);
+    return copyMode;
+  }
+
+  auto currentBlock = op->getBlock();
+  auto operationDeps = getExternalDependentOperations(buffer);
+  for (auto dependency : operationDeps) {
+    if (dependency->getBlock() == currentBlock) {
+      if (dependency->isBeforeInBlock(op)) {
+        copyMode = copyMode | BufferCopyMode::HostToDevice;
+      } else {
+        copyMode = copyMode | BufferCopyMode::DeviceToHost;
+      }
+    } else {
+      // Dependency is outside of current block.
+      copyMode = copyMode |
+                 (BufferCopyMode::HostToDevice | BufferCopyMode::DeviceToHost);
+    }
+  }
+  return copyMode;
+}
+
 mlir::LogicalResult
 RewriteLaunchFunc::matchAndRewrite(gpu::LaunchFuncOp op,
                                    mlir::PatternRewriter &rewriter) const {
@@ -106,101 +189,149 @@ RewriteLaunchFunc::matchAndRewrite(gpu::LaunchFuncOp op,
     return mlir::failure();
   }
   mlir::Value device = func.getArgument(0);
+
+  // Collect all following LaunchFuncOps to a vector
+  auto &opList = op.getOperation()->getBlock()->getOperations();
+  std::vector<gpu::LaunchFuncOp> launchOps;
+  for (size_t i = 0; i < opList.size(); i++) {
+    auto currOp = std::next(opList.begin(), i);
+    if (mlir::isa<gpu::LaunchFuncOp>(currOp) &&
+        op == mlir::cast<gpu::LaunchFuncOp>(*currOp)) {
+      for (size_t j = i; j < opList.size(); j++) {
+        auto nextOp = std::next(opList.begin(), j);
+        if (mlir::isa<gpu::LaunchFuncOp>(nextOp)) {
+          launchOps.push_back(mlir::cast<gpu::LaunchFuncOp>(*nextOp));
+        } else {
+          if (!mlir::isa<mlir::AllocOp>(nextOp)) {
+            // break if it is not gpu::LaunchFuncOp or mlir::AllocOp
+            break;
+          }
+        }
+      }
+      break;
+    }
+  }
+
+  // Insert created new ops after skipped mlir::AllocOps
+  rewriter.setInsertionPointAfter(launchOps.back());
+
   // Create execution environment.
   auto execEnvOp =
       rewriter.create<comp::CreateExecEnv>(loc, execEnvType, device);
   mlir::Value execEnv = execEnvOp.getResult();
-  // Allocate memory on device for memory operands.
-  std::vector<mlir::Value> newOperands;
-  if (mlir::failed(allocateDeviceMemory(rewriter, loc, execEnv, op.operands(),
-                                        newOperands)))
-    return mlir::failure();
+  std::map</*hostBuffer=*/mlir::Value, /*deviceAllocatedBuffer=*/mlir::Value,
+           valueComparator>
+      bufferPool;
+  std::vector<std::vector<mlir::Value>> newOperands(launchOps.size());
+  for (size_t i = 0; i < launchOps.size(); i++) {
+    // Allocate memory on device for memory operands.
+    if (mlir::failed(allocateDeviceMemory(rewriter, loc, execEnv, launchOps[i],
+                                          newOperands[i], bufferPool)))
+      return mlir::failure();
+  }
+
   mlir::Value funcEvent;
-  if (mlir::failed(createScheduleFuncOp(rewriter, loc, execEnv, op, newOperands,
-                                        funcEvent)))
+  if (mlir::failed(createScheduleFuncOp(rewriter, loc, execEnv, launchOps,
+                                        newOperands, funcEvent)))
     return mlir::failure();
+
+  // Remove original launch operations.
+  for (auto launchOp : launchOps) {
+    rewriter.eraseOp(launchOp.getOperation());
+  }
+
   // Read device memory back to host.
-  if (mlir::failed(readDeviceMemory(rewriter, loc, execEnv, op.operands(),
-                                    newOperands, funcEvent)))
+  if (mlir::failed(readDeviceMemory(rewriter, loc, execEnv, funcEvent,
+                                    bufferPool, launchOps.back())))
     return mlir::failure();
   // Deallocate device memory.
-  if (mlir::failed(deallocateDeviceMemory(rewriter, loc, execEnv, op.operands(),
-                                          newOperands)))
+  if (mlir::failed(deallocateDeviceMemory(rewriter, loc, execEnv, bufferPool)))
     return mlir::failure();
   // Destroy execution environment.
   rewriter.create<comp::DestroyExecEnv>(loc, execEnv);
-  // Remove original launch operation.
-  rewriter.eraseOp(op.getOperation());
-
   return mlir::success();
 }
 
 mlir::LogicalResult RewriteLaunchFunc::allocateDeviceMemory(
     mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
-    const mlir::ValueRange &host, std::vector<mlir::Value> &device) const {
+    gpu::LaunchFuncOp &op, std::vector<mlir::Value> &device,
+    std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool) const {
+  auto host = op.operands();
   device.reserve(host.size());
   for (mlir::Value hostArg : host) {
     mlir::Value newArg = hostArg;
-
-    if (auto memRefType = hostArg.getType().dyn_cast<mlir::MemRefType>()) {
-      if (!execEnvType.supportsMemorySpace(memRefType.getMemorySpace())) {
+    if (bufferPool.count(hostArg) == 0) {
+      if (auto memRefType = hostArg.getType().dyn_cast<mlir::MemRefType>()) {
         mlir::MemRefType newMemRefType =
             mlir::MemRefType::Builder(memRefType)
                 .setMemorySpace(execEnvType.getDefaultMemorySpace());
         auto allocOp =
             rewriter.create<comp::Alloc>(loc, newMemRefType, execEnv);
         newArg = allocOp.getResult();
-        comp::EventType eventType = execEnvType.getEventType();
-        mlir::Value event = rewriter.create<comp::ScheduleWrite>(
-            loc, eventType, hostArg, newArg, execEnv, mlir::ValueRange{});
-        rewriter.create<comp::Wait>(loc, event);
-      }
-    }
 
-    device.push_back(newArg);
+        auto copyMode = getBufferCopyMode(op.getOperation(), hostArg);
+        if ((copyMode & BufferCopyMode::HostToDevice) !=
+            BufferCopyMode::NoCopy) {
+          comp::EventType eventType = execEnvType.getEventType();
+          mlir::Value event = rewriter.create<comp::ScheduleWrite>(
+              loc, eventType, hostArg, newArg, execEnv, mlir::ValueRange{});
+          rewriter.create<comp::Wait>(loc, event);
+        }
+      }
+      bufferPool.insert({hostArg, newArg});
+    }
+    device.push_back(bufferPool[hostArg]);
   }
   return mlir::success();
 }
 
 mlir::LogicalResult RewriteLaunchFunc::createScheduleFuncOp(
     mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
-    gpu::LaunchFuncOp op, const mlir::ValueRange &operands,
+    std::vector<gpu::LaunchFuncOp> &ops,
+    const std::vector<std::vector<mlir::Value>> &operands,
     mlir::Value &event) const {
-  // Find kernel that operation launches.
-  mlir::SymbolRefAttr kernelSymbol = op.kernel();
-  auto kernelOp = mlir::SymbolTable::lookupNearestSymbolFrom<gpu::GPUFuncOp>(
-      op.getOperation(), kernelSymbol);
-  if (!kernelOp)
-    return mlir::failure();
+  for (size_t i = 0; i < ops.size(); i++) {
+    auto op = ops[i];
+    auto operand = operands[i];
+    // Find kernel that operation launches.
+    mlir::SymbolRefAttr kernelSymbol = op.kernel();
+    auto kernelOp = mlir::SymbolTable::lookupNearestSymbolFrom<gpu::GPUFuncOp>(
+        op.getOperation(), kernelSymbol);
+    if (!kernelOp)
+      return mlir::failure();
 
-  auto scheduleFuncOp = rewriter.create<comp::ScheduleFunc>(
-      loc, eventType, execEnv, mlir::ValueRange());
-  event = scheduleFuncOp.getResult();
+    auto scheduleFuncOp = rewriter.create<comp::ScheduleFunc>(
+        loc, eventType, execEnv, mlir::ValueRange());
+    event = scheduleFuncOp.getResult();
 
-  // Add launch_func with new operands inside schedule_func.
-  mlir::PatternRewriter::InsertionGuard insertionGuard(rewriter);
-  rewriter.createBlock(&scheduleFuncOp.body(), scheduleFuncOp.body().end());
-  rewriter.create<gpu::LaunchFuncOp>(loc, kernelOp,
-                                     op.getGridSizeOperandValues(),
-                                     op.getBlockSizeOperandValues(), operands);
-  rewriter.create<comp::ScheduleEnd>(loc);
-
+    // Add launch_func with new operands inside schedule_func.
+    mlir::PatternRewriter::InsertionGuard insertionGuard(rewriter);
+    rewriter.createBlock(&scheduleFuncOp.body(), scheduleFuncOp.body().end());
+    rewriter.create<gpu::LaunchFuncOp>(loc, kernelOp,
+                                       op.getGridSizeOperandValues(),
+                                       op.getBlockSizeOperandValues(), operand);
+    rewriter.create<comp::ScheduleEnd>(loc);
+  }
   return mlir::success();
 }
 
 mlir::LogicalResult RewriteLaunchFunc::readDeviceMemory(
     mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
-    const mlir::ValueRange &hostArgs, const mlir::ValueRange &deviceArgs,
-    mlir::Value dependency) const {
+    mlir::Value dependency,
+    std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool,
+    gpu::LaunchFuncOp &op) const {
   std::vector<mlir::Value> readEvents;
-  for (size_t argIdx = 0; argIdx < hostArgs.size(); ++argIdx) {
-    mlir::Value host = hostArgs[argIdx];
-    mlir::Value device = deviceArgs[argIdx];
+  for (auto pair : bufferPool) {
+    mlir::Value host = pair.first;
+    mlir::Value device = pair.second;
     if (host == device)
       continue;
-    auto readOp = rewriter.create<comp::ScheduleRead>(
-        loc, eventType, host, device, execEnv, dependency);
-    readEvents.push_back(readOp.getResult());
+    auto copyMode = getBufferCopyMode(op.getOperation(), host);
+    if ((copyMode & BufferCopyMode::DeviceToHost) != BufferCopyMode::NoCopy) {
+      auto readOp = rewriter.create<comp::ScheduleRead>(
+          loc, eventType, host, device, execEnv, dependency);
+      readEvents.push_back(readOp.getResult());
+    }
   }
   // Wait for all read operations to finish or dependency if no reads.
   if (!readEvents.empty())
@@ -213,11 +344,10 @@ mlir::LogicalResult RewriteLaunchFunc::readDeviceMemory(
 
 mlir::LogicalResult RewriteLaunchFunc::deallocateDeviceMemory(
     mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value execEnv,
-    const mlir::ValueRange &hostArgs,
-    const mlir::ValueRange &deviceArgs) const {
-  for (size_t argIdx = 0; argIdx < hostArgs.size(); ++argIdx) {
-    mlir::Value host = hostArgs[argIdx];
-    mlir::Value device = deviceArgs[argIdx];
+    std::map<mlir::Value, mlir::Value, valueComparator> &bufferPool) const {
+  for (auto pair : bufferPool) {
+    mlir::Value host = pair.first;
+    mlir::Value device = pair.second;
     if (host == device)
       continue;
     rewriter.create<comp::Dealloc>(loc, execEnv, device);


### PR DESCRIPTION
1. adds buffer transfer optimization at comp level  https://github.com/plaidml/plaidml/pull/1356#issuecomment-700854644
    OpenCL resnet50 overall inference latency improved from 74ms to 61ms (about 18% improvement) on my local machine with Gen9 . Resnet50 total number of memory transfers reduced from 473 to 230

2. optimized comp dialect representation to help support memory optimization and share comp dialect representation between ocl, vulkan and L0

Example: PLAIDML_DEVICE=vulkan.0 PLAIDML_TARGET=intel_gen bazelisk run plaidml/bridge/keras:backend_test -- TestBackendOps.testConv1d 

Below shows one of the conv1d test with input data shape  <2x3x1xf32>,<1x8x3xf32>, <1x8x1xf32>

Before 
```
func @main(%arg0: !comp.device, %arg1: memref<2x3x1xf32>, %arg2: memref<1x8x3xf32>, %arg3: memref<1x8x1xf32>) {
    %cst = constant 0.000000e+00 : f32
    %c2 = constant 2 : index
    %c4 = constant 4 : index
    %c5 = constant 5 : index
    %c6 = constant 6 : index
    %c7 = constant 7 : index
    %c0 = constant 0 : index
    %c10 = constant 10 : index
    %c3 = constant 3 : index
    %c8 = constant 8 : index
    %c1 = constant 1 : index
    %0 = alloc() : memref<1x10x3xf32>
    %1 = comp.create_execenv %arg0 : (!comp.device) -> !comp.execenv<ocl:0,(11)>
    %2 = comp.alloc %1 : (!comp.execenv<ocl:0,(11)>) -> memref<1x10x3xf32, 11>
    %3 = comp.schedule_write %0 to %2 on %1 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %3 : !comp.event<ocl>
    %4 = "comp.schedule_func"(%1) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c10, %c3, %2) {kernel = @main_kernel::@main_kernel} : (index, index, index, index, index, index, memref<1x10x3xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %5 = comp.schedule_read %0 from %2 on %1 wait for %4 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    comp.wait %5 : !comp.event<ocl>
    comp.dealloc %1 %2 : (!comp.execenv<ocl:0,(11)>, memref<1x10x3xf32, 11>) -> ()
    comp.destroy_execenv %1 : !comp.execenv<ocl:0,(11)>
    %6 = comp.create_execenv %arg0 : (!comp.device) -> !comp.execenv<ocl:0,(11)>
    %7 = comp.alloc %6 : (!comp.execenv<ocl:0,(11)>) -> memref<1x8x3xf32, 11>
    %8 = comp.schedule_write %arg2 to %7 on %6 : (memref<1x8x3xf32>, memref<1x8x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %8 : !comp.event<ocl>
    %9 = comp.alloc %6 : (!comp.execenv<ocl:0,(11)>) -> memref<1x10x3xf32, 11>
    %10 = comp.schedule_write %0 to %9 on %6 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %10 : !comp.event<ocl>
    %11 = "comp.schedule_func"(%6) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c8, %c3, %7, %9) {kernel = @main_kernel_0::@main_kernel} : (index, index, index, index, index, index, memref<1x8x3xf32, 11>, memref<1x10x3xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %12 = comp.schedule_read %arg2 from %7 on %6 wait for %11 : (memref<1x8x3xf32>, memref<1x8x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %13 = comp.schedule_read %0 from %9 on %6 wait for %11 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    comp.wait %12, %13 : !comp.event<ocl>, !comp.event<ocl>
    comp.dealloc %6 %7 : (!comp.execenv<ocl:0,(11)>, memref<1x8x3xf32, 11>) -> ()
    comp.dealloc %6 %9 : (!comp.execenv<ocl:0,(11)>, memref<1x10x3xf32, 11>) -> ()
    comp.destroy_execenv %6 : !comp.execenv<ocl:0,(11)>
    %14 = comp.create_execenv %arg0 : (!comp.device) -> !comp.execenv<ocl:0,(11)>
    %15 = comp.alloc %14 : (!comp.execenv<ocl:0,(11)>) -> memref<1x8x1xf32, 11>
    %16 = comp.schedule_write %arg3 to %15 on %14 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %16 : !comp.event<ocl>
    %17 = "comp.schedule_func"(%14) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c8, %c1, %15) {kernel = @main_kernel_1::@main_kernel} : (index, index, index, index, index, index, memref<1x8x1xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %18 = comp.schedule_read %arg3 from %15 on %14 wait for %17 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    comp.wait %18 : !comp.event<ocl>
    comp.dealloc %14 %15 : (!comp.execenv<ocl:0,(11)>, memref<1x8x1xf32, 11>) -> ()
    comp.destroy_execenv %14 : !comp.execenv<ocl:0,(11)>
    %19 = comp.create_execenv %arg0 : (!comp.device) -> !comp.execenv<ocl:0,(11)>
    %20 = comp.alloc %19 : (!comp.execenv<ocl:0,(11)>) -> memref<1x10x3xf32, 11>
    %21 = comp.schedule_write %0 to %20 on %19 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %21 : !comp.event<ocl>
    %22 = comp.alloc %19 : (!comp.execenv<ocl:0,(11)>) -> memref<2x3x1xf32, 11>
    %23 = comp.schedule_write %arg1 to %22 on %19 : (memref<2x3x1xf32>, memref<2x3x1xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %23 : !comp.event<ocl>
    %24 = comp.alloc %19 : (!comp.execenv<ocl:0,(11)>) -> memref<1x8x1xf32, 11>
    %25 = comp.schedule_write %arg3 to %24 on %19 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %25 : !comp.event<ocl>
    %26 = "comp.schedule_func"(%19) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c8, %c1, %c1, %20, %22, %24) {kernel = @main_kernel_2::@main_kernel} : (index, index, index, index, index, index, memref<1x10x3xf32, 11>, memref<2x3x1xf32, 11>, memref<1x8x1xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %27 = comp.schedule_read %0 from %20 on %19 wait for %26 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %28 = comp.schedule_read %arg1 from %22 on %19 wait for %26 : (memref<2x3x1xf32>, memref<2x3x1xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %29 = comp.schedule_read %arg3 from %24 on %19 wait for %26 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    comp.wait %27, %28, %29 : !comp.event<ocl>, !comp.event<ocl>, !comp.event<ocl>
    comp.dealloc %19 %20 : (!comp.execenv<ocl:0,(11)>, memref<1x10x3xf32, 11>) -> ()
    comp.dealloc %19 %22 : (!comp.execenv<ocl:0,(11)>, memref<2x3x1xf32, 11>) -> ()
    comp.dealloc %19 %24 : (!comp.execenv<ocl:0,(11)>, memref<1x8x1xf32, 11>) -> ()
    comp.destroy_execenv %19 : !comp.execenv<ocl:0,(11)>
    return
  }
```
After
```
  func @main(%arg0: !comp.device, %arg1: memref<2x3x1xf32>, %arg2: memref<1x8x3xf32>, %arg3: memref<1x8x1xf32>) {
    %cst = constant 0.000000e+00 : f32
    %c2 = constant 2 : index
    %c4 = constant 4 : index
    %c5 = constant 5 : index
    %c6 = constant 6 : index
    %c7 = constant 7 : index
    %c0 = constant 0 : index
    %c10 = constant 10 : index
    %c3 = constant 3 : index
    %c8 = constant 8 : index
    %c1 = constant 1 : index
    %0 = alloc() : memref<1x10x3xf32>
    %1 = comp.create_execenv %arg0 : (!comp.device) -> !comp.execenv<ocl:0,(11)>
    %2 = comp.alloc %1 : (!comp.execenv<ocl:0,(11)>) -> memref<1x10x3xf32, 11>
    %3 = comp.alloc %1 : (!comp.execenv<ocl:0,(11)>) -> memref<1x8x3xf32, 11>
    %4 = comp.schedule_write %arg2 to %3 on %1 : (memref<1x8x3xf32>, memref<1x8x3xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %4 : !comp.event<ocl>
    %5 = comp.alloc %1 : (!comp.execenv<ocl:0,(11)>) -> memref<1x8x1xf32, 11>
    %6 = comp.schedule_write %arg3 to %5 on %1 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %6 : !comp.event<ocl>
    %7 = comp.alloc %1 : (!comp.execenv<ocl:0,(11)>) -> memref<2x3x1xf32, 11>
    %8 = comp.schedule_write %arg1 to %7 on %1 : (memref<2x3x1xf32>, memref<2x3x1xf32, 11>, !comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    comp.wait %8 : !comp.event<ocl>
    %9 = "comp.schedule_func"(%1) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c10, %c3, %2) {kernel = @main_kernel::@main_kernel} : (index, index, index, index, index, index, memref<1x10x3xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %10 = "comp.schedule_func"(%1) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c8, %c3, %3, %2) {kernel = @main_kernel_0::@main_kernel} : (index, index, index, index, index, index, memref<1x8x3xf32, 11>, memref<1x10x3xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %11 = "comp.schedule_func"(%1) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c1, %c8, %c1, %5) {kernel = @main_kernel_1::@main_kernel} : (index, index, index, index, index, index, memref<1x8x1xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %12 = "comp.schedule_func"(%1) ( {
      "gpu.launch_func"(%c1, %c1, %c1, %c8, %c1, %c1, %2, %7, %5) {kernel = @main_kernel_2::@main_kernel} : (index, index, index, index, index, index, memref<1x10x3xf32, 11>, memref<2x3x1xf32, 11>, memref<1x8x1xf32, 11>) -> ()
      "comp.schedule_end"() : () -> ()
    }) : (!comp.execenv<ocl:0,(11)>) -> !comp.event<ocl>
    %13 = comp.schedule_read %arg1 from %7 on %1 wait for %12 : (memref<2x3x1xf32>, memref<2x3x1xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %14 = comp.schedule_read %arg3 from %5 on %1 wait for %12 : (memref<1x8x1xf32>, memref<1x8x1xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %15 = comp.schedule_read %arg2 from %3 on %1 wait for %12 : (memref<1x8x3xf32>, memref<1x8x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    %16 = comp.schedule_read %0 from %2 on %1 wait for %12 : (memref<1x10x3xf32>, memref<1x10x3xf32, 11>, !comp.execenv<ocl:0,(11)>, !comp.event<ocl>) -> !comp.event<ocl>
    comp.wait %13, %14, %15, %16 : !comp.event<ocl>, !comp.event<ocl>, !comp.event<ocl>, !comp.event<ocl>
    comp.dealloc %1 %7 : (!comp.execenv<ocl:0,(11)>, memref<2x3x1xf32, 11>) -> ()
    comp.dealloc %1 %5 : (!comp.execenv<ocl:0,(11)>, memref<1x8x1xf32, 11>) -> ()
    comp.dealloc %1 %3 : (!comp.execenv<ocl:0,(11)>, memref<1x8x3xf32, 11>) -> ()
    comp.dealloc %1 %2 : (!comp.execenv<ocl:0,(11)>, memref<1x10x3xf32, 11>) -> ()
    comp.destroy_execenv %1 : !comp.execenv<ocl:0,(11)>
    return
  }
```
3. OpenCL and Vulkan backends now share the same comp dialect representation, only memref memorySpace is different.
    https://github.com/plaidml/plaidml/issues/1413

4. adds multi command buffer support to vulkan backend, 
    Vulkan resnet50 kernel execute time changed from 75ms to 83ms due to overheads of multi-commandBuffer.
    Multi command buffer support fixed 12 keras backend tests which were modifing buffer on host side before Vulkan commandBuffer returns, https://github.com/plaidml/plaidml/issues/1414 is not needed.
    Memory transfer using memory map not vkCmd*