### PR TITLE
Fix openvino plaidml util get_axis method

### DIFF
--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -19,7 +19,7 @@ void registerReduceOps() {
   registerOp("ReduceLogicalAnd", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalAnd>(ctx.layer);
     auto I_i8 = edsl::cast(I, DType::UINT8);
     auto O = op::all(I_i8, edsl::make_tuple(axes), layer->get_keep_dims());
@@ -29,7 +29,7 @@ void registerReduceOps() {
   registerOp("ReduceLogicalOr", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalOr>(ctx.layer);
     auto I_i8 = edsl::cast(I, DType::UINT8);
     auto O = op::any(I_i8, edsl::make_tuple(axes), layer->get_keep_dims());
@@ -39,7 +39,7 @@ void registerReduceOps() {
   registerOp("ReduceMax", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMax>(ctx.layer);
     return edsl::make_tuple(op::max(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -47,7 +47,7 @@ void registerReduceOps() {
   registerOp("ReduceMean", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMean>(ctx.layer);
     return edsl::make_tuple(op::mean(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -55,7 +55,7 @@ void registerReduceOps() {
   registerOp("ReduceMin", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMin>(ctx.layer);
     return edsl::make_tuple(op::min(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -63,7 +63,7 @@ void registerReduceOps() {
   registerOp("ReduceProd", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceProd>(ctx.layer);
     return edsl::make_tuple(op::prod(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -71,7 +71,7 @@ void registerReduceOps() {
   registerOp("ReduceSum", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceSum>(ctx.layer);
     return edsl::make_tuple(op::sum(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -79,7 +79,7 @@ void registerReduceOps() {
   registerOp("ReduceL1", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL1>(ctx.layer);
     return edsl::make_tuple(op::sum(op::abs(I), edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -87,7 +87,7 @@ void registerReduceOps() {
   registerOp("ReduceL2", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL2>(ctx.layer);
     return edsl::make_tuple(edsl::sqrt(op::sum(I * I, edsl::make_tuple(axes), layer->get_keep_dims())));
   });

--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -14,7 +14,6 @@ namespace PlaidMLPlugin {
 ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    ngraph::AxisSet axes;
     const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
     const auto input_rank = layer->get_input_partial_shape(0).rank();
     const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
@@ -27,7 +26,6 @@ ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::N
 ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    ngraph::AxisVector axes;
     const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
     const auto input_rank = layer->get_input_partial_shape(0).rank();
     const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);

--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -14,7 +14,11 @@ namespace PlaidMLPlugin {
 ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    return axis_ngraph_op->get_axis_set_val();
+    ngraph::AxisSet axes;
+    const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
+    const auto input_rank = layer->get_input_partial_shape(0).rank();
+    const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
+    return ngraph::AxisSet{normalized_axes};
   } else {
     THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
   }
@@ -23,7 +27,11 @@ ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::N
 ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    return axis_ngraph_op->get_axis_vector_val();
+    ngraph::AxisVector axes;
+    const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
+    const auto input_rank = layer->get_input_partial_shape(0).rank();
+    const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
+    return ngraph::AxisVector{normalized_axes};
   } else {
     THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
   }

--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -4,6 +4,7 @@
 
 #include "plaidml_util.hpp"
 
+#include "ngraph/validation_util.hpp"
 #include "plaidml/edsl/edsl.h"
 
 using namespace plaidml;          // NOLINT[build/namespaces]
@@ -14,9 +15,9 @@ namespace PlaidMLPlugin {
 ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
-    const auto input_rank = layer->get_input_partial_shape(0).rank();
-    const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
+    auto const_data = axis_ngraph_op->cast_vector<int64_t>();
+    auto input_rank = layer->get_input_partial_shape(0).rank();
+    auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
     return ngraph::AxisSet{normalized_axes};
   } else {
     THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
@@ -26,9 +27,9 @@ ngraph::AxisSet get_axis_set_from_constant_operand(size_t operand_idx, ngraph::N
 ngraph::AxisVector get_axis_vector_from_constant_operand(size_t operand_idx, ngraph::Node* layer) {
   auto* axis_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
   if (axis_ngraph_op) {
-    const auto const_data = axis_ngraph_op->cast_vector<int64_t>();
-    const auto input_rank = layer->get_input_partial_shape(0).rank();
-    const auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
+    auto const_data = axis_ngraph_op->cast_vector<int64_t>();
+    auto input_rank = layer->get_input_partial_shape(0).rank();
+    auto normalized_axes = ngraph::normalize_axes(layer->get_friendly_name(), const_data, input_rank);
     return ngraph::AxisVector{normalized_axes};
   } else {
     THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -18,7 +18,6 @@
 #include "ngraph/op/util/attr_types.hpp"
 #include "ngraph/shape.hpp"
 #include "ngraph/type/element_type.hpp"
-#include "ngraph/validation_util.hpp"
 
 #include "plaidml/edsl/edsl.h"
 #include "plaidml/op/op.h"

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -18,6 +18,7 @@
 #include "ngraph/op/util/attr_types.hpp"
 #include "ngraph/shape.hpp"
 #include "ngraph/type/element_type.hpp"
+#include "ngraph/validation_util.hpp"
 
 #include "plaidml/edsl/edsl.h"
 #include "plaidml/op/op.h"


### PR DESCRIPTION
The original implementation of `get_axis_set_from_constant_operand` and `get_axis_set_from_constant_operand` use [`op::Constant::get_axis_*_val()`](https://github.com/plaidml/openvino/blob/plaidml/ngraph/core/src/op/constant.cpp#L520) which directly change negative axis value to 0, and fail some tests. 
```cpp
AxisSet op::Constant::get_axis_set_val() const
{
    NGRAPH_CHECK(m_element_type.is_integral_number());
    std::vector<int64_t> out_axis_set = cast_vector<int64_t>();
    AxisSet output_axis_set;
    for (auto& axis : out_axis_set)
    {
        output_axis_set.insert(axis > 0 ? axis : 0);
    }
    return output_axis_set;
}
```
So, using [`ngraph::normalize_axes`](https://github.com/plaidml/openvino/blob/plaidml/ngraph/core/src/validation_util.cpp#L910) to make all axis to non-negative before casting to `AxisSet` and `AxisVector` can solve this issue.
```cpp
int64_t ngraph::normalize_axis(const std::string& node_description, std::int64_t axis, ...)
{
    // ...
    if (axis < 0)
    {
        axis = axis + tensor_rank;
    }

    return int64_t(axis);
}
```

~This adjustment works on my local machine(Ubuntu 18.04), but fails on CI([subcommand failed](https://buildkite.com/plaidml/plaidml-plaidml/builds/5253#19064a27-2a98-45d2-9402-e05cf794b9b9/1227-1372)). 
Need more time to fix.~