### PR TITLE
Pin pyyaml to 5.3.1

### DIFF
--- a/conda/unix.yml
+++ b/conda/unix.yml
@@ -35,7 +35,7 @@ dependencies:
       - pybuildkite==0.0.6
       - pygments
       - pystache
-      - pyyaml
+      - pyyaml==5.3.1
       - sphinxcontrib.katex
       - sphinxcontrib-napoleon
       - sphinx_rtd_theme

--- a/environment-windows.yml
+++ b/environment-windows.yml
@@ -9,7 +9,7 @@ dependencies:
   - posix
   - pre_commit=1.17.0
   - python=3.7.0
-  - pyyaml
+  - pyyaml==5.3.1
   - pip:
     - breathe==4.26.0
     - certifi


### PR DESCRIPTION
Pinned pyyaml to 5.3.1 as pypi was updated to 5.4 today (01-19-2021) and plaidml-v1 build fails.