### PR TITLE
Update OpenVINO, including upstream fix on Roi Pooling and Roi Align

### DIFF
--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT InferenceEngineDeveloperPackage_FOUND)
   FetchContent_Declare(
     openvino
     GIT_REPOSITORY https://github.com/plaidml/openvino.git
-    GIT_TAG        78c7e637b2c00c8e071227e41b73681cd271a353
+    GIT_TAG        2a82d330a05eb06ccde9e7e38a1535c268ad58db
   )
   if(LOCAL_OPENVINO_DIR)
     set(openvino_SOURCE_DIR ${LOCAL_OPENVINO_DIR})

--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT InferenceEngineDeveloperPackage_FOUND)
   FetchContent_Declare(
     openvino
     GIT_REPOSITORY https://github.com/plaidml/openvino.git
-    GIT_TAG        40da19c64763fade9733aedaf770077636e5890b
+    GIT_TAG        78c7e637b2c00c8e071227e41b73681cd271a353
   )
   if(LOCAL_OPENVINO_DIR)
     set(openvino_SOURCE_DIR ${LOCAL_OPENVINO_DIR})

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/bucketize.cpp
@@ -9,38 +9,62 @@
 
 using namespace LayerTestsDefinitions;
 
-namespace {
-const std::vector<InferenceEngine::Precision> netPrecisions = {
+const std::vector<std::vector<size_t>> dataShapes = {
+    {1, 20, 20},
+    {2, 3, 50, 50},
+};
+
+const std::vector<std::vector<size_t>> bucketsShapes = {
+    {5},
+    {20},
+};
+
+const std::vector<InferenceEngine::Precision> inPrc = {
     InferenceEngine::Precision::FP32,
     InferenceEngine::Precision::FP16,
-    InferenceEngine::Precision::I8,
-};
-
-std::vector<std::vector<size_t>> inputShapes{
-    {2, 2},
-};
-std::vector<std::vector<size_t>> bucketsShapes{
-    {3},
-};
-
-// Output_type shall support i64 && i32, close i64 for openvino limitation
-std::vector<InferenceEngine::Precision> outputPrecision = {
-    InferenceEngine::Precision::I32,
     InferenceEngine::Precision::I64,
-};
-std::vector<bool> withRightBound{
-    true,
-    false,
+    InferenceEngine::Precision::I32,
 };
 
-INSTANTIATE_TEST_CASE_P(smoke, BucketizeLayerTest,
-                        ::testing::Combine(                                              //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::ValuesIn(inputShapes),                            //
-                            ::testing::ValuesIn(bucketsShapes),                          //
-                            ::testing::ValuesIn(outputPrecision),                        //
-                            ::testing::ValuesIn(withRightBound),                         //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
-                            ::testing::Values(std::map<std::string, std::string>({}))),  //
+const std::vector<InferenceEngine::Precision> netPrc = {
+    InferenceEngine::Precision::I64,
+    InferenceEngine::Precision::I32,
+};
+
+const auto test_Bucketize_right_edge = ::testing::Combine(  //
+    ::testing::ValuesIn(dataShapes),                        //
+    ::testing::ValuesIn(bucketsShapes),                     //
+    ::testing::Values(true),                                //
+    ::testing::ValuesIn(inPrc),                             //
+    ::testing::ValuesIn(inPrc),                             //
+    ::testing::ValuesIn(netPrc),                            //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)      //
+);
+
+const auto test_Bucketize_left_edge = ::testing::Combine(  //
+    ::testing::ValuesIn(dataShapes),                       //
+    ::testing::ValuesIn(bucketsShapes),                    //
+    ::testing::Values(false),                              //
+    ::testing::ValuesIn(inPrc),                            //
+    ::testing::ValuesIn(inPrc),                            //
+    ::testing::ValuesIn(netPrc),                           //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)     //
+);
+
+const auto smoke_args = ::testing::Combine(             //
+    ::testing::Values(dataShapes[0]),                   //
+    ::testing::Values(bucketsShapes[0]),                //
+    ::testing::Values(false),                           //
+    ::testing::Values(inPrc[0]),                        //
+    ::testing::Values(inPrc[0]),                        //
+    ::testing::Values(netPrc[0]),                       //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
+);
+
+INSTANTIATE_TEST_CASE_P(Bucketize_right, BucketizeLayerTest, test_Bucketize_right_edge,
                         BucketizeLayerTest::getTestCaseName);
-}  // namespace
+
+INSTANTIATE_TEST_CASE_P(Bucketize_left, BucketizeLayerTest, test_Bucketize_left_edge,
+                        BucketizeLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke, BucketizeLayerTest, smoke_args, BucketizeLayerTest::getTestCaseName);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/scatter_update.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/scatter_update.cpp
@@ -26,7 +26,7 @@ std::map<std::vector<size_t>, std::map<std::vector<size_t>, std::vector<int>>> a
     {{10, 9, 10, 9, 10}, {{{8}, {-3, -1, 0, 2, 4}}, {{4, 2}, {-2, 2}}}},
 };
 // indices should not be random value
-const std::vector<std::vector<size_t>> idxValue = {
+const std::vector<std::vector<int64_t>> idxValue = {
     {0, 2, 4, 6, 1, 3, 5, 7},
 };
 


### PR DESCRIPTION
This PR is based on  https://github.com/plaidml/openvino/tree/update-openvino (@tzerrell could you please help push this branch to plaidml branch?), which is rebased onto  https://github.com/openvinotoolkit/openvino/commit/3a86b3a17e3311a69687b8147b6f2317d60b8b82

This update includes upstream fix/update on bucketize, scatter_update, Roi Pooling and Roi Align.