### PR TITLE
Fix layer op

### DIFF
--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -2048,6 +2048,19 @@ TEST_F(CppEdsl, LayerMissingOperand) {
   EXPECT_ANY_THROW({ makeProgram("LayerMissingOperand", {A, B}, {O}); });
 }
 
+TEST_F(CppEdsl, LayerMultipleReturnValues) {
+  auto A = Placeholder(DType::FLOAT32, {10, 5});
+  TensorVec tuple = layer("two_output", {A}, {}, [&]() {
+    Tensor idxs = argsort(A, 0);
+    Tensor vals = gather(A, idxs);
+    TensorVec outputs = {vals, idxs};
+    return outputs;
+  });
+
+  auto program = makeProgram("LayerMultipleReturnValues", {A}, tuple);
+  runProgram(program);
+}
+
 TEST_F(CppEdsl, LayerEmbeddedConst) {
   auto A = Placeholder(DType::FLOAT32, {10, 20});
   Tensor O = layer("sum", {A}, [&]() {  //

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -2058,6 +2058,16 @@ TEST_F(CppEdsl, LayerMultipleReturnValues) {
   });
 
   auto program = makeProgram("LayerMultipleReturnValues", {A}, tuple);
+  // clang-format off
+  // CHECK-LABEL: CppEdsl.LayerMultipleReturnValues
+  // CHECK: module @LayerMultipleReturnValues
+  // CHECK: func @main(%[[ARG0:.*]]: tensor<10x5xf32>) -> (tensor<10x5x5xf32>, tensor<10x5xsi32>) {
+  // CHECK:   %[[X0:.*]]:2 = layer.box "two_output" (%[[ARG1:.*]]) = (%[[ARG0]]) : (tensor<10x5xf32>) -> (tensor<10x5x5xf32>, tensor<10x5xsi32>) {
+  // CHECK:      %[[X1:.*]] = tile.argsort asc %[[ARG1]][{{[0-9]*}}] : (tensor<10x5xf32>) -> tensor<10x5xsi32>
+  // CHECK:      %[[X2:.*]] = tile.gather %[[ARG1]] %[[X1]] {{{.*}}} : (tensor<10x5xf32>, tensor<10x5xsi32>) -> tensor<10x5x5xf32>
+  // CHECK:      layer.return %[[X2]], %[[X1]] : tensor<10x5x5xf32>, tensor<10x5xsi32>
+  // CHECK:   return %[[X0]]#0, %[[X0]]#1 : tensor<10x5x5xf32>, tensor<10x5xsi32>
+  // clang-format on
   runProgram(program);
 }
 

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -723,11 +723,11 @@ struct ProgramBuilder {
 
       auto itLayerResults = std::find(results.begin(), results.end(), value);
       if (itLayerResults != results.end()) {
-        auto opResults = op->getResults();
-        auto itOpResults = std::find(opResults.begin(), opResults.end(), value);
-        size_t idxOpResults = std::distance(opResults.begin(), itOpResults);
-        size_t idxLayerResults = std::distance(results.begin(), itLayerResults);
-        innerResults[idxLayerResults] = clonedOp->getResult(idxOpResults);
+        if (auto opResultVal = value.cast<OpResult>()) {
+          auto idxLayerResults = std::distance(results.begin(), itLayerResults);
+          innerResults[idxLayerResults] =
+              clonedOp->getResult(opResultVal.getResultNumber());
+        }
       }
       toRemove.insert(op);
     }

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -687,9 +687,9 @@ struct ProgramBuilder {
     for (const ExprNodePtr &operand : node->operands) {
       operands.push_back(builder.lookupNode(operand));
     }
-    llvm::SetVector<Value> results;
+    llvm::SmallVector<Value> results;
     for (const ExprNodePtr &result : node->results) {
-      results.insert(builder.lookupNode(result));
+      results.push_back(builder.lookupNode(result));
     }
     llvm::SmallVector<Type, 4> resultTypes;
     for (Value val : results) {

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -721,13 +721,13 @@ struct ProgramBuilder {
       assert(op && "Unexpected block argument");
       Operation *clonedOp = bodyBuilder.clone(*op, mapper);
 
-      auto iter = std::find(results.begin(), results.end(), value);
-      if (iter != results.end()) {
-        if (clonedOp->getNumResults() != 1) {
-          throw std::runtime_error("Program build failure.");
-        }
-        size_t index = std::distance(results.begin(), iter);
-        innerResults[index] = clonedOp->getResult(0);
+      auto itLayerResults = std::find(results.begin(), results.end(), value);
+      if (itLayerResults != results.end()) {
+        auto opResults = op->getResults();
+        auto itOpResults = std::find(opResults.begin(), opResults.end(), value);
+        size_t idxOpResults = std::distance(opResults.begin(), itOpResults);
+        size_t idxLayerResults = std::distance(results.begin(), itLayerResults);
+        innerResults[idxLayerResults] = clonedOp->getResult(idxOpResults);
       }
       toRemove.insert(op);
     }


### PR DESCRIPTION
When layer op has multiple return values, sometimes the order of the values in layer.return is not correct. 
This would cause error in TopK (not submitted yet). 
This patch fixes this issue. 