### PR TITLE
Update to latest MLIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,19 +71,6 @@ include(xsmm)
 # -------------------------------------------------------------------------------
 if(PML_BUILD_TESTS)
   enable_testing()
-  set(GLOBAL_CHECKS)
-  # add_custom_target(check-core
-  #   COMMAND ${CMAKE_CTEST_COMMAND} -L core --output-on-failure
-  #   USES_TERMINAL
-  # )
-  # add_custom_target(check-smoke
-  #   COMMAND ${CMAKE_CTEST_COMMAND} -L smoke --output-on-failure
-  #   USES_TERMINAL
-  # )
-  # add_custom_target(check-test
-  #   COMMAND ${CMAKE_CTEST_COMMAND} -L test --output-on-failure
-  #   USES_TERMINAL
-  # )
 endif()
 
 # -------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,18 +71,19 @@ include(xsmm)
 # -------------------------------------------------------------------------------
 if(PML_BUILD_TESTS)
   enable_testing()
-  add_custom_target(check-core
-    COMMAND ${CMAKE_CTEST_COMMAND} -L core --output-on-failure
-    USES_TERMINAL
-  )
-  add_custom_target(check-smoke
-    COMMAND ${CMAKE_CTEST_COMMAND} -L smoke --output-on-failure
-    USES_TERMINAL
-  )
-  add_custom_target(check-test
-    COMMAND ${CMAKE_CTEST_COMMAND} -L test --output-on-failure
-    USES_TERMINAL
-  )
+  set(GLOBAL_CHECKS)
+  # add_custom_target(check-core
+  #   COMMAND ${CMAKE_CTEST_COMMAND} -L core --output-on-failure
+  #   USES_TERMINAL
+  # )
+  # add_custom_target(check-smoke
+  #   COMMAND ${CMAKE_CTEST_COMMAND} -L smoke --output-on-failure
+  #   USES_TERMINAL
+  # )
+  # add_custom_target(check-test
+  #   COMMAND ${CMAKE_CTEST_COMMAND} -L test --output-on-failure
+  #   USES_TERMINAL
+  # )
 endif()
 
 # -------------------------------------------------------------------------------
@@ -99,16 +100,7 @@ include(pml_python)
 include(pml_tblgen_library)
 include(pml_whole_archive_link)
 
-get_directory_property(HAS_PARENT PARENT_DIRECTORY)
-if(HAS_PARENT)
-  set(IS_SUBPROJECT TRUE)
-else()
-  add_custom_target(check
-    DEPENDS
-      check-test
-      check-clang-format
-  )
-endif()
+get_directory_property(IS_SUBPROJECT PARENT_DIRECTORY)
 
 # Set general cpack variables for package description
 set(CPACK_GENERATOR "TGZ")
@@ -143,4 +135,16 @@ configure_lit_site_cfg(
 
 if(PML_ENABLE_DEVKIT)
   include(devkit)
+endif()
+
+if(PML_BUILD_TESTS)
+  get_property(_CHECKS GLOBAL PROPERTY GLOBAL_CHECKS)
+  foreach(_CHECK ${_CHECKS})
+    get_property(_CHECK_DEPS GLOBAL PROPERTY GLOBAL_CHECK_DEPS_${_CHECK})
+    add_custom_target(check-${_CHECK}
+      COMMAND ${CMAKE_CTEST_COMMAND} -L ${_CHECK} --output-on-failure
+      USES_TERMINAL
+      DEPENDS ${_CHECK_DEPS}
+    )
+  endforeach()
 endif()

--- a/cmake/pml_cc_test.cmake
+++ b/cmake/pml_cc_test.cmake
@@ -100,9 +100,10 @@ function(pml_cc_test)
   )
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
-  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}" "${_RULE_CHECKS}")
+  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "cc" "${_RULE_LABELS}" "${_RULE_CHECKS}")
 
-  foreach(_CHECK ${_RULE_CHECKS})
-    add_dependencies(check-${_CHECK} ${_NAME})
-  endforeach()
+  pml_add_checks(
+    CHECKS "cc" ${_RULE_CHECKS}
+    DEPS ${_RULE_DEPS}
+  )
 endfunction()

--- a/cmake/pml_lit_test.cmake
+++ b/cmake/pml_lit_test.cmake
@@ -42,11 +42,12 @@ function(pml_lit_test)
   )
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
-  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}" "${_RULE_CHECKS}")
+  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "lit" "${_RULE_LABELS}" "${_RULE_CHECKS}")
 
-  foreach(_CHECK ${_RULE_CHECKS})
-    add_dependencies(check-${_CHECK} ${_NAME} ${_DEPS})
-  endforeach()
+  pml_add_checks(
+    CHECKS "lit" ${_RULE_CHECKS}
+    DEPS ${_RULE_DEPS}
+  )
 
   set_target_properties(${_NAME} PROPERTIES FOLDER "Tests")
 endfunction()

--- a/cmake/pml_macros.cmake
+++ b/cmake/pml_macros.cmake
@@ -227,3 +227,28 @@ function(pml_add_executable_dependencies EXECUTABLE DEPENDENCY)
     add_dependencies(${EXECUTABLE} ${DEPENDENCY})
   endif()
 endfunction()
+
+
+function(pml_add_checks)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    ""
+    "CHECKS;DEPS"
+    ${ARGN}
+  )
+
+  foreach(_CHECK ${_RULE_CHECKS})
+    get_property(_CHECKS GLOBAL PROPERTY GLOBAL_CHECKS)
+    list(APPEND _CHECKS ${_CHECK})
+    list(REMOVE_DUPLICATES _CHECKS)
+    set_property(GLOBAL PROPERTY GLOBAL_CHECKS ${_CHECKS})
+
+    if(_RULE_DEPS)
+      get_property(_CHECK_DEPS GLOBAL PROPERTY GLOBAL_CHECK_DEPS_${_CHECK})
+      list(APPEND _CHECK_DEPS ${_RULE_DEPS})
+      list(REMOVE_DUPLICATES _CHECK_DEPS)
+      set_property(GLOBAL PROPERTY GLOBAL_CHECK_DEPS_${_CHECK} ${_CHECK_DEPS})
+    endif()
+  endforeach()
+endfunction()

--- a/cmake/pml_python.cmake
+++ b/cmake/pml_python.cmake
@@ -65,7 +65,7 @@ function(pml_py_test)
     _RULE
     ""
     "NAME;SRC"
-    "ARGS;LABELS;CHECKS"
+    "ARGS;LABELS;CHECKS;DEPS"
     ${ARGN}
   )
 
@@ -79,7 +79,7 @@ function(pml_py_test)
 
   pml_add_installed_test(
     TEST_NAME "${_NAME_PATH}"
-    LABELS "${_RULE_LABELS}" "${_RULE_CHECKS}"
+    LABELS "python" "${_RULE_LABELS}" "${_RULE_CHECKS}"
     ENVIRONMENT
       "PYTHONPATH=${PROJECT_BINARY_DIR}:$ENV{PYTHONPATH}"
     COMMAND
@@ -105,6 +105,11 @@ function(pml_py_test)
     COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}
       ${CMAKE_CURRENT_BINARY_DIR}/${_RULE_SRC}
+  )
+
+  pml_add_checks(
+    CHECKS "python" ${_RULE_CHECKS}
+    DEPS ${_RULE_DEPS}
   )
 endfunction()
 

--- a/cmake/third_party/llvm-project.cmake
+++ b/cmake/third_party/llvm-project.cmake
@@ -32,8 +32,8 @@ else()
   message("Fetching LLVM")
   FetchContent_Declare(
     llvm-project
-    URL      https://github.com/plaidml/llvm-project/archive/d661842f872f8cae56985cc6be3505119edb1e78.tar.gz
-    URL_HASH SHA256=a72817ab9b3bb8b54581c0d6a19882b527eeefac208fb91d6ba80e4d32ca226d
+    URL      https://github.com/plaidml/llvm-project/archive/8eeed9168e9d46eaa522e775311ed6ec5d01e4c0.tar.gz
+    # URL_HASH SHA256=a72817ab9b3bb8b54581c0d6a19882b527eeefac208fb91d6ba80e4d32ca226d
   )
   FetchContent_GetProperties(llvm-project)
   if(NOT llvm-project_POPULATED)

--- a/cmake/third_party/llvm-project.cmake
+++ b/cmake/third_party/llvm-project.cmake
@@ -32,8 +32,8 @@ else()
   message("Fetching LLVM")
   FetchContent_Declare(
     llvm-project
-    URL      https://github.com/plaidml/llvm-project/archive/8eeed9168e9d46eaa522e775311ed6ec5d01e4c0.tar.gz
-    # URL_HASH SHA256=a72817ab9b3bb8b54581c0d6a19882b527eeefac208fb91d6ba80e4d32ca226d
+    URL      https://github.com/plaidml/llvm-project/archive/480196768af18de71ceb576500b79933f52ecc85.tar.gz
+    URL_HASH SHA256=63399591e570816b706e4f8a9fd25af5b4561aad8e22813ad21dd33fec8c8f43
   )
   FetchContent_GetProperties(llvm-project)
   if(NOT llvm-project_POPULATED)

--- a/networks/scitile/LAS/CMakeLists.txt
+++ b/networks/scitile/LAS/CMakeLists.txt
@@ -1,6 +1,8 @@
 pml_py_test(
   NAME cg_test
   SRC cg_tests.py
+  DEPS
+    plaidml::plaidml
   CHECKS
     core
     smoke

--- a/plaidml/bridge/keras/CMakeLists.txt
+++ b/plaidml/bridge/keras/CMakeLists.txt
@@ -7,6 +7,8 @@ pml_py_library(
 pml_py_test(
   NAME backend_test
   SRC backend_test.py
+  DEPS
+    plaidml::plaidml
   CHECKS
     keras
     test
@@ -15,6 +17,8 @@ pml_py_test(
 pml_py_test(
   NAME trivial_model_test
   SRC trivial_model_test.py
+  DEPS
+    plaidml::plaidml
   CHECKS
     core
     keras

--- a/plaidml/bridge/openvino/tests/functional/CMakeLists.txt
+++ b/plaidml/bridge/openvino/tests/functional/CMakeLists.txt
@@ -33,6 +33,6 @@ add_custom_target(check-bridge-openvino
 add_dependencies(check-bridge-openvino ${_TARGET})
 
 if(PML_BUILD_TESTS)
-  add_dependencies(check-smoke ${_TARGET}Smoke)
-  add_dependencies(check-test ${_TARGET})
+  pml_add_checks(CHECKS smoke DEPS ${_TARGET}Smoke)
+  pml_add_checks(CHECKS test DEPS ${_TARGET})
 endif()

--- a/plaidml/edsl/tests/CMakeLists.txt
+++ b/plaidml/edsl/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ pml_cc_test(
 pml_py_test(
   NAME py_test
   SRC edsl_test.py
+  DEPS
+    plaidml::plaidml
   CHECKS
     core
     smoke

--- a/pmlc/compiler/program.cc
+++ b/pmlc/compiler/program.cc
@@ -7,6 +7,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 #include "mlir/Parser.h"

--- a/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
+++ b/pmlc/conversion/pxa_to_affine/pxa_to_affine.cc
@@ -25,13 +25,6 @@ namespace stdx = dialect::stdx;
 
 namespace {
 
-static void splitAffineMaps(AffineMap from, SmallVectorImpl<AffineMap> &into) {
-  for (AffineExpr expr : from.getResults()) {
-    into.push_back(
-        AffineMap::get(from.getNumDims(), from.getNumSymbols(), expr));
-  }
-}
-
 struct AffineParallelOpConversion
     : public OpConversionPattern<AffineParallelOp> {
   using OpConversionPattern<AffineParallelOp>::OpConversionPattern;
@@ -58,8 +51,8 @@ struct AffineParallelOpConversion
       } else {
         // Normal case for parallels with IVs
         SmallVector<AffineMap> lbMaps, ubMaps;
-        splitAffineMaps(op.lowerBoundsMap(), lbMaps);
-        splitAffineMaps(op.upperBoundsMap(), ubMaps);
+        util::splitAffineMaps(op.lowerBoundsMap(), lbMaps);
+        util::splitAffineMaps(op.upperBoundsMap(), ubMaps);
         newOp = rewriter.create<AffineParallelOp>(
             op.getLoc(),                                 //
             ArrayRef<Type>{}, ArrayRef<AtomicRMWKind>{}, //

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -655,27 +655,32 @@ struct ContractionOpConversion
     auto filled = parallel.getResult(0);
 
     // Determine lower and upper bounds.
-    SmallVector<AffineExpr, 8> ubExprs;
+    SmallVector<AffineMap, 8> lbMaps;
+    SmallVector<AffineMap, 8> ubMaps;
     auto lowerBounds = op.lowerBounds().getValue();
     auto upperBounds = op.upperBounds().getValue();
     assert(lowerBounds.getNumResults() == upperBounds.getNumResults() &&
            "mismatched dims for lower and upper bounds");
     for (unsigned i = 0; i < lowerBounds.getNumResults(); i++) {
-      auto ubExpr = upperBounds.getResult(i) + 1;
-      auto upper = ubExpr.cast<AffineConstantExpr>().getValue();
-      ubExprs.push_back(rewriter.getAffineConstantExpr(upper));
+      AffineExpr ubExpr = upperBounds.getResult(i) + 1;
+      int64_t upper = ubExpr.cast<AffineConstantExpr>().getValue();
+      lbMaps.push_back(AffineMap::get(lowerBounds.getNumDims(),
+                                      lowerBounds.getNumSymbols(),
+                                      lowerBounds.getResult(i)));
+      ubMaps.push_back(AffineMap::getConstantMap(upper, op.getContext()));
     }
 
-    auto ubMap = AffineMap::get(0, 0, {ubExprs}, op.getContext());
     // Make the outer loops
+    SmallVector<int64_t, 8> steps(lbMaps.size(), 1);
     auto forOp = rewriter.create<AffineParallelOp>(
         loc,
         /*resultTypes=*/ArrayRef<Type>{alloc.memRefType},
         /*reductions=*/ArrayRef<AtomicRMWKind>{AtomicRMWKind::assign},
-        /*lbMap=*/op.lowerBounds().getValue(),
+        /*lbMaps=*/lbMaps,
         /*lbArgs=*/ArrayRef<Value>{},
-        /*ubMap=*/ubMap,
-        /*ubArgs=*/ArrayRef<Value>{});
+        /*ubMaps=*/ubMaps,
+        /*ubArgs=*/ArrayRef<Value>{},
+        /*steps=*/steps);
 
     auto body = forOp.getBody();
     rewriter.setInsertionPointToStart(body);

--- a/pmlc/dialect/pxa/analysis/strides.cc
+++ b/pmlc/dialect/pxa/analysis/strides.cc
@@ -18,6 +18,7 @@
 #include "pmlc/dialect/pxa/analysis/affine_expr.h"
 #include "pmlc/util/bilp/ilp_solver.h"
 #include "pmlc/util/logging.h"
+#include "pmlc/util/util.h"
 
 using namespace mlir; // NOLINT
 
@@ -77,7 +78,7 @@ static Optional<StrideInfo> flatten(MemRefType memRefType,
 StrideRange::StrideRange(BlockArgument arg)
     : valid(false), minVal(0), maxVal(0), stride(0) {
   if (auto ap = dyn_cast<AffineParallelOp>(arg.getOwner()->getParentOp())) {
-    auto rangeExpr = ap.getRangesValueMap().getResult(arg.getArgNumber());
+    auto rangeExpr = util::getRangesValueMap(ap).getResult(arg.getArgNumber());
     auto rangeConstantExpr = rangeExpr.dyn_cast<AffineConstantExpr>();
     if (!rangeConstantExpr) {
       return;

--- a/pmlc/tools/pmlc-jit/pmlc-jit.cc
+++ b/pmlc/tools/pmlc-jit/pmlc-jit.cc
@@ -18,8 +18,10 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/Support/FileUtilities.h"
+
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"

--- a/pmlc/util/CMakeLists.txt
+++ b/pmlc/util/CMakeLists.txt
@@ -30,6 +30,7 @@ pml_cc_library(
   DEPS
     easyloggingpp
     LLVMCore
+    MLIRAffine
     MLIRIR
     MLIRStandard
     ::enums-gen

--- a/pmlc/util/util.cc
+++ b/pmlc/util/util.cc
@@ -14,7 +14,7 @@ namespace pmlc::util {
 uint64_t getByteSize(MemRefType type) {
   int64_t offset;
   SmallVector<int64_t, 8> strides;
-  if (failed(mlir::getStridesAndOffset(type, strides, offset))) {
+  if (failed(getStridesAndOffset(type, strides, offset))) {
     throw std::runtime_error("Could not retrieve strides");
   }
   auto sizes = type.getShape();
@@ -140,6 +140,13 @@ void wrapFunctionAndPackArguments(llvm::Module *module, StringRef funcName,
   } else {
     builder.CreateRet(val);
   }
+}
+
+AffineValueMap getRangesValueMap(AffineParallelOp op) {
+  AffineValueMap out;
+  AffineValueMap::difference(op.getUpperBoundsValueMap(),
+                             op.getLowerBoundsValueMap(), &out);
+  return out;
 }
 
 } // namespace pmlc::util

--- a/pmlc/util/util.cc
+++ b/pmlc/util/util.cc
@@ -125,8 +125,8 @@ void wrapFunctionAndPackArguments(llvm::Module *module, StringRef funcName,
     llvm::Value *argIndex = llvm::Constant::getIntegerValue(
         builder.getInt64Ty(), APInt(64, indexedArg.index()));
     llvm::Value *argPtrPtr = builder.CreateGEP(argList, argIndex);
-    llvm::Value *argPtr = builder.CreateLoad(argPtrPtr);
-    auto dstType = indexedArg.value().getType();
+    llvm::Value *argPtr = builder.CreateLoad(builder.getInt8PtrTy(), argPtrPtr);
+    llvm::Type *dstType = indexedArg.value().getType();
     llvm::Value *arg = dstType->isIntegerTy()
                            ? builder.CreatePtrToInt(argPtr, dstType)
                            : builder.CreateBitCast(argPtr, dstType);
@@ -147,6 +147,13 @@ AffineValueMap getRangesValueMap(AffineParallelOp op) {
   AffineValueMap::difference(op.getUpperBoundsValueMap(),
                              op.getLowerBoundsValueMap(), &out);
   return out;
+}
+
+void splitAffineMaps(AffineMap from, SmallVectorImpl<AffineMap> &into) {
+  for (AffineExpr expr : from.getResults()) {
+    into.push_back(
+        AffineMap::get(from.getNumDims(), from.getNumSymbols(), expr));
+  }
 }
 
 } // namespace pmlc::util

--- a/pmlc/util/util.h
+++ b/pmlc/util/util.h
@@ -10,6 +10,8 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/FormatVariadic.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
 
@@ -62,6 +64,8 @@ struct DiagnosticCounter {
   size_t counter;
   size_t threshold;
 };
+
+mlir::AffineValueMap getRangesValueMap(mlir::AffineParallelOp op);
 
 } // namespace pmlc::util
 

--- a/pmlc/util/util.h
+++ b/pmlc/util/util.h
@@ -67,6 +67,9 @@ struct DiagnosticCounter {
 
 mlir::AffineValueMap getRangesValueMap(mlir::AffineParallelOp op);
 
+void splitAffineMaps(mlir::AffineMap from,
+                     mlir::SmallVectorImpl<mlir::AffineMap> &into);
+
 } // namespace pmlc::util
 
 namespace llvm {


### PR DESCRIPTION
Also improves the `check-${CHECK}` targets so that dependencies are properly defined. This ensures that, for instance, `libplaidml.so` is built before running python tests (which depend on `libplaidml.so`).
