### PR TITLE
Unpack fixes

### DIFF
--- a/pmlc/dialect/pxa/transforms/reorder_layouts.h
+++ b/pmlc/dialect/pxa/transforms/reorder_layouts.h
@@ -9,6 +9,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SetVector.h"
 
 #include "pmlc/dialect/pxa/ir/interfaces.h"
 #include "pmlc/dialect/pxa/transforms/layout_utils.h"
@@ -117,7 +118,8 @@ using ReorderCreator = std::function<mlir::Value(
 /// It guards against reordering same memory used by two read operations
 /// twice, which could happen when directly using "creator".
 void reorderMemoryReads(const ReorderCreator &creator, ReorderDesc &reorderDesc,
-                        MemoryUsageDesc &memoryDesc, mlir::ModuleOp &moduleOp);
+                        MemoryUsageDesc &memoryDesc, mlir::ModuleOp &moduleOp,
+                        llvm::SetVector<mlir::Operation *> &toRemove);
 
 // ============================================================================
 // Helper affine map transformations

--- a/pmlc/dialect/pxa/transforms/vectorize_mem.cc
+++ b/pmlc/dialect/pxa/transforms/vectorize_mem.cc
@@ -11,6 +11,7 @@
 
 #include "pmlc/dialect/pxa/ir/ops.h"
 #include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/dialect/stdx/ir/ops.h"
 #include "pmlc/util/logging.h"
 
 using namespace mlir; // NOLINT[build/namespaces]
@@ -413,6 +414,9 @@ void getGlobalMemory(FuncOp f, std::list<Operation *> &globalAllocList) {
   }
   for (auto parallelOp : f.getOps<AffineParallelOp>()) {
     globalAllocList.push_back(parallelOp.getOperation());
+  }
+  for (auto unpackOp : f.getOps<stdx::UnpackOp>()) {
+    globalAllocList.push_back(unpackOp.getOperation());
   }
 }
 

--- a/pmlc/target/intel_gen_ocl_spirv/reorder_layouts.cc
+++ b/pmlc/target/intel_gen_ocl_spirv/reorder_layouts.cc
@@ -97,6 +97,7 @@ public:
     mlir::FuncOp func = getFunction();
     mlir::DenseMap<mlir::Value, pxa::MemoryUsageDesc> globalMemory =
         pxa::gatherGlobalMemoryDescs(func, intelGenOclScheduleModel);
+    llvm::SetVector<mlir::Operation *> toRemove;
     for (auto &valueDesc : globalMemory) {
       pxa::MemoryUsageDesc &memoryDesc = valueDesc.second;
       IVLOG(3, "Optimizing layout for " << mlir::debugString(memoryDesc.value));
@@ -119,8 +120,11 @@ public:
 
       IVLOG(3, "Failed to change layout in-place, inserting reorder");
       pxa::reorderMemoryReads(ThreadedReorderCreator(maxThreads), reorder,
-                              memoryDesc, moduleOp);
+                              memoryDesc, moduleOp, toRemove);
     }
+    // Cleanup
+    for (auto op : toRemove)
+      op->erase();
   }
 };
 


### PR DESCRIPTION
1. Reorder_layouts: Move cleaning up outdated unpackops after the optimizations are done, due to sporadic crashes on windows
2. Vectorize_mem: include values from unpackop as a global memory, which unblocks this optimization after init-fini changes