### PR TITLE
Enable FP16 tests where already passing

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -10,17 +10,10 @@
 using namespace LayerTestsDefinitions;
 using namespace ngraph::helpers;
 namespace {
-// Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-    InferenceEngine::Precision::FP32
-    // TODO: Fix Issue-27390
-    // InferenceEngine::Precision::I16,
-    // InferenceEngine::Precision::U8
-};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {
@@ -33,21 +26,10 @@ const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes
     {Abs, {}},
     {Clamp, {{-2.0f, 2.0f}}},
     {Negative, {}},
-    {Acos, {}},
-    {Acosh, {}},
-    {Asin, {}},
-    {Asinh, {}},
-    {Atan, {}},
-    {Atanh, {}},
     {Cos, {}},
-    {Cosh, {}},
-    {Floor, {}},
     {Sin, {}},
-    {Sinh, {}},
     {Sqrt, {}},
-    {Tan, {}},
     {Elu, {{0.1f}}},
-    {Erf, {}},
     {HardSigmoid, {{0.2f, 0.5f}}},
     {Selu, {{1.6732f, 1.0507f}}},
     {Ceiling, {}},
@@ -56,6 +38,24 @@ const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes
     {HSwish, {}},
     {SoftPlus, {}},
     {HSigmoid, {}},
+};
+
+const std::vector<InferenceEngine::Precision> f32Precision = {
+    InferenceEngine::Precision::FP32,
+};
+
+const std::map<ActivationTypes, std::vector<std::vector<float>>> activationF32Types = {
+    {Acos, {}},
+    {Acosh, {}},
+    {Asin, {}},
+    {Asinh, {}},
+    {Atan, {}},
+    {Atanh, {}},
+    {Cosh, {}},
+    {Floor, {}},
+    {Sinh, {}},
+    {Tan, {}},
+    {Erf, {}},
     {RoundHalfToEven, {}},
     {RoundHalfAwayFromZero, {}},
 };
@@ -86,6 +86,17 @@ const auto basicCases = ::testing::Combine(                                //
     ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)                     //
 );
 
+const auto f32OnlyCases = ::testing::Combine(                                 //
+    ::testing::ValuesIn(CommonTestUtils::combineParams(activationF32Types)),  //
+    ::testing::ValuesIn(f32Precision),                                        //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),               //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),               //
+    ::testing::Values(InferenceEngine::Layout::ANY),                          //
+    ::testing::Values(InferenceEngine::Layout::ANY),                          //
+    ::testing::ValuesIn(CommonTestUtils::combineParams(basic)),               //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)                        //
+);
+
 const auto basicPreluCases = ::testing::Combine(                                //
     ::testing::ValuesIn(CommonTestUtils::combineParams(activationParamTypes)),  //
     ::testing::ValuesIn(netPrecisions),                                         //
@@ -101,6 +112,13 @@ INSTANTIATE_TEST_CASE_P(                  //
     smoke_Activation_Basic,               //
     ActivationLayerTest,                  //
     basicCases,                           //
+    ActivationLayerTest::getTestCaseName  //
+);
+
+INSTANTIATE_TEST_CASE_P(                  //
+    smoke_Activation_F32_Only,            //
+    ActivationLayerTest,                  //
+    f32OnlyCases,                         //
     ActivationLayerTest::getTestCaseName  //
 );
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
@@ -47,6 +47,13 @@ batchToSpaceParamsTuple bts_only_test_cases[] = {
                             InferenceEngine::Layout::ANY,                                         //
                             InferenceEngine::Layout::ANY,                                         //
                             CommonTestUtils::DEVICE_PLAIDML),
+    batchToSpaceParamsTuple({1, 1, 3, 2, 2}, {0, 0, 1, 0, 3}, {0, 0, 2, 0, 0}, {12, 1, 2, 1, 2},  //
+                            InferenceEngine::Precision::FP16,                                     //
+                            InferenceEngine::Precision::UNSPECIFIED,                              //
+                            InferenceEngine::Precision::UNSPECIFIED,                              //
+                            InferenceEngine::Layout::ANY,                                         //
+                            InferenceEngine::Layout::ANY,                                         //
+                            CommonTestUtils::DEVICE_PLAIDML),
 };
 
 INSTANTIATE_TEST_CASE_P(                       //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/comparison.hpp"
+
+using namespace LayerTestsDefinitions;
+using namespace LayerTestsDefinitions::ComparisonParams;
+
+namespace {
+
+std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapes = {
+    {{1}, {{1}, {17}, {1, 1}, {2, 18}, {1, 1, 2}, {2, 2, 3}, {1, 1, 2, 3}}},
+    {{2, 200}, {{1}, {200}, {1, 200}, {2, 200}, {2, 2, 200}}},
+    {{1, 3, 20}, {{20}, {2, 1, 1}}},
+    {{2, 17, 3, 4}, {{4}, {1, 3, 4}, {2, 1, 3, 4}}},
+    {{2, 1, 1, 3, 1}, {{1}, {1, 3, 4}, {2, 1, 3, 4}, {1, 1, 1, 1, 1}}},
+};
+
+std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> smokeInputShapes = {
+    {{5}, {{1}, {1, 1}, {2, 5}, {1, 1, 1}, {2, 2, 5}}},
+};
+
+std::vector<InferenceEngine::Precision> inputsPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypes = {
+    ngraph::helpers::ComparisonTypes::EQUAL,          //
+    ngraph::helpers::ComparisonTypes::NOT_EQUAL,      //
+    ngraph::helpers::ComparisonTypes::GREATER,        //
+    ngraph::helpers::ComparisonTypes::GREATER_EQUAL,  //
+    ngraph::helpers::ComparisonTypes::LESS,           //
+    ngraph::helpers::ComparisonTypes::LESS_EQUAL,
+};
+
+std::vector<ngraph::helpers::InputLayerType> secondInputTypes = {
+    ngraph::helpers::InputLayerType::CONSTANT,
+    ngraph::helpers::InputLayerType::PARAMETER,
+};
+
+std::map<std::string, std::string> additional_config = {};
+
+const auto ComparisonTestParams = ::testing::Combine(                  //
+    ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),  //
+    ::testing::ValuesIn(inputsPrecisions),                             //
+    ::testing::ValuesIn(comparisonOpTypes),                            //
+    ::testing::ValuesIn(secondInputTypes),                             //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),        //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),        //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),                //
+    ::testing::Values(additional_config));
+
+const auto SmokeComparisonTestParams = ::testing::Combine(                  //
+    ::testing::ValuesIn(CommonTestUtils::combineParams(smokeInputShapes)),  //
+    ::testing::ValuesIn(inputsPrecisions),                                  //
+    ::testing::ValuesIn(comparisonOpTypes),                                 //
+    ::testing::ValuesIn(secondInputTypes),                                  //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),             //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),             //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),                     //
+    ::testing::Values(additional_config));
+
+INSTANTIATE_TEST_CASE_P(CompareWithRefs, ComparisonLayerTest, ComparisonTestParams,
+                        ComparisonLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, ComparisonLayerTest, SmokeComparisonTestParams,
+                        ComparisonLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/depth_to_space.cpp
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <ngraph/opsets/opset3.hpp>
 #include <vector>
+
+#include <ngraph/opsets/opset3.hpp>
 
 #include "common_test_utils/test_constants.hpp"
 #include "single_layer_tests/depth_to_space.hpp"
@@ -14,6 +15,7 @@ using namespace ngraph::opset3;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::U8,
     InferenceEngine::Precision::I16,
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -26,10 +26,20 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
     {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
 };
 
+std::vector<std::vector<std::vector<size_t>>> smokeShapes = {
+    {{1, 2, 3, 4}},
+    {{2, 2, 2, 2}},
+    {{2, 1, 2, 1, 2, 2}},
+};
+
 std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
-    // InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::I32,
+};
+
+std::vector<InferenceEngine::Precision> f32Precision = {
+    InferenceEngine::Precision::FP32,
 };
 
 std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
@@ -47,15 +57,18 @@ std::vector<ngraph::helpers::EltwiseTypes> eltwiseOpTypes = {
     ngraph::helpers::EltwiseTypes::MULTIPLY,      //
     ngraph::helpers::EltwiseTypes::SUBTRACT,      //
     ngraph::helpers::EltwiseTypes::DIVIDE,        //
-    ngraph::helpers::EltwiseTypes::FLOOR_MOD,     //
     ngraph::helpers::EltwiseTypes::SQUARED_DIFF,  //
-    ngraph::helpers::EltwiseTypes::POWER,         //
     ngraph::helpers::EltwiseTypes::MOD,           //
+};
+
+std::vector<ngraph::helpers::EltwiseTypes> f32OpTypes = {
+    ngraph::helpers::EltwiseTypes::FLOOR_MOD,  //
+    ngraph::helpers::EltwiseTypes::POWER,      //
 };
 
 std::map<std::string, std::string> additional_config = {};
 
-const auto multiply_params = ::testing::Combine(                 //
+const auto params = ::testing::Combine(                          //
     ::testing::ValuesIn(inShapes),                               //
     ::testing::ValuesIn(eltwiseOpTypes),                         //
     ::testing::ValuesIn(secondaryInputTypes),                    //
@@ -68,26 +81,11 @@ const auto multiply_params = ::testing::Combine(                 //
     ::testing::Values(additional_config)                         //
 );
 
-INSTANTIATE_TEST_CASE_P(Eltwise, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(Eltwise, EltwiseLayerTest, params, EltwiseLayerTest::getTestCaseName);
 
-std::vector<std::vector<std::vector<size_t>>> inShapesSingleThread = {
-    {{1, 2, 3, 4}},
-    {{2, 2, 2, 2}},
-    {{2, 1, 2, 1, 2, 2}},
-};
-
-std::vector<ngraph::helpers::EltwiseTypes> eltwiseOpTypesSingleThread = {
-    ngraph::helpers::EltwiseTypes::ADD,
-    ngraph::helpers::EltwiseTypes::POWER,
-};
-
-std::map<std::string, std::string> additional_config_single_thread = {
-    {"CPU_THREADS_NUM", "1"},
-};
-
-const auto single_thread_params = ::testing::Combine(            //
-    ::testing::ValuesIn(inShapesSingleThread),                   //
-    ::testing::ValuesIn(eltwiseOpTypesSingleThread),             //
+const auto smokeParams = ::testing::Combine(                     //
+    ::testing::ValuesIn(smokeShapes),                            //
+    ::testing::ValuesIn(eltwiseOpTypes),                         //
     ::testing::ValuesIn(secondaryInputTypes),                    //
     ::testing::ValuesIn(opTypes),                                //
     ::testing::ValuesIn(netPrecisions),                          //
@@ -95,9 +93,39 @@ const auto single_thread_params = ::testing::Combine(            //
     ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
     ::testing::Values(InferenceEngine::Layout::ANY),             //
     ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
-    ::testing::Values(additional_config_single_thread)           //
+    ::testing::Values(additional_config)                         //
 );
 
-INSTANTIATE_TEST_CASE_P(smoke_SingleThread, EltwiseLayerTest, single_thread_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smokeEltwise, EltwiseLayerTest, smokeParams, EltwiseLayerTest::getTestCaseName);
+
+const auto f32Params = ::testing::Combine(                       //
+    ::testing::ValuesIn(inShapes),                               //
+    ::testing::ValuesIn(f32OpTypes),                             //
+    ::testing::ValuesIn(secondaryInputTypes),                    //
+    ::testing::ValuesIn(opTypes),                                //
+    ::testing::ValuesIn(f32Precision),                           //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    ::testing::Values(InferenceEngine::Layout::ANY),             //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+    ::testing::Values(additional_config)                         //
+);
+
+INSTANTIATE_TEST_CASE_P(f32OnlyEltwise, EltwiseLayerTest, f32Params, EltwiseLayerTest::getTestCaseName);
+
+const auto smokeF32Params = ::testing::Combine(                  //
+    ::testing::ValuesIn(smokeShapes),                            //
+    ::testing::ValuesIn(f32OpTypes),                             //
+    ::testing::ValuesIn(secondaryInputTypes),                    //
+    ::testing::ValuesIn(opTypes),                                //
+    ::testing::ValuesIn(f32Precision),                           //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    ::testing::Values(InferenceEngine::Layout::ANY),             //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+    ::testing::Values(additional_config)                         //
+);
+
+INSTANTIATE_TEST_CASE_P(smokeF32OnlyEltwise, EltwiseLayerTest, smokeF32Params, EltwiseLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::I32,
 };
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::I32,
 };
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_segments_sum.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/embedding_segments_sum.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::I32,
 };
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<size_t>> inputShapes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
@@ -13,9 +13,14 @@ using LayerTestsDefinitions::GrnLayerTest;
 
 namespace {
 
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
 INSTANTIATE_TEST_CASE_P(smoke, GrnLayerTest,
                         ::testing::Combine(                                              //
-                            ::testing::Values(InferenceEngine::Precision::FP32),         //
+                            ::testing::ValuesIn(netPrecisions),                          //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Layout::ANY),             //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 /* ============= 2D GroupConvolution ============= */

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/logical.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/logical.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/logical.hpp"
+
+using namespace LayerTestsDefinitions;
+using namespace LayerTestsDefinitions::LogicalParams;
+
+namespace {
+
+std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapes = {
+    {{1}, {{1}, {17}, {1, 1}, {2, 18}, {1, 1, 2}, {2, 2, 3}, {1, 1, 2, 3}}},  //
+    {{5}, {{1}, {1, 1}, {2, 5}, {1, 1, 1}, {2, 2, 5}}},                       //
+    {{2, 200}, {{1}, {200}, {1, 200}, {2, 200}, {2, 2, 200}}},                //
+    {{1, 3, 20}, {{20}, {2, 1, 1}}},                                          //
+    {{2, 17, 3, 4}, {{4}, {1, 3, 4}, {2, 1, 3, 4}}},                          //
+    {{2, 1, 1, 3, 1}, {{1}, {1, 3, 4}, {2, 1, 3, 4}, {1, 1, 1, 1, 1}}},       //
+};
+
+std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapesNot = {
+    {{1}, {}},              //
+    {{5}, {}},              //
+    {{2, 200}, {}},         //
+    {{1, 3, 20}, {}},       //
+    {{2, 17, 3, 4}, {}},    //
+    {{2, 1, 1, 3, 1}, {}},  //
+};
+
+std::vector<InferenceEngine::Precision> inputsPrecisions = {
+    InferenceEngine::Precision::BOOL,
+};
+
+std::vector<ngraph::helpers::LogicalTypes> logicalOpTypes = {
+    // ngraph::helpers::LogicalTypes::LOGICAL_XOR,
+    ngraph::helpers::LogicalTypes::LOGICAL_AND,  //
+    ngraph::helpers::LogicalTypes::LOGICAL_OR,   //
+};
+
+std::vector<ngraph::helpers::InputLayerType> secondInputTypes = {
+    ngraph::helpers::InputLayerType::CONSTANT,
+    ngraph::helpers::InputLayerType::PARAMETER,
+};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+std::map<std::string, std::string> additional_config = {};
+
+const auto LogicalTestParams = ::testing::Combine(                      //
+    ::testing::ValuesIn(LogicalLayerTest::combineShapes(inputShapes)),  //
+    ::testing::ValuesIn(logicalOpTypes),                                //
+    ::testing::ValuesIn(secondInputTypes),                              //
+    ::testing::ValuesIn(netPrecisions),                                 //
+    ::testing::ValuesIn(inputsPrecisions),                              //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),         //
+    ::testing::Values(InferenceEngine::Layout::ANY),                    //
+    ::testing::Values(InferenceEngine::Layout::ANY),                    //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),                 //
+    ::testing::Values(additional_config));
+
+const auto LogicalTestParamsNot = ::testing::Combine(                      //
+    ::testing::ValuesIn(LogicalLayerTest::combineShapes(inputShapesNot)),  //
+    ::testing::Values(ngraph::helpers::LogicalTypes::LOGICAL_NOT),         //
+    ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),          //
+    ::testing::ValuesIn(netPrecisions),                                    //
+    ::testing::ValuesIn(inputsPrecisions),                                 //
+    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),            //
+    ::testing::Values(InferenceEngine::Layout::ANY),                       //
+    ::testing::Values(InferenceEngine::Layout::ANY),                       //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),                    //
+    ::testing::Values(additional_config));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, LogicalLayerTest, LogicalTestParams, LogicalLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefsNot, LogicalLayerTest, LogicalTestParamsNot,
+                        LogicalLayerTest::getTestCaseName);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -11,6 +11,7 @@ using namespace LayerTestsDefinitions;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -12,9 +12,6 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 // Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-    InferenceEngine::Precision::FP32,
-};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
@@ -26,7 +23,7 @@ const std::vector<std::vector<size_t>> kernels = {
 };
 const std::vector<std::vector<size_t>> strides = {
     {1, 1},
-    //{1, 2},
+    // {1, 2},
 };
 const std::vector<std::vector<size_t>> padBegins = {
     {0, 0},

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/prior_box.cpp
@@ -12,7 +12,7 @@ using LayerTestsDefinitions::PriorBoxLayerTest;
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<float>> minSizes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -12,9 +12,8 @@ using namespace LayerTestsDefinitions;
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::I32,
-    InferenceEngine::Precision::U8,
-    InferenceEngine::Precision::I8,
 };
 
 const std::vector<bool> keepDims = {
@@ -53,6 +52,14 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
     ngraph::helpers::ReductionType::L2,    //
 };
 
+const std::vector<ngraph::helpers::ReductionType> reductionIntTypes = {
+    ngraph::helpers::ReductionType::Min,   //
+    ngraph::helpers::ReductionType::Max,   //
+    ngraph::helpers::ReductionType::Sum,   //
+    ngraph::helpers::ReductionType::Prod,  //
+    ngraph::helpers::ReductionType::L1,    //
+};
+
 const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
     ngraph::helpers::ReductionType::LogicalOr,
     ngraph::helpers::ReductionType::LogicalAnd,
@@ -88,9 +95,8 @@ const auto params_Precisions = testing::Combine(               //
     testing::Values(std::vector<int>{1, 3}),                   //
     testing::Values(opTypes[1]),                               //
     testing::ValuesIn(keepDims),                               //
-    testing::Values(ngraph::helpers::ReductionType::Sum),      //
-    testing::Values(InferenceEngine::Precision::FP32,          //
-                    InferenceEngine::Precision::I32),          //
+    testing::ValuesIn(reductionIntTypes),                      //
+    testing::ValuesIn(netPrecisions),                          //
     testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
     testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
     testing::Values(InferenceEngine::Layout::ANY),             //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/region_yolo.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/region_yolo.cpp
@@ -49,6 +49,11 @@ const std::vector<size_t> num_regions = {
     9,
 };
 
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
 const size_t coords = 4;
 const int start_axis = 1;
 const int end_axis = 3;
@@ -63,7 +68,7 @@ INSTANTIATE_TEST_CASE_P(TestsRegionYolov3, RegionYoloLayerTest,
                             ::testing::Values(masks[2]),                          //
                             ::testing::Values(start_axis),                        //
                             ::testing::Values(end_axis),                          //
-                            ::testing::Values(InferenceEngine::Precision::FP32),  //
+                            ::testing::ValuesIn(netPrecisions),                   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         RegionYoloLayerTest::getTestCaseName);
 
@@ -77,7 +82,7 @@ INSTANTIATE_TEST_CASE_P(TestsRegionYoloMxnet, RegionYoloLayerTest,
                             ::testing::Values(masks[1]),                          //
                             ::testing::Values(start_axis),                        //
                             ::testing::Values(end_axis),                          //
-                            ::testing::Values(InferenceEngine::Precision::FP32),  //
+                            ::testing::ValuesIn(netPrecisions),                   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         RegionYoloLayerTest::getTestCaseName);
 
@@ -91,7 +96,7 @@ INSTANTIATE_TEST_CASE_P(TestsRegionYoloCaffe, RegionYoloLayerTest,
                             ::testing::Values(masks[0]),                          //
                             ::testing::Values(start_axis),                        //
                             ::testing::Values(end_axis),                          //
-                            ::testing::Values(InferenceEngine::Precision::FP32),  //
+                            ::testing::ValuesIn(netPrecisions),                   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         RegionYoloLayerTest::getTestCaseName);
 
@@ -105,6 +110,6 @@ INSTANTIATE_TEST_CASE_P(smoke, RegionYoloLayerTest,
                             ::testing::Values(masks[0]),                          //
                             ::testing::Values(start_axis),                        //
                             ::testing::Values(end_axis),                          //
-                            ::testing::Values(InferenceEngine::Precision::FP32),  //
+                            ::testing::ValuesIn(netPrecisions),                   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         RegionYoloLayerTest::getTestCaseName);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reorg_yolo.cpp
@@ -27,46 +27,51 @@ const std::vector<size_t> strides = {
     3,
 };
 
-const auto testCase_caffe_yolov2 = ::testing::Combine(    //
-    ::testing::ValuesIn(inShapes_caffe_yolov2),           //
-    ::testing::Values(strides[0]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+const auto testCase_caffe_yolov2 = ::testing::Combine(  //
+    ::testing::ValuesIn(inShapes_caffe_yolov2),         //
+    ::testing::Values(strides[0]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-const auto testCase_smallest = ::testing::Combine(        //
-    ::testing::Values(inShapes[0]),                       //
-    ::testing::Values(strides[0]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const auto testCase_smallest = ::testing::Combine(      //
+    ::testing::Values(inShapes[0]),                     //
+    ::testing::Values(strides[0]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-const auto testCase_stride_2 = ::testing::Combine(        //
-    ::testing::Values(inShapes[1]),                       //
-    ::testing::Values(strides[0]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const auto testCase_stride_2 = ::testing::Combine(      //
+    ::testing::Values(inShapes[1]),                     //
+    ::testing::Values(strides[0]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-const auto testCase_stride_3 = ::testing::Combine(        //
-    ::testing::Values(inShapes[2]),                       //
-    ::testing::Values(strides[1]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const auto testCase_stride_3 = ::testing::Combine(      //
+    ::testing::Values(inShapes[2]),                     //
+    ::testing::Values(strides[1]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-const auto testCase_smaller_h = ::testing::Combine(       //
-    ::testing::Values(inShapes[4]),                       //
-    ::testing::Values(strides[0]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const auto testCase_smaller_h = ::testing::Combine(     //
+    ::testing::Values(inShapes[4]),                     //
+    ::testing::Values(strides[0]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-const auto testCase_batch_2 = ::testing::Combine(         //
-    ::testing::Values(inShapes[3]),                       //
-    ::testing::Values(strides[0]),                        //
-    ::testing::Values(InferenceEngine::Precision::FP32),  //
-    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+const auto testCase_batch_2 = ::testing::Combine(       //
+    ::testing::Values(inShapes[3]),                     //
+    ::testing::Values(strides[0]),                      //
+    ::testing::ValuesIn(netPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
 INSTANTIATE_TEST_CASE_P(TestsReorgYolo_caffe_YoloV2, ReorgYoloLayerTest, testCase_caffe_yolov2,
@@ -85,7 +90,7 @@ INSTANTIATE_TEST_CASE_P(TestsReorgYolo_batch_2, ReorgYoloLayerTest, testCase_bat
 INSTANTIATE_TEST_CASE_P(smoke, ReorgYoloLayerTest,
                         ::testing::Combine(::testing::Values(inShapes[0]),                       //
                                            ::testing::Values(strides[0]),                        //
-                                           ::testing::Values(InferenceEngine::Precision::FP32),  //
+                                           ::testing::ValuesIn(netPrecisions),                   //
                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),  //
                         ReorgYoloLayerTest::getTestCaseName);
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -21,7 +21,7 @@ std::vector<std::vector<std::string>> activations = {{"relu"}, {"sigmoid"}, {"ta
 std::vector<float> clips = {0.f, 0.7f};
 std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP16,
 };
 
 INSTANTIATE_TEST_CASE_P(RNNCellCommon, RNNCellTest,

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
@@ -9,6 +9,8 @@
 
 using namespace LayerTestsDefinitions;
 
+namespace {
+
 const auto ROIAlignCases_average = ::testing::Combine(  //
     ::testing::ValuesIn(std::vector<std::vector<size_t>>{
         {3, 8, 16, 16},
@@ -46,3 +48,4 @@ const auto ROIAlignCases_max = ::testing::Combine(  //
 
 INSTANTIATE_TEST_CASE_P(smoke_TestsROIAlign_max, ROIAlignLayerTest, ROIAlignCases_max,
                         ROIAlignLayerTest::getTestCaseName);
+};  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/scatter_update.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/scatter_update.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::I32,
 };
 
@@ -47,8 +48,7 @@ INSTANTIATE_TEST_CASE_P(smoke, ScatterUpdateLayerTest,
                             ::testing::ValuesIn(idxValue),                                                 //
                             ::testing::Values(InferenceEngine::Precision::FP32),                           //
                             ::testing::Values(InferenceEngine::Precision::I32),                            //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)                             //
-                            ),
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),                           //
                         ScatterUpdateLayerTest::getTestCaseName);
 
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
@@ -15,6 +15,7 @@ const std::vector<InferenceEngine::Precision> inputPrecision = {
     InferenceEngine::Precision::I64,   //
     InferenceEngine::Precision::I32,   //
     InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::FP16,  //
 };
 
 const std::vector<std::vector<std::vector<size_t>>> noneShapes = {
@@ -89,6 +90,5 @@ INSTANTIATE_TEST_CASE_P(smoke, SelectLayerTest,
                             ::testing::Values(std::vector<std::vector<size_t>>({{4, 5}, {4, 5}, {4, 5}})),  //
                             ::testing::Values(InferenceEngine::Precision::FP32),                            //
                             ::testing::Values(ngraph::op::AutoBroadcastSpec::NONE),                         //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)                              //
-                            ),
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),                            //
                         SelectLayerTest::getTestCaseName);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
@@ -13,6 +13,7 @@ namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::I32,
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<int> axes = {0, 1, 2, 3};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/softmax.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/softmax.cpp
@@ -13,6 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<InferenceEngine::Layout> inputLayouts2D = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_batch.cpp
@@ -47,6 +47,13 @@ spaceToBatchParamsTuple stb_only_test_cases[] = {
                             InferenceEngine::Layout::ANY,                                        //
                             InferenceEngine::Layout::ANY,                                        //
                             CommonTestUtils::DEVICE_PLAIDML),                                    //
+    spaceToBatchParamsTuple({1, 1, 3, 2, 2}, {0, 0, 1, 0, 3}, {0, 0, 2, 0, 0}, {1, 1, 3, 2, 1},  //
+                            InferenceEngine::Precision::FP16,                                    //
+                            InferenceEngine::Precision::UNSPECIFIED,                             //
+                            InferenceEngine::Precision::UNSPECIFIED,                             //
+                            InferenceEngine::Layout::ANY,                                        //
+                            InferenceEngine::Layout::ANY,                                        //
+                            CommonTestUtils::DEVICE_PLAIDML),                                    //
 };
 
 INSTANTIATE_TEST_CASE_P(smoke, SpaceToBatchLayerTest, ::testing::ValuesIn(stb_only_test_cases),

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/space_to_depth.cpp
@@ -15,6 +15,7 @@ using ngraph::opset3::SpaceToDepth;
 namespace {
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::U8,
     InferenceEngine::Precision::I16,
 };

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squared_difference.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squared_difference.cpp
@@ -14,6 +14,7 @@ using LayerTestsDefinitions::SquaredDifferenceLayerTest;
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<std::size_t>> inputShapes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squeeze_unsqueeze.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/squeeze_unsqueeze.cpp
@@ -22,8 +22,8 @@ std::map<std::vector<size_t>, std::vector<std::vector<int>>> axesVectors = {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::I32,
-    // InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16,
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<ngraph::helpers::SqueezeOpType> opTypes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -281,10 +281,16 @@ std::vector<StridedSliceSpecificParams> ss_only_test_cases = {
     //    },
 };
 
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
 INSTANTIATE_TEST_CASE_P(smoke, StridedSliceLayerTest,
                         ::testing::Combine(                                              //
                             ::testing::ValuesIn(ss_only_test_cases),                     //
-                            ::testing::Values(InferenceEngine::Precision::FP32),         //
+                            ::testing::ValuesIn(netPrecisions),                          //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Layout::ANY),             //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/tile.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/tile.cpp
@@ -11,7 +11,9 @@ using namespace LayerTestsDefinitions;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<int64_t>> repeats = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/transpose.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/transpose.cpp
@@ -12,7 +12,9 @@ using namespace LayerTestsDefinitions;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
     InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<size_t>> inputShapes = {


### PR DESCRIPTION
We have a number of ops that work with fp16 data but which we have not been testing with fp16 data. This adds fp16 tests for these ops to better cover & understand which ops are working in fp16. This also makes some non-fp16 test improvements, notably adding test coverage for logical & comparison ops, which were previously altogether untested.

This supersedes & replaces the work in https://github.com/plaidml/openvino/pull/98, which also added tests like these but was for code that is now outdated.