### PR TITLE
PrioBox only supports fixed_ratio with one element now.

### DIFF
--- a/plaidml/bridge/openvino/ops/prior_box.cpp
+++ b/plaidml/bridge/openvino/ops/prior_box.cpp
@@ -401,6 +401,12 @@ void registerPriorBox() {
     IE_ASSERT(ctx.operands.size() == 2);
     const ngraph::op::PriorBoxAttrs& attrs = layer->get_attrs();
     IE_ASSERT(attrs.variance.size() == 1 || attrs.variance.size() == 4 || attrs.variance.empty());
+    // The size of fixed_ratio need to be one to create the right number of prior boxes.
+    // TODO: Once the process of density in number_of_priors() is changed, remove this.
+    if (attrs.fixed_size.size() > 0 && attrs.fixed_ratio.size() != 1) {
+      THROW_IE_EXCEPTION << "Due to number_of_priors() implementation in PriorBox, the size of fixed_ratio must be one "
+                            "when it is used";
+    }
     PriorBoxImpl pbi(ctx, attrs);
     int fixed_size_count = attrs.fixed_size.size();
     if (fixed_size_count) {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
@@ -30,7 +30,7 @@ const std::vector<std::vector<float>> density = {
     {2.0f, 4.0f},
 };
 const std::vector<std::vector<float>> fixedRatios = {
-    {2.0f, 4.0f},
+    {2.0f},
 };
 const std::vector<std::vector<float>> fixedSizes = {
     {2.0f, 4.0f},

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
@@ -101,7 +101,7 @@ const auto layerSpecificParamsForSmokeTest = ::testing::Combine(  //
     ::testing::Values(std::vector<float>({315.0f})),              //
     ::testing::Values(std::vector<float>({2.0f, 3.0f})),          //
     ::testing::Values(std::vector<float>({2.0f, 4.0f})),          //
-    ::testing::Values(std::vector<float>({2.0f, 4.0f})),          //
+    ::testing::Values(std::vector<float>({2.0f})),                //
     ::testing::Values(std::vector<float>({2.0f, 4.0f})),          //
     ::testing::Values(true),                                      //
     ::testing::Values(true),                                      //


### PR DESCRIPTION
Ngraph's implementation of number_of_priors use a weird way to process density (https://github.com/openvinotoolkit/openvino/blob/master/ngraph/core/src/op/prior_box.cpp#L116), this is different from the reference it provided (https://github.com/openvinotoolkit/openvino/blob/master/ngraph/core/reference/include/ngraph/runtime/reference/prior_box.hpp#L159) . This conflict makes the node output shape is different from the real output so it only work well when the fixed_ratio size is one.  Change the test case of PriorBox to follow this implicit rule and wait for their fix now.




Signed-off-by: xin1.wang <xin1.wang@intel.com>