### PR TITLE
fix matmul and add new test cases

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -15,6 +15,7 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {
     {{{1, 4, 5, 6}, false}, {{1, 4, 6, 4}, false}},
+    {{{1, 3, 4, 8}, false}, {{5, 1, 8, 2}, false}},
 };
 
 std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {


### PR DESCRIPTION
Fix the problem memtioned by Tim at https://github.com/plaidml/plaidml/pull/1679#discussion_r563909981.

I simply use `op::repeat` to fix the problem because when we need broadcast semantics over the leading "batch" dimensions, they are always equal to 1. I think in this case `op::repeat` and `op::broadcast` perfom the same functionality and `op::repeat` is less complex. What do you think @tzerrell ?