### PR TITLE
Convert dense tensor constant op to global memref ops

### DIFF
--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -211,7 +211,7 @@ struct GenericOpConversion : public OpConversionPattern<GenericOp> {
   LogicalResult
   matchAndRewrite(GenericOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    GenericOpAdaptor adaptor(operands, op.getOperation()->getAttrDictionary());
+    GenericOpAdaptor adaptor(operands, op->getAttrDictionary());
     auto inputs = adaptor.inputs();
     auto outputs = adaptor.outputs();
     auto idxMapAttrs = adaptor.indexing_maps().getValue();
@@ -353,7 +353,7 @@ struct IndexOpConversion : public OpConversionPattern<IndexOp> {
   LogicalResult
   matchAndRewrite(IndexOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    auto idxs = op.getOperation()->getBlock()->getArguments();
+    auto idxs = op->getBlock()->getArguments();
     op.replaceAllUsesWith(idxs[op.dim()]);
     rewriter.eraseOp(op);
     return success();
@@ -366,8 +366,7 @@ struct InitTensorOpConversion : public OpConversionPattern<InitTensorOp> {
   LogicalResult
   matchAndRewrite(InitTensorOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    BufferAllocator allocResult(rewriter, op.getOperation(),
-                                op.result().getType());
+    BufferAllocator allocResult(rewriter, op, op.result().getType());
     op.replaceAllUsesWith(allocResult.resultMemRef);
     rewriter.eraseOp(op);
     return success();

--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -17,8 +17,6 @@ using namespace mlir::linalg; // NOLINT
 
 namespace {
 
-static int constCount = 0;
-
 static RankedTensorType getRankedTensorType(Type type) {
   if (auto rankedTensorType = type.dyn_cast<RankedTensorType>()) {
     return rankedTensorType;
@@ -142,6 +140,7 @@ struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
   LogicalResult
   matchAndRewrite(ConstantOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
+    static int constCount = 0;
     auto origValue = op.getValue();
     if (auto origType = origValue.getType().dyn_cast<ShapedType>()) {
       LinalgToPXATypeConverter typeConverter;

--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -145,7 +145,7 @@ struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
     if (auto origType = origValue.getType().dyn_cast<ShapedType>()) {
       LinalgToPXATypeConverter typeConverter;
       auto newType = typeConverter.convertType(origType);
-      auto name = llvm::formatv("cst_{0}", constCount++).str();
+      auto name = llvm::formatv("cst_memref_{0}", constCount++).str();
       auto funcOp = op->getParentOfType<FuncOp>();
       rewriter.setInsertionPoint(funcOp);
       auto globalOp = rewriter.create<memref::GlobalOp>(

--- a/pmlc/conversion/linalg_to_pxa/passes.td
+++ b/pmlc/conversion/linalg_to_pxa/passes.td
@@ -8,7 +8,6 @@ def LowerLinalgToPXA : Pass<"convert-linalg-to-pxa", "mlir::ModuleOp"> {
   let constructor = "pmlc::conversion::linalg_to_pxa::createLowerLinalgToPXAPass()";
   let dependentDialects = [
     "mlir::AffineDialect",
-    "mlir::linalg::LinalgDialect",
     "mlir::math::MathDialect",
     "mlir::memref::MemRefDialect",
     "mlir::scf::SCFDialect",

--- a/pmlc/conversion/linalg_to_pxa/test/constant.mlir
+++ b/pmlc/conversion/linalg_to_pxa/test/constant.mlir
@@ -1,0 +1,17 @@
+// RUN: pmlc-opt --convert-linalg-to-pxa %s | FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2, d3) -> ()>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>  
+func @main(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x224x224x3xf32> {
+  %cst = constant dense<"0x00000000"> : tensor<f32>
+  %0 = linalg.init_tensor [1, 224, 224, 3] : tensor<1x224x224x3xf32>
+  %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst : tensor<f32>) outs(%0 : tensor<1x224x224x3xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+    linalg.yield %arg1 : f32
+  } -> tensor<1x224x224x3xf32>
+  return %1 : tensor<1x224x224x3xf32>
+}
+
+// CHECK: memref.global "private" constant @[[cst:.*]] : memref<f32> = dense<0.000000e+00>
+// CHECK: func @main
+// CHECK: memref.get_global @[[cst]] : memref<f32>


### PR DESCRIPTION
ConstantOp with MemRefType result can't take a dense tensor. So we should add a global memref outside the function, and a GetGlobalOp where we need the memref.