### PR TITLE
Fixes for check-XXXX

### DIFF
--- a/cmake/pml_cc_test.cmake
+++ b/cmake/pml_cc_test.cmake
@@ -104,6 +104,6 @@ function(pml_cc_test)
 
   pml_add_checks(
     CHECKS "cc" ${_RULE_CHECKS}
-    DEPS ${_RULE_DEPS}
+    DEPS ${_NAME} ${_RULE_DEPS}
   )
 endfunction()

--- a/cmake/pml_lit_test.cmake
+++ b/cmake/pml_lit_test.cmake
@@ -22,7 +22,11 @@ function(pml_lit_test)
   # Prefix the library with the package name, so we get: pml_package_name
   pml_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
-
+  set(LIT_DEPS
+    FileCheck
+    count
+    not
+  )
   set(_COMMAND ${LLVM_BINARY_DIR}/bin/llvm-lit ${CMAKE_CURRENT_BINARY_DIR} -v)
   add_custom_target(${_NAME}
     COMMAND ${_COMMAND}
@@ -30,7 +34,7 @@ function(pml_lit_test)
     USES_TERMINAL
   )
   pml_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
-  add_dependencies(${_NAME} ${_RULE_DEPS} FileCheck count not)
+  add_dependencies(${_NAME} ${_RULE_DEPS} ${LIT_DEPS})
 
   string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_TEST_NAME "${_PACKAGE_PATH}/${_RULE_NAME}")
@@ -46,7 +50,7 @@ function(pml_lit_test)
 
   pml_add_checks(
     CHECKS "lit" ${_RULE_CHECKS}
-    DEPS ${_RULE_DEPS}
+    DEPS ${_NAME} ${_RULE_DEPS}
   )
 
   set_target_properties(${_NAME} PROPERTIES FOLDER "Tests")

--- a/cmake/pml_python.cmake
+++ b/cmake/pml_python.cmake
@@ -24,6 +24,7 @@ function(pml_py_library)
   pml_package_ns(_PACKAGE_NS)
   # Replace dependencies passed by ::name with ::pml::package::name
   list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+  list(TRANSFORM _RULE_DEPS REPLACE "::" "_")
 
   pml_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
@@ -76,6 +77,8 @@ function(pml_py_test)
   string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}/${_RULE_NAME}")
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
+  list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+  list(TRANSFORM _RULE_DEPS REPLACE "::" "_")
 
   pml_add_installed_test(
     TEST_NAME "${_NAME_PATH}"

--- a/networks/scitile/LAS/CMakeLists.txt
+++ b/networks/scitile/LAS/CMakeLists.txt
@@ -2,7 +2,7 @@ pml_py_test(
   NAME cg_test
   SRC cg_tests.py
   DEPS
-    plaidml::plaidml
+    plaidml::py
   CHECKS
     core
     smoke

--- a/plaidml/CMakeLists.txt
+++ b/plaidml/CMakeLists.txt
@@ -66,8 +66,12 @@ pml_py_library(
     ffi.py
     plaidml_setup.py
   DEPS
+    ::_ffi
     ::plaidml
-    plaidml__ffi
+    plaidml::core::py
+    plaidml::edsl::py
+    plaidml::exec::py
+    plaidml::op::py
 )
 
 pml_py_cffi(

--- a/plaidml/bridge/keras/CMakeLists.txt
+++ b/plaidml/bridge/keras/CMakeLists.txt
@@ -1,5 +1,7 @@
 pml_py_library(
   NAME py
+  DEPS
+    plaidml::py
   SRCS
     __init__.py
 )
@@ -8,7 +10,7 @@ pml_py_test(
   NAME backend_test
   SRC backend_test.py
   DEPS
-    plaidml::plaidml
+    ::py
   CHECKS
     keras
     test
@@ -18,7 +20,7 @@ pml_py_test(
   NAME trivial_model_test
   SRC trivial_model_test.py
   DEPS
-    plaidml::plaidml
+    ::py
   CHECKS
     core
     keras

--- a/plaidml/edsl/tests/CMakeLists.txt
+++ b/plaidml/edsl/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ pml_py_test(
   NAME py_test
   SRC edsl_test.py
   DEPS
-    plaidml::plaidml
+    plaidml::py
   CHECKS
     core
     smoke


### PR DESCRIPTION
This should resolve issues with fresh builds following this workflow:

```
./configure
cd build-x86_64/Release
ninja check-core
```
