### PR TITLE
Build OpenVINO with Python enabled

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,7 +47,7 @@ steps:
     async: false
     build:
       message: "${BUILDKITE_MESSAGE}"
-      commit: "9cdb3ed3218d782115996c700b322828e9c357a6"
+      commit: "3089ca537808c6c227c98156932af2da0a7eb54a"
       env:
         PLAIDML_COMMIT: "${BUILDKITE_COMMIT}"
         BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"

--- a/configure
+++ b/configure
@@ -149,6 +149,7 @@ class Configure:
             '-DENABLE_GNA=OFF',
             '-DENABLE_MKL_DNN=OFF',
             '-DENABLE_MYRIAD=OFF',
+            '-DENABLE_PYTHON=ON',
             '-DENABLE_SPEECH_DEMO=OFF',
             '-DENABLE_TESTS=ON',
             '-DENABLE_VPU=OFF',

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - ccache=3.7.12
   - cmake=3.18.4
+  - cython=0.29.22
   - doxygen=1.8.20
   - matplotlib=3.3.2
   - ninja=1.10.1

--- a/plaidml/bridge/openvino/plaidml_builder.cpp
+++ b/plaidml/bridge/openvino/plaidml_builder.cpp
@@ -31,7 +31,14 @@ plaidml::Program nodeProgramBuilder(const std::shared_ptr<ngraph::Node>& _node) 
   for (const auto& input : _node->inputs()) {
     std::vector<int64_t> dims{input.get_shape().begin(), input.get_shape().end()};
     auto type = to_plaidml(input.get_element_type());
-    auto tensor = plaidml::edsl::Placeholder(type, dims, input.get_tensor().get_name());
+    std::string tensor_name;
+    if (input.get_tensor().get_names().empty()) {
+      tensor_name = "";
+    } else {
+      // PlaidML only has one name per tensor, and it isn't semantic, just pick one arbitrarily
+      tensor_name = *input.get_tensor().get_names().begin();
+    }
+    auto tensor = plaidml::edsl::Placeholder(type, dims, tensor_name);
     edsl_inputs.push_back(tensor);
     ctx.operands.push_back(tensor);
   }


### PR DESCRIPTION
Turns on Python support when we build OpenVINO. This requires us to include Cython in the .cenv.

Also fixes a warning raised about get_name() being deprecated for ngraph tensor descriptors.