### PR TITLE
Fix DetectionOutput tests

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -9,7 +9,8 @@
 
 std::vector<std::string> disabledTestPatterns() {
   return {
-      ".*ShapeOfLayerTest.*",  // Broken until https://github.com/plaidml/openvino/issues/88 is fixed
+      ".*ShapeOfLayerTest.*",          // Broken until https://github.com/plaidml/openvino/issues/88 is fixed
+      ".*DetectionOutputLayerTest.*",  // TODO: Investigate and re-enable
 #ifdef SMOKE_TESTS_ONLY
       "^(?!smoke).*",
 #endif  // SMOKE_TESTS_ONLY

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -9,8 +9,7 @@
 
 std::vector<std::string> disabledTestPatterns() {
   return {
-      ".*ShapeOfLayerTest.*",          // Broken until https://github.com/plaidml/openvino/issues/88 is fixed
-      ".*DetectionOutputLayerTest.*",  // TODO: Investigate and re-enable
+      ".*ShapeOfLayerTest.*",  // Broken until https://github.com/plaidml/openvino/issues/88 is fixed
 #ifdef SMOKE_TESTS_ONLY
       "^(?!smoke).*",
 #endif  // SMOKE_TESTS_ONLY


### PR DESCRIPTION
~The DetectionOutput tests are sporadically failing. We discussed this in the context of #1741 and I had thought this was fixed at the time, but clearly my understanding there was wrong. So, this PR disables those tests for now (to unblock CI), and meanwhile I'm looking into what happened in #1741 and related PRs to see whether we didn't actually land the fix, or if the fix was incomplete, or if there's some additional bug.~

This fixes a bug in DetectionOutput testing by updating the OpenVINO reference to a version that includes the bugfix.