### PR TITLE
Do cast to fix illegal inputs of GatherTree.

### DIFF
--- a/plaidml/bridge/openvino/ops/gather_tree.cpp
+++ b/plaidml/bridge/openvino/ops/gather_tree.cpp
@@ -40,8 +40,8 @@ Tensor GatherTree(Tensor step_ids, Tensor parent_idx, Tensor max_seq_len, Tensor
   // Add padding to update the whole PARENT_IDX value.
   Tensor index_time =
       edsl::index({edsl::TensorDim(MaxTime), edsl::TensorDim(BatchSize), edsl::TensorDim(BeamWidth)}, 0);
-  Tensor max_time = edsl::cast(Tensor(MaxTime), max_seq_len.dtype());
-  Tensor max_seq_len_in_beam = op::minimum(max_seq_len, max_time);
+  Tensor max_time = edsl::cast(Tensor(MaxTime), DType::INT32);
+  Tensor max_seq_len_in_beam = op::minimum(edsl::cast(max_seq_len, DType::INT32), max_time);
   Tensor parent_idx_filter = index_time - edsl::reshape(max_seq_len_in_beam, {1, BatchSize, 1});
   // Set padding value to unused index.
   Tensor index_beam = edsl::index({edsl::TensorDim(BatchSize), edsl::TensorDim(BeamWidth)}, 1);

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gather_tree.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gather_tree.cpp
@@ -19,8 +19,10 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 const std::vector<std::vector<size_t>> inputShapes = {
-    {5, 1, 10}, {1, 1, 10}, {20, 1, 10},
-    // {20, 20, 10},
+    {5, 1, 10},
+    {1, 1, 10},
+    {20, 1, 10},
+    {20, 20, 10},
 };
 
 const std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {


### PR DESCRIPTION
The inputs shall be integer values even their containers are float type, but the openvino tests will produce illegal inputs when we use CONSTANT type as secondaryInputType, add cast to solve this issue.