### PR TITLE
layer.box op may contain side effects; do not tag NoSideEffect

### DIFF
--- a/pmlc/dialect/layer/ir/ops.td
+++ b/pmlc/dialect/layer/ir/ops.td
@@ -17,7 +17,7 @@ class LayerOp<string mnemonic, list<OpTrait> traits = []>
 }
 
 
-def BoxOp : LayerOp<"box", [NoSideEffect, IsolatedFromAbove]> {
+def BoxOp : LayerOp<"box", [IsolatedFromAbove]> {
   let summary = "layer container operation";
   let arguments = (ins
     Variadic<AnyType>:$operands,


### PR DESCRIPTION
Original definition of layer dialect BoxOp was erroneously marked [NoSideEffect], but this is not a reasonable guarantee.