### PR TITLE
Lower relu -> TPP

### DIFF
--- a/plaidbench/CMakeLists.txt
+++ b/plaidbench/CMakeLists.txt
@@ -44,6 +44,8 @@ pml_py_library(
     plaidbench/networks/ops/conv2d.py
     plaidbench/networks/ops/dense.py
     plaidbench/networks/ops/op.py
+  DEPS
+    plaidml::bridge::keras::py
 )
 
 pml_py_wheel(

--- a/plaidbench/plaidbench/__init__.py
+++ b/plaidbench/plaidbench/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import pkg_resources
 try:
     __version__ = pkg_resources.get_distribution("plaidbench").version
@@ -37,56 +36,3 @@ SUPPORTED_NETWORKS = {
         'xception',
     ],
 }
-
-
-def make_parser():
-    # Create the parser outside of main() so the doc system can call this function
-    # and thereby generate a web page describing these options. See docs/index.rst.
-    parser = argparse.ArgumentParser()
-    plaidargs = parser.add_mutually_exclusive_group()
-    plaidargs.add_argument('--plaid', action='store_true', help="Use PlaidML as the backend.")
-    plaidargs.add_argument('--caffe2', action='store_true', help="Use Caffe2 as the backend.")
-    plaidargs.add_argument('--tf', action='store_true', help="Use TensorFlow as the backend.")
-    plaidargs.add_argument(
-        '--no-plaid',
-        action='store_true',
-        help="Use the non-PlaidML backend most appropriate to the chosen frontend")
-    frontendargs = parser.add_mutually_exclusive_group()
-    frontendargs.add_argument('--keras', action='store_true', help='Use Keras as the frontend')
-    parser.add_argument('--fp16',
-                        action='store_true',
-                        help="Use half-precision floats, setting floatx='float16'.")
-    parser.add_argument('-v',
-                        '--verbose',
-                        action='count',
-                        default=0,
-                        help="Logging verbosity level (0..4).")
-    parser.add_argument('--result',
-                        default='/tmp/plaidbench_results',
-                        help="Destination directory for results output.")
-    parser.add_argument('--callgrind',
-                        action='store_true',
-                        help="Invoke callgrind during timing runs.")
-    parser.add_argument('--no-warmup', action='store_true', help="Skip the warmup runs.")
-    parser.add_argument('-n',
-                        '--examples',
-                        type=int,
-                        default=None,
-                        help="Number of examples to use.")
-    parser.add_argument('--epochs', type=int, default=1, help="Number of epochs per test.")
-    parser.add_argument('--batch-size', type=int, default=1)
-    parser.add_argument('--train',
-                        action='store_true',
-                        help="Measure training performance instead of inference.")
-    parser.add_argument('--blanket-run',
-                        action='store_true',
-                        help="Run all networks at a range of batch sizes, ignoring the "
-                        "--batch-size and --examples options and the choice of network.")
-    parser.add_argument('--print-stacktraces',
-                        action='store_true',
-                        help="Print a stack trace if an exception occurs.")
-    all_supported_networks = set()
-    for _, networks in SUPPORTED_NETWORKS.items():
-        all_supported_networks = all_supported_networks.union(networks)
-    parser.add_argument('module', choices=all_supported_networks, metavar='network')
-    return parser

--- a/plaidml/bridge/keras/__init__.py
+++ b/plaidml/bridge/keras/__init__.py
@@ -1333,7 +1333,7 @@ def random_uniform_variable(shape, low, high, dtype=None, name=None, seed=None):
 
 
 @_log_call
-def relu(x, alpha=None, max_value=None, threshold=0.):
+def relu(x, alpha=None, max_value=None, threshold=0.0):
     return _KerasNode('relu',
                       tensor=plaidml_op.relu(x.tensor, alpha, max_value, threshold),
                       operands=[x])

--- a/plaidml/op/__init__.py
+++ b/plaidml/op/__init__.py
@@ -217,7 +217,7 @@ def pool(
     ]).as_tensor()
 
 
-def relu(x, alpha=None, max_value=None, threshold=0.):
+def relu(x, alpha=None, max_value=None, threshold=None):
     return op('relu', [x, alpha, max_value, threshold]).as_tensor()
 
 
@@ -258,8 +258,10 @@ def slice_of(x, slices):
 def softmax(x, axis=None):
     return op('softmax', [x, axis]).as_tensor()
 
+
 def sort(x, axis=None, direction=edsl.SortDirection.ASC):
-    return op('sort', [x, axis]).as_tensor()
+    return op('sort', [x, axis, direction]).as_tensor()
+
 
 def spatial_padding(x, lo_pads, hi_pads, data_layout):
     return op("spatial_padding", [x, lo_pads, hi_pads, data_layout]).as_tensor()

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2554,19 +2554,18 @@ Value relu(const Value& value) {
   if (args.size() != 4) {
     throw std::runtime_error("relu expects 4 arguments");
   }
-  auto I = args[0].as_tensor();
-  auto alpha = args[1];
-  auto max_value = args[2];
-  auto threshold = args[3].as_float();
-  Tensor A;
-  if (alpha.is_none()) {
-    A = Tensor(0.0);
-  } else {
-    A = alpha.as_tensor();
+  Tensor I = args[0].as_tensor();
+  Value alpha = args[1];
+  Value max_value = args[2];
+  Value threshold = args[3];
+  double T = threshold.is_none() ? 0.0 : threshold.as_float();
+  if ((alpha.is_none() || (alpha.is_float() && alpha.as_float() == 0.0)) && max_value.is_none() && T == 0.0) {
+    return Value{edsl::relu(I)};
   }
-  auto O = select(I < threshold, edsl::cast(A * (I - threshold), I.dtype()), I);
+  Tensor A = alpha.is_none() ? Tensor(0.0) : alpha.as_tensor();
+  Tensor O = select(I < T, edsl::cast(A * (I - T), I.dtype()), I);
   if (!max_value.is_none()) {
-    auto M = cast(max_value.as_tensor(), I.dtype());
+    Tensor M = cast(max_value.as_tensor(), I.dtype());
     O = select(O < M, O, M);
   }
   return Value{O};

--- a/plaidml/op/op.h
+++ b/plaidml/op/op.h
@@ -799,7 +799,7 @@ class relu {
   }
 
   relu& threshold(double threshold) {
-    threshold_ = threshold;
+    threshold_ = edsl::Value(threshold);
     return *this;
   }
 
@@ -812,7 +812,7 @@ class relu {
   edsl::Tensor I_;
   edsl::Tensor alpha_;
   edsl::Tensor max_value_;
-  double threshold_ = 0.0;
+  edsl::Value threshold_;
 };
 
 inline edsl::Tensor reorg_yolo(const edsl::Tensor& I, int stride, bool decrease, const std::string& layout = "NCHW") {

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -1282,6 +1282,7 @@ struct LowerTileToPXAPass : public LowerTileToPXABase<LowerTileToPXAPass> {
         EltwiseOpConversion<tile::LogicalNotOp, LogicalNotOp>,
         EltwiseOpConversion<tile::LogicalOrOp, LogicalOp<mlir::OrOp>>,
         EltwiseOpConversion<tile::LogicalXorOp, LogicalOp<mlir::XOrOp>>,
+        EltwiseOpConversion<tile::ReluOp, StdOp<stdx::ReluOp>>,
         EltwiseOpConversion<tile::SelectOp, SelectOp>,
         EltwiseOpConversion<tile::IdentOp, FirstOperand>>(&getContext());
 

--- a/pmlc/dialect/layer/ir/ops.cc
+++ b/pmlc/dialect/layer/ir/ops.cc
@@ -18,11 +18,9 @@ using llvm::SmallVector;
 Block *BoxOp::getBody() { return &body().front(); }
 
 void BoxOp::build(OpBuilder &builder, OperationState &result, StringRef op,
-                  ArrayRef<Value> operands, ArrayRef<Type> resultTypes,
+                  ValueRange operands, TypeRange resultTypes,
                   DictionaryAttr attrs) {
-  for (Type type : resultTypes) {
-    result.types.push_back(type);
-  }
+  result.addTypes(resultTypes);
   result.addOperands(operands);
   result.addAttribute("op", builder.getStringAttr(op));
   result.addAttribute("attrs", attrs);
@@ -61,7 +59,7 @@ ParseResult parseBoxOp(OpAsmParser &parser, OperationState &result) {
   auto loc = parser.getCurrentLocation();
   if (parser.parseAttribute(opName, "op", result.attributes) ||
       parser.parseRegionArgumentList(inner, OpAsmParser::Delimiter::Paren) ||
-      parser.parseEqual() || //
+      parser.parseEqual() ||
       parser.parseOperandList(outer, OpAsmParser::Delimiter::Paren) ||
       parser.parseColonType(funcType) ||
       parser.resolveOperands(outer, funcType.getInputs(), loc,

--- a/pmlc/dialect/layer/ir/ops.td
+++ b/pmlc/dialect/layer/ir/ops.td
@@ -30,8 +30,8 @@ def BoxOp : LayerOp<"box", [IsolatedFromAbove]> {
   let builders = [
     OpBuilder<(ins
       "mlir::StringRef":$op,
-      "mlir::ArrayRef<mlir::Value>":$operands,
-      "mlir::ArrayRef<mlir::Type>":$resultTypes,
+      "mlir::ValueRange":$operands,
+      "mlir::TypeRange":$resultTypes,
       "mlir::DictionaryAttr":$attrs
     )>
   ];

--- a/pmlc/dialect/pxa/ir/interfaces.td
+++ b/pmlc/dialect/pxa/ir/interfaces.td
@@ -21,10 +21,10 @@ def PxaReadOpInterface : PxaOpInterface<"PxaReadOpInterface"> {
       /*retTy=*/"::mlir::Value",
       /*methodName=*/"getMemRef",
       /*args=*/(ins),
-      /*methodBody*/[{}],
-      /*defaultImplementation=*/ [{
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
         ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
-        return op.getOperand(op.getMemRefOperandIndex());
+        return op.getMemRef();
       }]
     >,
     InterfaceMethod<
@@ -90,7 +90,7 @@ def PxaReduceOpInterface : PxaOpInterface<"PxaReduceOpInterface"> {
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
-        return op.getOperand(op.getMemRefOperandIndex());
+        return op.getMemRef();
       }]
     >,
     InterfaceMethod<
@@ -122,7 +122,7 @@ def PxaReduceOpInterface : PxaOpInterface<"PxaReduceOpInterface"> {
       /*retTy=*/"::mlir::AffineMap",
       /*methodName=*/"getAffineMap",
       /*args=*/(ins),
-      /*methodName=*/[{}],
+      /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         ConcreteOp op = ::mlir::cast<ConcreteOp>(this->getOperation());
         return op.getAffineMapAttr().getValue();

--- a/pmlc/dialect/pxa/ir/ops.td
+++ b/pmlc/dialect/pxa/ir/ops.td
@@ -34,15 +34,11 @@ class PxaReduceOpBase<string mnemonic, list<OpTrait> traits = []> :
 
   code extraClassDeclarationBase = [{
     mlir::Value getMemRef() { return memref(); }
-    unsigned getMemRefOperandIndex() { return 1; }
-    void setMemRef(mlir::Value value) { setOperand(getMemRefOperandIndex(), value); }
     mlir::MemRefType getMemRefType() { return memref().getType().cast<mlir::MemRefType>(); }
     mlir::AffineMap getAffineMap() { return map(); }
     operand_range getMapOperands() { return idxs(); }
     static mlir::StringRef getMapAttrName() { return "map"; }
-    mlir::AffineMapAttr getAffineMapAttr() {
-      return (*this)->getAttr(getMapAttrName()).cast<mlir::AffineMapAttr>();
-    }
+    mlir::AffineMapAttr getAffineMapAttr() { return mapAttr(); }
     mlir::AtomicRMWKind getAgg() { return agg(); }
   }];
 }
@@ -144,19 +140,15 @@ class PxaLoadOpBase<string mnemonic, list<OpTrait> traits = []> :
         MemRefsNormalizable])> {
   let arguments = (ins
     AnyMemRef:$memref,
-    Variadic<Index>:$indices
+    AffineMapAttr:$map,
+    Variadic<Index>:$idxs
   );
 
   code extraClassDeclarationBase = [{
-    /// Returns the operand index of the memref.
-    unsigned getMemRefOperandIndex() { return 0; }
-
-    void setMemRef(mlir::Value value) { setOperand(getMemRefOperandIndex(), value); }
+    mlir::Value getMemRef() { return memref(); }
 
     /// Returns the affine map used to index the memref for this operation.
-    mlir::AffineMapAttr getAffineMapAttr() {
-      return (*this)->getAttr(getMapAttrName()).cast<mlir::AffineMapAttr>();
-    }
+    mlir::AffineMapAttr getAffineMapAttr() { return mapAttr(); }
 
     static mlir::StringRef getMapAttrName() { return "map"; }
   }];

--- a/pmlc/dialect/pxa/transforms/layout_utils.cc
+++ b/pmlc/dialect/pxa/transforms/layout_utils.cc
@@ -241,7 +241,7 @@ void LayoutConverter::convertPxaLoadOp(PxaLoadOp loadOp) {
 
   mlir::AffineMap newMap = transformAffineMap(loadOp.getAffineMap());
   mlir::Value loadRes = builder.create<PxaLoadOp>(
-      loadOp.getLoc(), loadOp.getMemRef(), newMap, loadOp.indices());
+      loadOp.getLoc(), loadOp.getMemRef(), newMap, loadOp.idxs());
   loadOp.replaceAllUsesWith(loadRes);
   loadOp.erase();
 }
@@ -253,7 +253,7 @@ void LayoutConverter::convertPxaVectorLoadOp(PxaVectorLoadOp loadOp) {
   mlir::VectorType newVectorType = transformVectorType(loadOp.getVectorType());
   mlir::Value loadRes = builder.create<PxaVectorLoadOp>(
       loadOp.getLoc(), newVectorType, loadOp.getMemRef(), newMap,
-      loadOp.indices());
+      loadOp.idxs());
   loadOp.replaceAllUsesWith(loadRes);
   loadOp.erase();
 }

--- a/pmlc/dialect/stdx/ir/ops.td
+++ b/pmlc/dialect/stdx/ir/ops.td
@@ -94,6 +94,10 @@ def PowOp : StdX_Op<"pow"> {
   let verifier = ?;
 }
 
+def ReluOp : StdX_UnaryFuncOp<"relu"> {
+  let summary = "ReLU operation";
+}
+
 def RoundOp : StdX_UnaryFuncOp<"round"> {
   let summary = "round to nearest integer";
 }

--- a/pmlc/dialect/tile/ir/ops.cc
+++ b/pmlc/dialect/tile/ir/ops.cc
@@ -91,7 +91,7 @@ unsigned ContractionOp::getNumTensors(CombinationKind combo) {
 }
 
 void ContractionOp::build(OpBuilder &builder, OperationState &result,
-                          Type resultType, Value init, ArrayRef<Value> tensors,
+                          Type resultType, Value init, ValueRange tensors,
                           AggregationKind agg, CombinationKind combo,
                           AffineMap sink, ArrayRef<AffineMap> srcs,
                           IntegerSet cons, StringRef name) {

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -40,7 +40,7 @@ def ContractionOp : TileOp<"contract", [
     OpBuilder<(ins
       "mlir::Type":$resultType,
       "mlir::Value":$init,
-      "mlir::ArrayRef<mlir::Value>":$tensors,
+      "mlir::ValueRange":$tensors,
       "util::AggregationKind":$agg,
       "util::CombinationKind":$combo,
       "mlir::AffineMap":$sink,

--- a/pmlc/target/x86/passes.h
+++ b/pmlc/target/x86/passes.h
@@ -22,6 +22,8 @@ std::unique_ptr<mlir::Pass> createOpenMPWorkaroundPass();
 
 std::unique_ptr<mlir::Pass> createPRNGLinkingPass();
 
+std::unique_ptr<mlir::Pass> createTppPatternsPass();
+
 std::unique_ptr<mlir::Pass> createTraceLinkingPass();
 
 std::unique_ptr<mlir::Pass> createXSMMLoweringPass();

--- a/pmlc/target/x86/passes.td
+++ b/pmlc/target/x86/passes.td
@@ -32,6 +32,11 @@ def PRNGLinking : Pass<"x86-prng-linking", "mlir::ModuleOp"> {
   let constructor = "pmlc::target::x86::createPRNGLinkingPass()";
 }
 
+def TppPatterns : FunctionPass<"x86-tpp-patterns"> {
+  let summary = "Convert TPP patterns to pxa.generic ops";
+  let constructor = "pmlc::target::x86::createTppPatternsPass()";
+}
+
 def TraceLinking : Pass<"x86-trace-linking", "mlir::ModuleOp"> {
   let summary = "Link trace ops to runtime functions";
   let constructor = "pmlc::target::x86::createTraceLinkingPass()";

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -288,6 +288,8 @@ void pipelineBuilder(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   pm.addPass(createPRNGLinkingPass());
+  pm.addNestedPass<FuncOp>(createTppPatternsPass());
+
   pm.addPass(createLowerPXAToAffinePass());
   pm.addPass(createLoopInvariantCodeMotionPass());
   pm.addPass(createCanonicalizerPass());

--- a/pmlc/target/x86/tests/tpp_generic.mlir
+++ b/pmlc/target/x86/tests/tpp_generic.mlir
@@ -1,0 +1,47 @@
+// RUN: pmlc-opt -x86-tpp-patterns %s | FileCheck %s
+
+func @relu(%I: memref<10x20xf32>, %O: memref<10x20xf32>) -> memref<10x20xf32> {
+  // CHECK: affine.parallel
+  %0 = affine.parallel (%ox, %oy) = (0, 0) to (5, 10) reduce ("assign") -> (memref<10x20xf32>) {
+    // CHECK: pxa.generic (%{{.*}}[%{{.*}} * 2, %{{.*}} * 2]: #{{.*}}) = @tpp_relu(%{{.*}}[%{{.*}} * 2, %{{.*}} * 2]: #{{.*}}) tile: [2, 2] : (memref<10x20xf32>) -> memref<10x20xf32>
+    %1 = affine.parallel (%ix, %iy) = (0, 0) to (2, 2) reduce ("assign") -> (memref<10x20xf32>) {
+      %2 = pxa.load %I[%ix + %ox * 2, %iy + %oy * 2] : memref<10x20xf32>
+      %3 = stdx.relu(%2) : (f32) -> f32
+      %4 = pxa.reduce assign %3, %O[%ix + %ox * 2, %iy + %oy * 2] : memref<10x20xf32>
+      affine.yield %4 : memref<10x20xf32>
+    }
+    affine.yield %1 : memref<10x20xf32>
+  }
+  return %0 : memref<10x20xf32>
+}
+
+func @resnet_2d(%I: memref<1x7x1x64xf32>, %O: memref<1x7x7x512xf32>) -> memref<1x7x7x512xf32> {
+  // CHECK: affine.parallel
+  %257 = affine.parallel (%arg3, %arg4) = (0, 0) to (7, 8) reduce ("assign") -> (memref<1x7x7x512xf32>) {
+    // CHECK: pxa.generic (%{{.*}}[0, 0, %{{.*}}, %{{.*}} * 64]: #{{.*}}) = @tpp_relu(%{{.*}}[0, 0, 0, 0]: #{{.*}}) tile: [7, 64] : (memref<1x7x1x64xf32>) -> memref<1x7x7x512xf32>
+    %297 = affine.parallel (%arg113, %arg114) = (0, 0) to (7, 64) reduce ("assign") -> (memref<1x7x7x512xf32>) {
+      %298 = pxa.load %I[0, %arg113, 0, %arg114] : memref<1x7x1x64xf32>
+      %299 = stdx.relu(%298) : (f32) -> f32
+      %300 = pxa.reduce assign %299, %O[0, %arg113, %arg3, %arg114 + %arg4 * 64] : memref<1x7x7x512xf32>
+      affine.yield %300 : memref<1x7x7x512xf32>
+    }
+    affine.yield %297 : memref<1x7x7x512xf32>
+  }
+  return %257 : memref<1x7x7x512xf32>
+}
+
+func @resnet_3d(%I: memref<1x112x16x8xf32>, %O: memref<1x112x16x8xf32>) -> memref<1x112x16x8xf32> {
+    // CHECK: affine.parallel
+    %8 = affine.parallel (%arg111, %arg112) = (0, 0) to (7, 8) reduce ("assign") -> (memref<1x112x16x8xf32>) {
+      // CHECK: affine.parallel
+      %298 = affine.parallel (%arg113, %arg114, %arg115) = (0, 0, 0) to (112, 16, 8) reduce ("assign") -> (memref<1x112x16x8xf32>) {
+        %300 = pxa.load %I[0, %arg113, %arg114, %arg115] : memref<1x112x16x8xf32>
+        // CHECK: stdx.relu
+        %301 = stdx.relu(%300) : (f32) -> f32
+        %302 = pxa.reduce assign %301, %O[0, %arg113, %arg114, %arg115] : memref<1x112x16x8xf32>
+        affine.yield %302 : memref<1x112x16x8xf32>
+      }
+      affine.yield %298 : memref<1x112x16x8xf32>
+    }
+    return %8 : memref<1x112x16x8xf32>
+}

--- a/pmlc/target/x86/tests/xsmm_lowering.mlir
+++ b/pmlc/target/x86/tests/xsmm_lowering.mlir
@@ -47,7 +47,7 @@ func @res2a_branch2a(%I: memref<1x56x56x64xf32>, %K: memref<1x1x64x64xf32>, %O: 
 // CHECK-LABEL: func @relu
 func @relu(%I: memref<1x56x56x64xf32>, %O: memref<1x56x56x64xf32>) -> memref<1x56x56x64xf32> {
   %0 = affine.parallel (%x, %y) = (0, 0) to (56, 56) step (14, 1) reduce ("assign") -> (memref<1x56x56x64xf32>) {
-    // CHECK: xsmm.unary.dispatch RELU(memref<1x56x56x64xf32>, [4, 64], 3584, 3584) : (memref<1x56x56x64xf32>) -> memref<1x56x56x64xf32>
+    // CHECK: xsmm.unary.dispatch RELU(f32, [4, 64], 3584, 3584) : (f32) -> f32
     // CHECK: affine.for
     // CHECK:   affine.for
     // CHECK:     xsmm.unary.invoke


### PR DESCRIPTION
* Add special case to oplib relu impl to use new eDSL primitive.
* Add lowering: `tile.relu -> stdx.relu`
* Add `-x86-tpp-patterns` pass to convert `stdx.relu` to `pxa.generic` when possible.
* Add fallback lowering for `stdx.relu -> std.cmpf, std.select` when TPP patterns fail.
