### PR TITLE
Adding support for installing plaidml via pip --user

### DIFF
--- a/plaidml/__init__.py
+++ b/plaidml/__init__.py
@@ -50,6 +50,7 @@ import plaidml.library
 import plaidml.settings
 import platform
 import sys
+import site
 import threading
 import traceback
 import uuid
@@ -178,6 +179,8 @@ class _Library(plaidml.library.Library):
             lib = load_library('libplaidml.dylib', ['lib'])
         else:
             prefixes = [sys.exec_prefix, os.path.join(sys.exec_prefix, 'local')]
+            if(site.USER_SITE == os.path.commonprefix([__file__, site.USER_SITE])):
+                prefixes = [site.USER_BASE]
             lib = load_library('libplaidml.so', ['lib'], prefixes)
 
         super(_Library, self).__init__(lib, logger=logger)

--- a/plaidml/settings.py
+++ b/plaidml/settings.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import site
 import uuid
 
 import plaidml.exceptions
@@ -13,6 +14,8 @@ def _find_config(name):
         sys.prefix,
         os.path.join(sys.prefix, 'local'),
     ]
+    if(site.USER_SITE == os.path.commonprefix([__file__, site.USER_SITE])):
+        prefixes = [site.USER_BASE]
     for prefix in prefixes:
         cfg_path = os.path.join(prefix, 'share', 'plaidml', name)
         if os.path.exists(cfg_path):


### PR DESCRIPTION
After installing to the home directory via pip on Linux, PlaidML was having trouble locating the configuration and shared libraries. This change uses the site module to locate the correct directories. The site.USER_SITE variable should also work for OSX and Windows variants user installations, but I don't have test systems for those so I haven't made those changes.