### PR TITLE
Fix for broken h5py dependency

### DIFF
--- a/ci/conda/tensorflow.yml
+++ b/ci/conda/tensorflow.yml
@@ -4,5 +4,6 @@ dependencies:
   - pip=19
   - python=3.6
   - pip:
+      - h5py < 3.0.0
       - tensorflow==1.15; platform_system == 'Darwin'
       - tensorflow-gpu==1.15; platform_system != 'Darwin'

--- a/conda/unix.yml
+++ b/conda/unix.yml
@@ -23,6 +23,7 @@ dependencies:
       - dm-sonnet<2.0.0
       - drawSvg
       - graphviz
+      - h5py < 3.0.0
       - humanize
       - keras==2.2.4
       - keras-applications==1.0.8

--- a/conda/windows.yml
+++ b/conda/windows.yml
@@ -14,6 +14,7 @@ dependencies:
     - click
     - defaultlist
     - graphviz
+    - h5py < 3.0.0
     - humanize
     - keras==2.2.4
     - keras-applications==1.0.8

--- a/plaidbench/setup.py
+++ b/plaidbench/setup.py
@@ -14,7 +14,7 @@ INSTALL_REQUIRES = [
     'click>=6.0.0',
     'colorama',
     'enum34>=1.1.6',
-    'h5py=2.10',
+    'h5py==2.10',
     'numpy',
     'plaidml',
     'six',

--- a/plaidbench/setup.py
+++ b/plaidbench/setup.py
@@ -14,7 +14,7 @@ INSTALL_REQUIRES = [
     'click>=6.0.0',
     'colorama',
     'enum34>=1.1.6',
-    'h5py>=2.7.0',
+    'h5py=2.10',
     'numpy',
     'plaidml',
     'six',


### PR DESCRIPTION
It appears the h5py v3.0.0+ has made some incompatible changes:
https://github.com/tensorflow/tensorflow/issues/44467