### PR TITLE
Fix ReLUs and re-enable tests

### DIFF
--- a/plaidml/bridge/openvino/ops/activations.cpp
+++ b/plaidml/bridge/openvino/ops/activations.cpp
@@ -20,7 +20,7 @@ void registerActivations() {
     IE_ASSERT(ctx.operands.size() == 1);
     auto I = ctx.operands.at(0);
     auto alpha = layer->get_alpha();
-    return edsl::make_tuple(edsl::select(I >= 0, I, alpha * (edsl::exp(I) - 1)));
+    return edsl::make_tuple(edsl::select(I >= 0, I, edsl::cast(alpha * (edsl::exp(I) - 1), I.dtype())));
   });
 
   registerOp("gelu", [](const Context& ctx) {
@@ -34,7 +34,7 @@ void registerActivations() {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
     auto slope = ctx.operands.at(1);
-    auto O = select(I < 0.0, slope * I, I);
+    auto O = select(I < 0.0, edsl::cast(slope * I, I.dtype()), I);
     return edsl::make_tuple(O);
   });
 
@@ -49,7 +49,7 @@ void registerActivations() {
     auto I = ctx.operands.at(0);
     auto alpha = ctx.operands.at(1);
     auto lambda = ctx.operands.at(2);
-    return edsl::make_tuple(lambda * edsl::select(I > 0, I, alpha * (edsl::exp(I) - 1)));
+    return edsl::make_tuple(lambda * edsl::select(I > 0, I, edsl::cast(alpha * (edsl::exp(I) - 1), I.dtype())));
   });
 }
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -19,7 +19,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {
     {Sigmoid, {{}}},
     {Tanh, {{}}},
-    // {Relu,        {}},  // TODO
+    {Relu, {}},
     {Exp, {{}}},
     {Log, {{}}},
     {Sign, {{}}},
@@ -50,11 +50,8 @@ const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes
     {SoftPlus, {{}}},
 };
 
-// TODO
-// const std::map<ActivationTypes, std::vector<std::vector<float>>> activationParamTypes = {
-//     {PReLu, {{-0.01f}}},
-//     {LeakyRelu, {{0.01f}}}
-// };
+const std::map<ActivationTypes, std::vector<std::vector<float>>> activationParamTypes = {{PReLu, {{-0.01f}}},
+                                                                                         {LeakyRelu, {{0.01f}}}};
 
 std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> basic = {
     {{1, 50}, {{}}},
@@ -72,18 +69,17 @@ const auto basicCases = ::testing::Combine(::testing::ValuesIn(CommonTestUtils::
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)                     //
 );
 
-// const auto basicPreluCases = ::testing::Combine(
-//         ::testing::ValuesIn(CommonTestUtils::combineParams(activationParamTypes)),
-//         ::testing::ValuesIn(netPrecisions),
-//         ::testing::ValuesIn(CommonTestUtils::combineParams(preluBasic)),
-//         ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)
-// );
+const auto basicPreluCases =
+    ::testing::Combine(::testing::ValuesIn(CommonTestUtils::combineParams(activationParamTypes)),  //
+                       ::testing::ValuesIn(netPrecisions),                                         //
+                       ::testing::ValuesIn(CommonTestUtils::combineParams(preluBasic)),            //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
 INSTANTIATE_TEST_CASE_P(smoke, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
-// INSTANTIATE_TEST_CASE_P(smoke_Prelu, ActivationLayerTest, basicPreluCases,
-// ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Prelu, ActivationLayerTest, basicPreluCases, ActivationLayerTest::getTestCaseName);
 
+// TODO: Fix & re-enable once no longer broken for CPU plugin as well
 // INSTANTIATE_TEST_CASE_P(smoke_Prelu_Param, ActivationParamLayerTest, basicPreluCases,
-// ActivationLayerTest::getTestCaseName);
+//                         ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2163,7 +2163,7 @@ Value relu(const Value& value) {
   } else {
     A = alpha.as_tensor();
   }
-  auto O = select(I < threshold, A * (I - threshold), I);
+  auto O = select(I < threshold, edsl::cast(A * (I - threshold), I.dtype()), I);
   if (!max_value.is_none()) {
     auto M = cast(max_value.as_tensor(), I.dtype());
     O = select(O < M, O, M);


### PR DESCRIPTION
Fixes a problem with ReLU variants where parameters of a different type than the input could cause type mismatches in `select`. Restores tests for these ops.