### PR TITLE
Hoisting added to gpu ocl pipeline

### DIFF
--- a/pmlc/target/intel_gen_ocl_spirv/BUILD
+++ b/pmlc/target/intel_gen_ocl_spirv/BUILD
@@ -40,6 +40,7 @@ plaidml_cc_library(
         "//pmlc/dialect/pxa/transforms",
         "//pmlc/dialect/stdx/transforms",
         "//pmlc/dialect/tile/transforms",
+        "//pmlc/transforms",
         "//pmlc/rt/opencl",
         "//pmlc/target/intel_gen",
         "//pmlc/target/x86:prng_lowering",

--- a/pmlc/target/intel_gen_ocl_spirv/CMakeLists.txt
+++ b/pmlc/target/intel_gen_ocl_spirv/CMakeLists.txt
@@ -26,6 +26,7 @@ pml_cc_library(
     pmlc::dialect::pxa::transforms
     pmlc::dialect::stdx::transforms
     pmlc::dialect::tile::transforms
+    pmlc::transforms
     pmlc::target::intel_gen
     pmlc::target::x86::prng_lowering
     MLIRAffineToStandard

--- a/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/pipeline.cc
@@ -43,6 +43,7 @@
 #include "pmlc/dialect/tile/transforms/passes.h"
 #include "pmlc/target/intel_gen/passes.h"
 #include "pmlc/target/intel_gen_ocl_spirv/passes.h"
+#include "pmlc/transforms/passes.h"
 
 using namespace mlir; // NOLINT[build/namespaces]
 
@@ -70,6 +71,8 @@ void pipelineBuilder(OpPassManager &pm,
   pm.addPass(tile::createComputeBoundsPass());
   pm.addPass(tile::createPadRangesPass());
   pm.addPass(tile::createPadConstraintsPass());
+  pm.addPass(tile::createSplitMainPass());
+  pm.addPass(transforms::createHoistingPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/pmlc/transforms/BUILD
+++ b/pmlc/transforms/BUILD
@@ -33,6 +33,7 @@ plaidml_cc_library(
         ":gen-pass",
         "//pmlc/util",
         "//pmlc/dialect/stdx/ir",
+        "//pmlc/dialect/tile/ir", 
         "@llvm-project//mlir:Pass",
     ],
 )

--- a/pmlc/transforms/CMakeLists.txt
+++ b/pmlc/transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ pml_cc_library(
     MLIRIR
     pmlc::util
     pmlc::dialect::stdx::ir
+    pmlc::dialect::tile::ir
     ::passes-gen
 )
 


### PR DESCRIPTION
Excluded constant ops from hoisting, due to constant folding problems in the lower dialect canonicalizations.
Changed ‘maybeCrossFunc’ to ‘inInit’ per proposition from Jeremy.