### PR TITLE
Adding tuple pack/unpack ops + lowerings

### DIFF
--- a/pmlc/conversion/stdx_to_llvm/tests/pack.mlir
+++ b/pmlc/conversion/stdx_to_llvm/tests/pack.mlir
@@ -1,0 +1,48 @@
+// RUN: pmlc-opt -convert-stdx-to-llvm %s | FileCheck %s
+// RUN: pmlc-opt -x86-convert-std-to-llvm %s | pmlc-jit -e jitEntry | FileCheck %s --check-prefix=JIT
+
+// CHECK-LABEL: @packLowering
+func @packLowering(%A: memref<20x10xf32>, %i: index, %f: f32) -> (tuple<memref<20x10xf32>, index, f32>) {
+  %0 = stdx.pack %A, %i, %f : memref<20x10xf32>, index, f32
+  // llvm.call @malloc
+  // llvm.bitcast 
+  // llvm.mlir.undef
+  // llvm.insertvalue
+  // llvm.insertvalue
+  // llvm.insertvalue
+  // llvm.store
+  return %0 : tuple<memref<20x10xf32>, index, f32>
+}
+
+// CHECK-LABEL: @unpackLowering
+func @unpackLowering(%P: tuple<memref<20x10xf32>, index, f32>) -> (memref<20x10xf32>, index, f32) {
+  %A, %i, %f = stdx.unpack %P : memref<20x10xf32>, index, f32
+  // llvm.bitcast
+  // llvm.load
+  // llvm.extractvalue
+  // llvm.extractvalue
+  // llvm.extractvalue
+  return %A, %i, %f : memref<20x10xf32>, index, f32
+}
+
+func @print_memref_f32(memref<*xf32>)
+
+func @jitEntry() -> () {
+  %in = alloc() : memref<3xf32>
+  %a = constant 1.0 : f32
+  %b = constant 2.0 : f32
+  %c = constant 3.0 : f32
+  %p = stdx.pack %in, %a, %b, %c : memref<3xf32>, f32, f32, f32
+  %out, %a2, %b2, %c2 = stdx.unpack %p : memref<3xf32>, f32, f32, f32
+  %i0 = constant 0 : index
+  %i1 = constant 1 : index
+  %i2 = constant 2 : index
+  store %a2, %out[%i0] : memref<3xf32>
+  store %b2, %out[%i1] : memref<3xf32>
+  store %c2, %out[%i2] : memref<3xf32>
+  %outUnranked = memref_cast %out : memref<3xf32> to memref<*xf32>
+  call @print_memref_f32(%outUnranked) : (memref<*xf32>) -> ()
+  // JIT: [1, 2, 3]
+  return
+}
+

--- a/pmlc/dialect/stdx/ir/ops.cc
+++ b/pmlc/dialect/stdx/ir/ops.cc
@@ -47,6 +47,47 @@ verifySubgroupBlockWriteINTELOp(SubgroupBlockWriteINTELOp op) {
   return success();
 }
 
+static LogicalResult verifyPackOp(PackOp op) {
+  auto tupleType = op.getTupleType();
+  if (op.getNumOperands() != tupleType.size()) {
+    return failure();
+  }
+  for (unsigned i = 0; i < tupleType.size(); i++) {
+    if (op.getOperand(i).getType() != tupleType.getType(i)) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult verifyUnpackOp(UnpackOp op) {
+  auto tupleType = op.getTupleType();
+  if (op.getNumResults() != tupleType.size()) {
+    return failure();
+  }
+  for (unsigned i = 0; i < tupleType.size(); i++) {
+    if (op.getResult(i).getType() != tupleType.getType(i)) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static ParseResult parseTupleTypeAsm(OpAsmParser &parser, Type &tuple,
+                                     SmallVectorImpl<Type> &expanded) {
+  auto ret = parser.parseTypeList(expanded);
+  if (ret) {
+    return failure();
+  }
+  tuple = TupleType::get(expanded, parser.getBuilder().getContext());
+  return ret;
+}
+
+static void printTupleTypeAsm(OpAsmPrinter &printer, Type tuple,
+                              TypeRange expanded) {
+  printer << expanded;
+}
+
 void StdXDialect::initialize() {
   addOperations<
 #define GET_OP_LIST

--- a/pmlc/dialect/stdx/ir/ops.h
+++ b/pmlc/dialect/stdx/ir/ops.h
@@ -6,8 +6,10 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/StandardTypes.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Support/LogicalResult.h"
 
 namespace pmlc::dialect::stdx {
 

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -161,4 +161,32 @@ def SubgroupBlockWriteINTELOp : StdX_Op<"subgroup_block_write_intel", [NoSideEff
   }];
 }
 
+def PackOp : StdX_Op<"pack", [NoSideEffect]> {
+  let summary = "Pack multiple values into a tuple";
+  let arguments = (ins Variadic<AnyType>:$in);
+  let results = (outs AnyTuple:$out);
+  let assemblyFormat = [{ $in `:` custom<TupleTypeAsm>(type($out), type($in)) attr-dict }];
+  let builders = [OpBuilder<
+    "mlir::OpBuilder &, mlir::OperationState &, mlir::ArrayRef<mlir::Value>">];
+  let extraClassDeclaration = [{
+    mlir::TupleType getTupleType() {
+      return out().getType().cast<mlir::TupleType>();
+    }
+  }];
+}
+
+def UnpackOp : StdX_Op<"unpack", [NoSideEffect]> {
+  let summary = "Pack multiple values into a tuple";
+  let arguments = (ins AnyTuple:$in);
+  let results = (outs Variadic<AnyType>:$out);
+  let assemblyFormat = [{ $in `:` custom<TupleTypeAsm>(type($in), type($out)) attr-dict }];
+  let builders = [OpBuilder<
+    "mlir::OpBuilder &, mlir::OperationState &, mlir::Value">];
+  let extraClassDeclaration = [{
+    mlir::TupleType getTupleType() {
+      return in().getType().cast<mlir::TupleType>();
+    }
+  }];
+}
+
 #endif // __PML_STDX_OPS__


### PR DESCRIPTION
Pack + unpack support in preparation for init/fini goo.  Note: pack mallocs, unpack doesn't free, the assumption here is that returned allocations will have their lifetime managed by outer API.