### PR TITLE
Update LLVM to latest MLIR

### DIFF
--- a/cmake/third_party/llvm-project.cmake
+++ b/cmake/third_party/llvm-project.cmake
@@ -32,8 +32,8 @@ else()
   message("Fetching LLVM")
   FetchContent_Declare(
     llvm-project
-    URL      https://github.com/plaidml/llvm-project/archive/b8b6faf202164a09169a61783edd61a53d98c9f3.tar.gz
-    # URL_HASH SHA256=63399591e570816b706e4f8a9fd25af5b4561aad8e22813ad21dd33fec8c8f43
+    URL      https://github.com/plaidml/llvm-project/archive/39c5bdb3e5ad8ef4ce6b7424a8ba59fa560015b2.tar.gz
+    URL_HASH SHA256=908583224871b97e144b2629594425b6a4424e2ed026fbf6a0eb64c9d56e5369
   )
   FetchContent_GetProperties(llvm-project)
   if(NOT llvm-project_POPULATED)

--- a/cmake/third_party/llvm-project.cmake
+++ b/cmake/third_party/llvm-project.cmake
@@ -32,8 +32,8 @@ else()
   message("Fetching LLVM")
   FetchContent_Declare(
     llvm-project
-    URL      https://github.com/plaidml/llvm-project/archive/480196768af18de71ceb576500b79933f52ecc85.tar.gz
-    URL_HASH SHA256=63399591e570816b706e4f8a9fd25af5b4561aad8e22813ad21dd33fec8c8f43
+    URL      https://github.com/plaidml/llvm-project/archive/b8b6faf202164a09169a61783edd61a53d98c9f3.tar.gz
+    # URL_HASH SHA256=63399591e570816b706e4f8a9fd25af5b4561aad8e22813ad21dd33fec8c8f43
   )
   FetchContent_GetProperties(llvm-project)
   if(NOT llvm-project_POPULATED)

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -765,10 +765,10 @@ TEST_F(CppEdsl, LarsMomentum4d) {
   // clang-format off
   // CHECK-LABEL: CppEdsl.LarsMomentum4d
   // CHECK: module @lars_momentum4d
-  // CHECK: tile.constant(0.000000e+00 : f64) : tensor<f32>
-  // CHECK: tile.constant(1.250000e-01 : f64) : tensor<f32>
-  // CHECK: tile.constant(9.765625E-4 : f64) : tensor<f32>
-  // CHECK: tile.constant(4.8828125E-4 : f64) : tensor<f32>
+  // CHECK-DAG: tile.constant(0.000000e+00 : f64) : tensor<f32>
+  // CHECK-DAG: tile.constant(1.250000e-01 : f64) : tensor<f32>
+  // CHECK-DAG: tile.constant(9.765625E-4 : f64) : tensor<f32>
+  // CHECK-DAG: tile.constant(4.8828125E-4 : f64) : tensor<f32>
   // CHECK: tile.mul %{{.*}}, %{{.*}} : (tensor<4x7x3x9xf32>, tensor<f32>) -> tensor<4x7x3x9xf32>
   // CHECK: tile.mul %{{.*}}, %{{.*}} : (tensor<f32>, tensor<f32>) -> tensor<f32>
   // CHECK: tile.mul %{{.*}}, %{{.*}} : (tensor<4x7x3x9xf32>, tensor<4x7x3x9xf32>) -> tensor<4x7x3x9xf32>

--- a/pmlc/compiler/program.cc
+++ b/pmlc/compiler/program.cc
@@ -161,6 +161,7 @@ void Program::compile(StringRef targetNameAndOptions, bool collectPasses,
     pm.enableIRPrinting(shouldPrintBeforePass, shouldPrintAfterPass,
                         /*printModuleScope=*/true,
                         /*printAfterOnlyOnChange=*/false,
+                        /*printAfterOnlyOnFailure=*/false,
                         /*out=*/llvm::errs());
   }
 

--- a/pmlc/conversion/stdx_to_llvm/stdx_to_llvm.cc
+++ b/pmlc/conversion/stdx_to_llvm/stdx_to_llvm.cc
@@ -4,7 +4,6 @@
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/StandardOps/EDSC/Intrinsics.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/Pass/Pass.h"
@@ -124,37 +123,36 @@ struct TanLowering : public LibMCallLowering<stdx::TanOp> {
 
 class BaseViewConversionHelper {
 public:
-  explicit BaseViewConversionHelper(Type type)
-      : desc(MemRefDescriptor::undef(rewriter(), loc(), type)) {}
+  BaseViewConversionHelper(OpBuilder &rewriter, Location loc, Type type)
+      : rewriter(rewriter), loc(loc),
+        desc(MemRefDescriptor::undef(rewriter, loc, type)) {}
 
-  explicit BaseViewConversionHelper(Value v) : desc(v) {}
+  explicit BaseViewConversionHelper(OpBuilder &rewriter, Location loc, Value v)
+      : rewriter(rewriter), loc(loc), desc(v) {}
 
   /// Wrappers around MemRefDescriptor that use EDSC builder and location.
-  Value allocatedPtr() { return desc.allocatedPtr(rewriter(), loc()); }
-  void setAllocatedPtr(Value v) { desc.setAllocatedPtr(rewriter(), loc(), v); }
-  Value alignedPtr() { return desc.alignedPtr(rewriter(), loc()); }
-  void setAlignedPtr(Value v) { desc.setAlignedPtr(rewriter(), loc(), v); }
-  Value offset() { return desc.offset(rewriter(), loc()); }
-  void setOffset(Value v) { desc.setOffset(rewriter(), loc(), v); }
-  Value size(unsigned i) { return desc.size(rewriter(), loc(), i); }
-  void setSize(unsigned i, Value v) { desc.setSize(rewriter(), loc(), i, v); }
+  Value allocatedPtr() { return desc.allocatedPtr(rewriter, loc); }
+  void setAllocatedPtr(Value v) { desc.setAllocatedPtr(rewriter, loc, v); }
+  Value alignedPtr() { return desc.alignedPtr(rewriter, loc); }
+  void setAlignedPtr(Value v) { desc.setAlignedPtr(rewriter, loc, v); }
+  Value offset() { return desc.offset(rewriter, loc); }
+  void setOffset(Value v) { desc.setOffset(rewriter, loc, v); }
+  Value size(unsigned i) { return desc.size(rewriter, loc, i); }
+  void setSize(unsigned i, Value v) { desc.setSize(rewriter, loc, i, v); }
   void setConstantSize(unsigned i, int64_t v) {
-    desc.setConstantSize(rewriter(), loc(), i, v);
+    desc.setConstantSize(rewriter, loc, i, v);
   }
-  Value stride(unsigned i) { return desc.stride(rewriter(), loc(), i); }
-  void setStride(unsigned i, Value v) {
-    desc.setStride(rewriter(), loc(), i, v);
-  }
+  Value stride(unsigned i) { return desc.stride(rewriter, loc, i); }
+  void setStride(unsigned i, Value v) { desc.setStride(rewriter, loc, i, v); }
   void setConstantStride(unsigned i, int64_t v) {
-    desc.setConstantStride(rewriter(), loc(), i, v);
+    desc.setConstantStride(rewriter, loc, i, v);
   }
 
   operator Value() { return desc; }
 
 private:
-  OpBuilder &rewriter() { return edsc::ScopedContext::getBuilderRef(); }
-  Location loc() { return edsc::ScopedContext::getLocation(); }
-
+  OpBuilder &rewriter;
+  Location loc;
   MemRefDescriptor desc;
 };
 
@@ -177,10 +175,10 @@ struct ReshapeLowering : public ConvertOpToLLVMPattern<stdx::ReshapeOp> {
         }))
       return failure();
 
-    edsc::ScopedContext context(rewriter, op->getLoc());
     stdx::ReshapeOpAdaptor adaptor(operands);
-    BaseViewConversionHelper baseDesc(adaptor.tensor());
-    BaseViewConversionHelper desc(typeConverter->convertType(dstType));
+    BaseViewConversionHelper baseDesc(rewriter, op->getLoc(), adaptor.tensor());
+    BaseViewConversionHelper desc(rewriter, op->getLoc(),
+                                  typeConverter->convertType(dstType));
     desc.setAllocatedPtr(baseDesc.allocatedPtr());
     desc.setAlignedPtr(baseDesc.alignedPtr());
     desc.setOffset(baseDesc.offset());

--- a/pmlc/dialect/pxa/tests/dataflow_opt.mlir
+++ b/pmlc/dialect/pxa/tests/dataflow_opt.mlir
@@ -18,12 +18,14 @@ func @simple(%out : memref<2xf32>) -> memref<2xf32> {
 
 // CHECK-LABEL: func @grn
 func @grn(%arg0: memref<1x4x4x3xf16>) -> memref<1x4x4x3xf16> {
-  // CHECK: constant 1.001360e-05
   %cst = constant 1.001360e-05 : f16
-  // CHECK-NEXT: constant 0.0
   %cst_0 = constant 0.000000e+00 : f16
-  // CHECK-NEXT: constant 1.0
   %cst_1 = constant 1.000000e+00 : f16
+
+  // CHECK-DAG: constant 1.001360e-05
+  // CHECK-DAG: constant 0.0
+  // CHECK-DAG: constant 1.0
+
   // CHECK-NEXT: memref.alloc() : memref<1x4x4x1xf16>
   // CHECK-NEXT: memref.alloc() : memref<1x4x4x3xf16>
   %0 = memref.alloc() : memref<1x4x4x3xf16>


### PR DESCRIPTION
* Use `CHECK-DAG` for constants checks.
* Remove `EDSC` usage.

Related PR: https://github.com/plaidml/llvm-project/pull/40