### PR TITLE
Access qualifier for read only buffers pass

### DIFF
--- a/pmlc/target/intel_gen_ocl_spirv/CMakeLists.txt
+++ b/pmlc/target/intel_gen_ocl_spirv/CMakeLists.txt
@@ -4,6 +4,7 @@ pml_cc_library(
     passes.h
     pipeline.h
   SRCS
+    access_qualifiers.cc
     legalize_spirv.cc
     pipeline.cc
     reorder_layouts.cc

--- a/pmlc/target/intel_gen_ocl_spirv/access_qualifiers.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/access_qualifiers.cc
@@ -1,0 +1,121 @@
+// Copyright 2020, Intel Corporation
+
+#include "pmlc/target/intel_gen_ocl_spirv/pass_detail.h"
+#include "pmlc/target/intel_gen_ocl_spirv/passes.h"
+
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
+#include "mlir/Dialect/SPIRV/TargetAndABI.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
+
+#include "mlir/Support/DebugStringHelper.h"
+#include "pmlc/util/logging.h"
+
+namespace pmlc::target::intel_gen_ocl_spirv {
+namespace spirv = mlir::spirv;
+
+namespace {
+
+/// This pass adds read only access qualifier for the buffer that is used
+/// only by spv.Load and spv.SubgroupBlockReadINTEL.
+/// The qualifier is added with OpMemberDecorate FuncParamAttr NoWrite.
+/// This works only with spirv Capability "Kernel" (OpenCL backend).
+
+class IntelGenOclSetAccessQualifiers
+    : public IntelGenOclSetAccessQualifiersBase<
+          IntelGenOclSetAccessQualifiers> {
+public:
+  /// Returns entry point function in module or nullptr if there is none.
+  spirv::FuncOp getEntryPoint(spirv::ModuleOp module) {
+    spirv::FuncOp func = nullptr;
+    module.walk([&](spirv::FuncOp op) {
+      if (!op.getAttr(spirv::getEntryPointABIAttrName()))
+        return mlir::WalkResult::advance();
+      func = op;
+      return mlir::WalkResult::interrupt();
+    });
+    return func;
+  }
+
+  bool checkForReadOnly(mlir::Operation *op) {
+    for (auto *user : op->getUsers()) {
+      if (!(mlir::isa<spirv::LoadOp>(user) ||
+            mlir::isa<spirv::SubgroupBlockReadINTELOp>(user)))
+        return false;
+    }
+    return true;
+  }
+
+  void runOnOperation() {
+    spirv::ModuleOp module = getOperation();
+    spirv::FuncOp func = getEntryPoint(module);
+    if (!func)
+      return;
+
+    for (auto &arg : func.getArguments()) {
+      auto readOnly = false;
+      for (auto *op : arg.getUsers()) {
+        // Case where argument is used directly by AccessChainOp
+        if (mlir::isa<spirv::AccessChainOp>(op)) {
+          readOnly = checkForReadOnly(op);
+        } else if (mlir::isa<spirv::BitcastOp>(op)) {
+          // Case where argument is casted before AccessChainOp
+          for (auto *bitCastUser : op->getUsers()) {
+            if (mlir::isa<spirv::AccessChainOp>(bitCastUser)) {
+              readOnly = checkForReadOnly(bitCastUser);
+            } else {
+              readOnly = false;
+              break;
+            }
+          }
+        } else {
+          // If something else then go to next argument immediately
+          readOnly = false;
+          break;
+        }
+      }
+      // Add NoWrite decoration to the argument
+      if (readOnly) {
+        auto ptrType = arg.getType().dyn_cast<spirv::PointerType>();
+        if (!ptrType)
+          continue;
+
+        auto structType =
+            ptrType.getPointeeType().dyn_cast<spirv::StructType>();
+        if (!ptrType)
+          continue;
+
+        mlir::SmallVector<mlir::Type, 4> memberTypes;
+        mlir::SmallVector<spirv::StructType::OffsetInfo, 4> offsetInfo;
+        mlir::SmallVector<spirv::StructType::MemberDecorationInfo, 4>
+            memberDecorations;
+
+        for (uint32_t i = 0; i < structType.getNumElements(); i++) {
+          memberTypes.push_back(structType.getElementType(i));
+          offsetInfo.push_back(structType.getMemberOffset(i));
+        }
+        structType.getMemberDecorations(memberDecorations);
+
+        // TODO: create new enum in SPIRV dialect that would use actual enum and
+        // not the magic number 6 (that is NoWrite)
+        spirv::StructType::MemberDecorationInfo readOnlyDecor(
+            0, 1, spirv::Decoration::FuncParamAttr, 6);
+        memberDecorations.push_back(readOnlyDecor);
+
+        auto newStructType =
+            spirv::StructType::get(memberTypes, offsetInfo, memberDecorations);
+        auto newPtrType =
+            spirv::PointerType::get(newStructType, ptrType.getStorageClass());
+        arg.setType(newPtrType);
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> createSetAccessQualifiersPass() {
+  return std::make_unique<IntelGenOclSetAccessQualifiers>();
+}
+
+} // namespace pmlc::target::intel_gen_ocl_spirv

--- a/pmlc/target/intel_gen_ocl_spirv/passes.h
+++ b/pmlc/target/intel_gen_ocl_spirv/passes.h
@@ -20,6 +20,8 @@ std::unique_ptr<mlir::Pass> createIntelGenOclReorderLayoutsPass();
 std::unique_ptr<mlir::Pass>
 createIntelGenOclReorderLayoutsPass(unsigned maxThreads, bool allowReorder);
 
+std::unique_ptr<mlir::Pass> createSetAccessQualifiersPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "pmlc/target/intel_gen_ocl_spirv/passes.h.inc"

--- a/pmlc/target/intel_gen_ocl_spirv/passes.td
+++ b/pmlc/target/intel_gen_ocl_spirv/passes.td
@@ -47,4 +47,10 @@ def IntelGenOclReorderLayouts : FunctionPass<"intel-gen-ocl-reorder-layouts"> {
   ];
 }
 
+def IntelGenOclSetAccessQualifiers : Pass<"intel-gen-ocl-set-access-qualifiers", "mlir::spirv::ModuleOp"> {
+  let summary = "Set access qualifiers for function arguments.";
+  let constructor = "pmlc::target::intel_gen_ocl_spirv::createSetAccessQualifiersPass()";
+  let dependentDialects = ["mlir::spirv::SPIRVDialect"];
+}
+
 #endif // __PMLC_TARGET_INTEL_GEN__OCL_SPIRV_PASSES__

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -187,6 +187,7 @@ void pipelineBuilder(OpPassManager &pm,
 
   // SPIR-V passes for lowering attributes.
   pm.addPass(createSetSubgroupSizePass());
+  pm.addPass(createSetAccessQualifiersPass());
   pm.addPass(createLegalizeSpirvPass());
   pm.addPass(spirv::createLowerABIAttributesPass());
   pm.addPass(spirv::createUpdateVersionCapabilityExtensionPass());

--- a/pmlc/target/intel_gen_ocl_spirv/tests/access_qualifiers.mlir
+++ b/pmlc/target/intel_gen_ocl_spirv/tests/access_qualifiers.mlir
@@ -1,0 +1,32 @@
+// RUN: pmlc-opt --intel-gen-ocl-set-access-qualifiers %s | FileCheck %s
+
+spv.module @access_qualifier1 Physical64 OpenCL {
+  spv.func @kernel(%arg0: !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup>) "None" attributes {spv.entry_point_abi = {local_size = dense<[16, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+	// CHECK: spv.AccessChain {{.*}}[{{.*}}, {{.*}}] : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0, FuncParamAttr=6])>
+	%0 = spv.constant 0 : i32
+    %1 = spv.AccessChain %arg0[%0, %0] : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup>, i32, i32
+	%2 = spv.Load "CrossWorkgroup" %1 : f32
+    spv.Return
+  }
+}
+
+spv.module @access_qualifier2 Physical64 OpenCL {
+  spv.func @kernel(%arg0: !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup>) "None" attributes {spv.entry_point_abi = {local_size = dense<[16, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+	// CHECK: spv.AccessChain {{.*}}[{{.*}}, {{.*}}] : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0, FuncParamAttr=6])>
+	%0 = spv.constant 0 : i32
+    %1 = spv.AccessChain %arg0[%0, %0] : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup>, i32, i32
+	%2 = spv.SubgroupBlockReadINTEL "CrossWorkgroup" %1 : f32
+    spv.Return
+  }
+}
+
+spv.module @access_qualifier3 Physical64 OpenCL {
+  spv.func @kernel(%arg0: !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup>) "None" attributes {spv.entry_point_abi = {local_size = dense<[16, 3, 3]> : vector<3xi32>}, workgroup_attributions = 0 : i64} {
+	// CHECK: spv.Bitcast {{.*}} : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0, FuncParamAttr=6])>, CrossWorkgroup>
+	%0 = spv.constant 0 : i32
+	%1 = spv.Bitcast %arg0 : !spv.ptr<!spv.struct<(!spv.array<64 x f32, stride=4> [0])>, CrossWorkgroup> to !spv.ptr<!spv.struct<(!spv.array<64 x i32, stride=4> [0])>, CrossWorkgroup>
+    %2 = spv.AccessChain %1[%0, %0] : !spv.ptr<!spv.struct<(!spv.array<64 x i32, stride=4> [0])>, CrossWorkgroup>, i32, i32
+	%3 = spv.Load "CrossWorkgroup" %2 : i32
+    spv.Return
+  }
+}


### PR DESCRIPTION
Added this pass on spirv level so we would not need to propagate the read only attribute all the way down. Also we need to set it per kernel as some kernel use same buffers for read, others for write.
I tried to add the NoWrite enum to spirv dialect instead of adding magic number, but seems like it is kind of pandora's box when I tried to add Function Parameter Attribute Adds to SPIRVBase.td using provided mlir scripts. There are tons of new Extensions to be added (which seems need to be done manually), not sure if it is related directly with this change or lack of new updates lately. I also got problems with lack of definitions for the NVidia's extensions, so decided to abandon this and fix for magic number for now.