### PR TITLE
Add AlgebraicOpt pass

### DIFF
--- a/pmlc/dialect/tile/tests/algebraic_opt.mlir
+++ b/pmlc/dialect/tile/tests/algebraic_opt.mlir
@@ -1,0 +1,18 @@
+// RUN: pmlc-opt -tile-algebraic-opt -cse -split-input-file %s | FileCheck %s
+
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 * 2 + d4, d2 * 2 + d5, d6)>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+
+func @add_init(%I: tensor<1x230x230x3xf32>, %K: tensor<7x7x3x64xf32>, %B: tensor<64xf32>) -> tensor<1x112x112x64xf32> {
+  %zero = tile.constant(0.0 : f64) : tensor<f32>
+  %conv1 = tile.contract add, mul, %zero, %I, %K {sink = #map2, srcs = [#map3, #map4]} : tensor<f32>, tensor<1x230x230x3xf32>, tensor<7x7x3x64xf32> -> tensor<1x112x112x64xf32>
+  %1 = tile.add %conv1, %B : (tensor<1x112x112x64xf32>, tensor<64xf32>) -> tensor<1x112x112x64xf32>
+  %2 = tile.relu %1 : (tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+  return %2 : tensor<1x112x112x64xf32>
+}
+
+// CHECK-LABEL: func @add_init
+//  CHECK-SAME: (%[[I:.*]]: tensor<1x230x230x3xf32>, %[[K:.*]]: tensor<7x7x3x64xf32>, %[[B:.*]]: tensor<64xf32>)
+//       CHECK: %[[O:.*]] = tile.contract add, mul, %[[B]], %[[I]], %[[K]]
+//  CHECK-NEXT: tile.relu %[[O]]

--- a/pmlc/dialect/tile/transforms/CMakeLists.txt
+++ b/pmlc/dialect/tile/transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ pml_cc_library(
     expand_reshape.h
     passes.h
   SRCS
+    algebraic_opt.cc
     contraction.cc
     expand_reshape.cc
     materialize.cc

--- a/pmlc/dialect/tile/transforms/algebraic_opt.cc
+++ b/pmlc/dialect/tile/transforms/algebraic_opt.cc
@@ -1,0 +1,79 @@
+// Copyright 2020, Intel Corporation
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "pmlc/dialect/tile/ir/ops.h"
+#include "pmlc/dialect/tile/transforms/pass_detail.h"
+#include "pmlc/dialect/tile/transforms/passes.h"
+#include "pmlc/util/logging.h"
+
+using namespace mlir; // NOLINT
+
+namespace pmlc::dialect::tile {
+
+namespace {
+
+// From:
+// %zero = tile.constant(0.0 : f64)
+// %0 = tile.contract add, mul, %zero, %I, %K
+// %1 = tile.add %0, %B
+// %2 = tile.relu %1
+// Into:
+// %0 = tile.contract add, mul, %B, %I, %K
+// %2 = tile.relu %0
+struct AddInitPattern final : public OpRewritePattern<AddOp> {
+  using OpRewritePattern<AddOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(AddOp op, PatternRewriter &rewriter) const {
+    if (ContractionOp contractOp =
+            dyn_cast_or_null<ContractionOp>(op.lhs().getDefiningOp())) {
+      if (!contractOp->hasOneUse())
+        return failure();
+      if (isa_and_nonnull<ContractionOp>(op.rhs().getDefiningOp()))
+        return failure();
+      if (op.result().getType() != contractOp.result().getType())
+        return failure();
+
+      FloatAttr init;
+      if (!matchPattern(contractOp.init(), m_Constant(&init)))
+        return failure();
+      if (init.getValueAsDouble() != 0.0)
+        return failure();
+
+      contractOp.setOperand(0, op.rhs());
+      rewriter.replaceOp(op, contractOp.result());
+
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct AlgebraicOptPass : public AlgebraicOptBase<AlgebraicOptPass> {
+  void runOnFunction() final {
+    FuncOp op = getFunction();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.insert<AddInitPattern>(context);
+
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      op.emitOpError("AlgebraicOpt pass failure.");
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createAlgebraicOptPass() {
+  return std::make_unique<AlgebraicOptPass>();
+}
+
+} // namespace pmlc::dialect::tile

--- a/pmlc/dialect/tile/transforms/passes.h
+++ b/pmlc/dialect/tile/transforms/passes.h
@@ -10,6 +10,8 @@ class Pass;
 
 namespace pmlc::dialect::tile {
 
+std::unique_ptr<mlir::Pass> createAlgebraicOptPass();
+
 std::unique_ptr<mlir::Pass> createComputeBoundsPass();
 
 std::unique_ptr<mlir::Pass> createExpandReshapePass();

--- a/pmlc/dialect/tile/transforms/passes.td
+++ b/pmlc/dialect/tile/transforms/passes.td
@@ -3,6 +3,11 @@
 
 include "mlir/Pass/PassBase.td"
 
+def AlgebraicOpt : FunctionPass<"tile-algebraic-opt"> {
+  let summary = "Algebraic optimizations";
+  let constructor = "pmlc::dialect::tile::createAlgebraicOptPass()";
+}
+
 def ComputeBounds : FunctionPass<"tile-compute-bounds"> {
   let summary = "Compute bounds for contractions";
   let constructor = "pmlc::dialect::tile::createComputeBoundsPass()";

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -191,6 +191,7 @@ void pipelineBuilderStage1(OpPassManager &pm, const Options &options) {
   IVLOG(1, "Number of threads: " << maxThreads);
 
   pm.addNestedPass<FuncOp>(layer::createInlineLayersPass());
+  pm.addNestedPass<FuncOp>(tile::createAlgebraicOptPass());
   pm.addNestedPass<FuncOp>(tile::createComputeBoundsPass());
   pm.addPass(tile::createSplitMainPass());
   pm.addPass(transforms::createHoistingPass());


### PR DESCRIPTION
First pattern to be implemented does the following.

From:
```
%zero = tile.constant(0.0 : f64)
%0 = tile.contract add, mul, %zero, %I, %K
%1 = tile.add %0, %B
%2 = tile.relu %1
```

Into:
```
%0 = tile.contract add, mul, %B, %I, %K
%2 = tile.relu %0
```
