### PR TITLE
Fixing SAME_UPPER/SAME_LOWER padding

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -20,11 +20,10 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 const std::vector<std::vector<size_t>> kernels = {
     {3, 3},
     {3, 5},
-    {2, 2},
 };
 const std::vector<std::vector<size_t>> strides = {
     {1, 1},
-    {2, 2},
+    // {1, 2},
 };
 const std::vector<std::vector<size_t>> padBegins = {
     {0, 0},
@@ -87,10 +86,10 @@ INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest
 /* ========== Same Upper Pad Ceil Rounding ========== */
 const auto maxPool_SameUpperPad_CeilRounding_Params = ::testing::Combine(  //
     ::testing::Values(ngraph::helpers::PoolingTypes::MAX),                 //
-    ::testing::ValuesIn(kernels),                                          //
-    ::testing::ValuesIn(strides),                                          //
-    ::testing::ValuesIn(padBegins),                                        //
-    ::testing::ValuesIn(padEnds),                                          //
+    ::testing::Values(std::vector<size_t>{2, 2}),                          //
+    ::testing::Values(std::vector<size_t>{2, 2}),                          //
+    ::testing::Values(std::vector<size_t>{0, 0}),                          //
+    ::testing::Values(std::vector<size_t>{0, 0}),                          //
     ::testing::Values(ngraph::op::RoundingType::CEIL),                     //
     ::testing::Values(ngraph::op::PadType::SAME_UPPER),                    //
     ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -61,6 +61,7 @@ INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTes
                             ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
+
 /* ========== Explicit Pad Ceil Rounding ========== */
 const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(  //
     ::testing::Values(ngraph::helpers::PoolingTypes::MAX),                //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -20,10 +20,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 const std::vector<std::vector<size_t>> kernels = {
     {3, 3},
     {3, 5},
+    {2, 2},
 };
 const std::vector<std::vector<size_t>> strides = {
     {1, 1},
-    // {1, 2},
+    {2, 2},
 };
 const std::vector<std::vector<size_t>> padBegins = {
     {0, 0},
@@ -101,7 +102,7 @@ INSTANTIATE_TEST_CASE_P(smoke_MaxPool_SameUpperPad_CeilRpunding, PoolingLayerTes
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Layout::ANY),             //
                             ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
+                            ::testing::Values(std::vector<size_t>({1, 16, 416, 416})),   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
 /* ========== Valid Pad Ceil Rounding ========== */

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -82,6 +82,51 @@ INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest
                             ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
+/* ========== Same Upper Pad Ceil Rounding ========== */
+const auto maxPool_SameUpperPad_CeilRounding_Params = ::testing::Combine(  //
+    ::testing::Values(ngraph::helpers::PoolingTypes::MAX),                 //
+    ::testing::ValuesIn(kernels),                                          //
+    ::testing::ValuesIn(strides),                                          //
+    ::testing::ValuesIn(padBegins),                                        //
+    ::testing::ValuesIn(padEnds),                                          //
+    ::testing::Values(ngraph::op::RoundingType::CEIL),                     //
+    ::testing::Values(ngraph::op::PadType::SAME_UPPER),                    //
+    ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
+);
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_SameUpperPad_CeilRpunding, PoolingLayerTest,
+                        ::testing::Combine(                                              //
+                            maxPool_SameUpperPad_CeilRounding_Params,                    //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        PoolingLayerTest::getTestCaseName);
+/* ========== Valid Pad Ceil Rounding ========== */
+const auto maxPool_ValidPad_CeilRounding_Params = ::testing::Combine(  //
+    ::testing::Values(ngraph::helpers::PoolingTypes::MAX),             //
+    ::testing::ValuesIn(kernels),                                      //
+    ::testing::ValuesIn(strides),                                      //
+    ::testing::ValuesIn(padBegins),                                    //
+    ::testing::ValuesIn(padEnds),                                      //
+    ::testing::Values(ngraph::op::RoundingType::CEIL),                 //
+    ::testing::Values(ngraph::op::PadType::VALID),                     //
+    ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
+);
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ValidPad_CeilRpunding, PoolingLayerTest,
+                        ::testing::Combine(                                              //
+                            maxPool_ValidPad_CeilRounding_Params,                        //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        PoolingLayerTest::getTestCaseName);
+
 ////* ========== Avg Pooling ========== */
 /* +========== Explicit Pad Ceil Rounding ========== */
 const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(  //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -106,28 +106,6 @@ INSTANTIATE_TEST_CASE_P(smoke_MaxPool_SameUpperPad_CeilRpunding, PoolingLayerTes
                             ::testing::Values(std::vector<size_t>({1, 16, 416, 416})),   //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
-/* ========== Valid Pad Ceil Rounding ========== */
-const auto maxPool_ValidPad_CeilRounding_Params = ::testing::Combine(  //
-    ::testing::Values(ngraph::helpers::PoolingTypes::MAX),             //
-    ::testing::ValuesIn(kernels),                                      //
-    ::testing::ValuesIn(strides),                                      //
-    ::testing::ValuesIn(padBegins),                                    //
-    ::testing::ValuesIn(padEnds),                                      //
-    ::testing::Values(ngraph::op::RoundingType::CEIL),                 //
-    ::testing::Values(ngraph::op::PadType::VALID),                     //
-    ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
-);
-INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ValidPad_CeilRpunding, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            maxPool_ValidPad_CeilRounding_Params,                        //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-                        PoolingLayerTest::getTestCaseName);
 
 ////* ========== Avg Pooling ========== */
 /* +========== Explicit Pad Ceil Rounding ========== */

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -372,7 +372,7 @@ std::pair<TensorDim, TensorDim> compute_padding_and_output_size(  //
   if (autopad_mode == AutoPadMode::SAME_LOWER || autopad_mode == AutoPadMode::SAME_UPPER) {
     TensorDim output_size((I_eff + stride - 1) / stride);
     int64_t lower_term = (autopad_mode == AutoPadMode::SAME_LOWER) ? 1 : 0;
-    TensorDim pad_before(max(0, (output_size - 1) * stride + F_eff - I_eff) * lower_term);
+    TensorDim pad_before((max(0, (output_size - 1) * stride + F_eff - I_eff) + lower_term) / 2);
     return std::pair<TensorDim, TensorDim>(pad_before, output_size);
   }
   throw std::runtime_error(llvm::formatv("Unexpected autopadding mode: {0}", to_string(autopad_mode)));

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -370,9 +370,9 @@ std::pair<TensorDim, TensorDim> compute_padding_and_output_size(  //
     return std::pair<TensorDim, TensorDim>(pad_before, output_size);
   }
   if (autopad_mode == AutoPadMode::SAME_LOWER || autopad_mode == AutoPadMode::SAME_UPPER) {
-    TensorDim output_size((I_eff + stride - 1 + ceil_term) / stride);
+    TensorDim output_size((I_eff + stride - 1) / stride);
     int64_t lower_term = (autopad_mode == AutoPadMode::SAME_LOWER) ? 1 : 0;
-    TensorDim pad_before((max(0, (output_size - 1) * stride + F_eff - I_eff) + lower_term) / 2);
+    TensorDim pad_before(max(0, (output_size - 1) * stride + F_eff - I_eff) * lower_term);
     return std::pair<TensorDim, TensorDim>(pad_before, output_size);
   }
   throw std::runtime_error(llvm::formatv("Unexpected autopadding mode: {0}", to_string(autopad_mode)));


### PR DESCRIPTION
Fixing rounding-related error in output size calculation for SAME_UPPER/SAME_LOWER autopad modes.