### PR TITLE
Support for scalar broadcast ops stenciling for tpp

### DIFF
--- a/cmake/third_party/xsmm.cmake
+++ b/cmake/third_party/xsmm.cmake
@@ -1,8 +1,8 @@
 message("Fetching xsmm")
 FetchContent_Declare(
   xsmm
-  URL      https://github.com/hfp/libxsmm/archive/8b32567d69a6c0e9e8b982d47c8514185d98eaa8.zip
-  URL_HASH SHA256=ba1da6a1f9db48bf1eb2ee77c451cb2a56528008a67f12aa34e638160bf6c9eb
+  URL      https://github.com/hfp/libxsmm/archive/011dfb33d01e97274f70aac73f40eb68957f6e32.zip
+  URL_HASH SHA256=a1a36ab2421d6d433f15b5656cef20126f066cdc7e95cb6354fbdfdf49027695
 )
 
 FetchContent_GetProperties(xsmm)

--- a/cmake/third_party/xsmm.cmake
+++ b/cmake/third_party/xsmm.cmake
@@ -1,7 +1,7 @@
 message("Fetching xsmm")
 FetchContent_Declare(
   xsmm
-  URL      https://github.com/hfp/libxsmm/archive/011dfb33d01e97274f70aac73f40eb68957f6e32.zip
+  URL      https://github.com/libxsmm/libxsmm/archive/011dfb33d01e97274f70aac73f40eb68957f6e32.zip
   URL_HASH SHA256=a1a36ab2421d6d433f15b5656cef20126f066cdc7e95cb6354fbdfdf49027695
 )
 

--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -192,9 +192,31 @@ struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
       rewriter.setInsertionPoint(op);
       rewriter.replaceOpWithNewOp<memref::GetGlobalOp>(op, newType,
                                                        globalOp.sym_name());
-      return success();
+    } else {
+      Type elementType = origValue.getType();
+      MemRefType memRefType = MemRefType::get({}, elementType);
+      auto shapeType = RankedTensorType::get({}, elementType);
+      std::string funcName =
+          llvm::formatv("cst_scalar_memref_{0}", constCount++).str();
+
+      auto funcOp = op->getParentOfType<FuncOp>();
+      rewriter.setInsertionPoint(funcOp);
+
+      auto globalOp = rewriter.create<memref::GlobalOp>(
+          funcOp.getLoc(),
+          /*sym_name=*/funcName,
+          /*sym_visibility=*/rewriter.getStringAttr("private"),
+          /*type=*/memRefType,
+          /*initial_value=*/
+          DenseElementsAttr::get(shapeType, {origValue}),
+          /*constant=*/true);
+
+      rewriter.setInsertionPoint(op);
+
+      rewriter.replaceOpWithNewOp<memref::GetGlobalOp>(op, memRefType,
+                                                       globalOp.sym_name());
     }
-    return failure();
+    return success();
   }
 };
 
@@ -476,8 +498,12 @@ struct LowerLinalgToPXAPass
     target.addDynamicallyLegalOp<stdx::ClosureOp>([&](stdx::ClosureOp op) {
       return converter.isSignatureLegal(op.getType());
     });
+
+    // target.addDynamicallyLegalOp<ConstantOp>(
+    //    [&](ConstantOp op) { return !op.getType().isa<TensorType>(); });
+
     target.addDynamicallyLegalOp<ConstantOp>(
-        [&](ConstantOp op) { return !op.getType().isa<TensorType>(); });
+        [&](ConstantOp op) { return false; });
 
     RewritePatternSet patterns(&getContext());
     patterns.insert<ConstantOpConversion,              //

--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -217,7 +217,6 @@ struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
       auto getGlobalOp = rewriter.create<memref::GetGlobalOp>(
           op.getLoc(), memRefType, globalOp.sym_name());
       SmallVector<Value, 8> idxs;
-      // idxs[0] = rewriter.create<mlir::ConstantIndexOp>(op.getLoc(), 0);
       auto loadOp =
           rewriter.create<pxa::PxaLoadOp>(op.getLoc(), getGlobalOp, idxs);
       op.replaceAllUsesWith(loadOp.getResult());

--- a/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
+++ b/pmlc/conversion/linalg_to_pxa/linalg_to_pxa.cc
@@ -193,6 +193,38 @@ struct ConstantOpConversion : public OpConversionPattern<ConstantOp> {
       rewriter.replaceOpWithNewOp<memref::GetGlobalOp>(op, newType,
                                                        globalOp.sym_name());
       return success();
+    } else if (origValue.getType().isF32()) {
+      Type elementType = origValue.getType();
+      MemRefType memRefType = MemRefType::get({}, elementType);
+      auto shapeType = RankedTensorType::get({}, elementType);
+      std::string funcName =
+          llvm::formatv("cst_scalar_memref_{0}", constCount++).str();
+
+      auto funcOp = op->getParentOfType<FuncOp>();
+      rewriter.setInsertionPoint(funcOp);
+
+      auto globalOp = rewriter.create<memref::GlobalOp>(
+          funcOp.getLoc(),
+          /*sym_name=*/funcName,
+          /*sym_visibility=*/rewriter.getStringAttr("private"),
+          /*type=*/memRefType,
+          /*initial_value=*/
+          DenseElementsAttr::get(shapeType, {origValue}),
+          /*constant=*/true);
+
+      rewriter.setInsertionPoint(op);
+
+      auto getGlobalOp = rewriter.create<memref::GetGlobalOp>(
+          op.getLoc(), memRefType, globalOp.sym_name());
+      SmallVector<Value, 8> idxs;
+      // idxs[0] = rewriter.create<mlir::ConstantIndexOp>(op.getLoc(), 0);
+      auto loadOp =
+          rewriter.create<pxa::PxaLoadOp>(op.getLoc(), getGlobalOp, idxs);
+      op.replaceAllUsesWith(loadOp.getResult());
+
+      rewriter.eraseOp(op);
+
+      return success();
     }
     return failure();
   }
@@ -478,8 +510,13 @@ struct LowerLinalgToPXAPass
     target.addDynamicallyLegalOp<stdx::ClosureOp>([&](stdx::ClosureOp op) {
       return converter.isSignatureLegal(op.getType());
     });
-    target.addDynamicallyLegalOp<ConstantOp>(
-        [&](ConstantOp op) { return !op.getType().isa<TensorType>(); });
+
+    target.addDynamicallyLegalOp<ConstantOp>([&](ConstantOp op) {
+      return (!op.getType().isa<TensorType>() && !op.getType().isF32());
+    });
+
+    // target.addDynamicallyLegalOp<ConstantOp>(
+    //    [&](ConstantOp op) { return !op.getType().isa<TensorType>(); });
 
     RewritePatternSet patterns(&getContext());
     patterns.insert<ConstantOpConversion,              //

--- a/pmlc/conversion/linalg_to_pxa/test/fill.mlir
+++ b/pmlc/conversion/linalg_to_pxa/test/fill.mlir
@@ -7,10 +7,17 @@ func @main() -> tensor<16x16xf32> {
   return %fill : tensor<16x16xf32>
 }
 
+//CHECK: module
+// CHECK:  memref.global "private" constant @cst_scalar_memref_0 : memref<f32> = dense<0.000000e+00>
 // CHECK-LABEL: func @main
 //  CHECK-SAME: (%[[arg0:.*]]: memref<16x16xf32>) -> memref<16x16xf32>
-//       CHECK:   %[[cst:.*]] = constant 0.000000e+00 : f32
+//       CHECK:  %[[cst0:.*]] = memref.get_global @cst_scalar_memref_0 : memref<f32>
+//       CHECK:  %[[t0:.*]]  = pxa.load %[[cst0]][] : memref<f32>
 //       CHECK:   %[[out0:.*]] = affine.parallel (%[[arg1:.*]], %[[arg2:.*]]) = (0, 0) to (16, 16) reduce ("assign") -> (memref<16x16xf32>)
-//       CHECK:     %[[t0:.*]] = pxa.reduce assign %[[cst]], %[[arg0]][%[[arg1]], %[[arg2]]] : memref<16x16xf32>
-//       CHECK:     affine.yield %[[t0]] : memref<16x16xf32>
+//       CHECK:     %[[t1:.*]] = pxa.reduce assign %[[t0]], %[[arg0]][%[[arg1]], %[[arg2]]] : memref<16x16xf32>
+//       CHECK:     affine.yield %[[t1]] : memref<16x16xf32>
 //       CHECK:   return %[[out0]] : memref<16x16xf32>
+
+
+ 
+

--- a/pmlc/conversion/linalg_to_pxa/test/pad_tensor.mlir
+++ b/pmlc/conversion/linalg_to_pxa/test/pad_tensor.mlir
@@ -9,12 +9,15 @@ func @test_pad(%arg0: tensor<4x8x8x16xf32>) -> tensor<8x10x14x20xf32> {
   return %0 : tensor<8x10x14x20xf32>
 }
 
+
+// CHECK memref.global "private" constant @cst_scalar_memref_0 : memref<f32> = dense<0.000000e+00>
 // CHECK-LABEL: func @test_pad
 //  CHECK-SAME: (%[[arg0:.*]]: memref<4x8x8x16xf32>, %[[arg1:.*]]: memref<8x10x14x20xf32>) -> memref<8x10x14x20xf32>
-//       CHECK:   %[[cst:.*]] = constant 0.000000e+00 : f32
+//	 CHECK: %[[cst_0:.*]] = memref.get_global @cst_scalar_memref_0 : memref<f32>
+//	 CHECK: %[[c0:.*]] = pxa.load %[[cst_0]][] : memref<f32>
 //       CHECK:   %[[init:.*]] = memref.alloc()
 //       CHECK:   %[[out1:.*]] = affine.parallel (%[[arg2:.*]], %[[arg3:.*]], %[[arg4:.*]], %[[arg5:.*]]) = (0, 0, 0, 0) to (8, 10, 14, 20)
-//       CHECK:     %[[t0:.*]] = pxa.reduce assign %[[cst]], %[[init]][%[[arg2]], %[[arg3]], %[[arg4]], %[[arg5]]] : memref<8x10x14x20xf32>
+//       CHECK:     %[[t0:.*]] = pxa.reduce assign %[[c0]], %[[init]][%[[arg2]], %[[arg3]], %[[arg4]], %[[arg5]]] : memref<8x10x14x20xf32>
 //       CHECK:     affine.yield %[[t0]] : memref<8x10x14x20xf32>
 //       CHECK:   %[[out2:.*]] = affine.parallel (%[[arg2:.*]], %[[arg3:.*]], %[[arg4:.*]], %[[arg5:.*]]) = (0, 0, 0, 0) to (8, 10, 14, 20)
 //       CHECK:     %[[t1:.*]] = pxa.load %[[out1]][%arg2, %arg3, %arg4, %arg5] : memref<8x10x14x20xf32>
@@ -25,3 +28,6 @@ func @test_pad(%arg0: tensor<4x8x8x16xf32>) -> tensor<8x10x14x20xf32> {
 //       CHECK:     %[[t4:.*]] = pxa.reduce assign %[[t3]], %[[out2]][%[[arg2]] + 2, %[[arg3]] + 2, %[[arg4]] + 4, %[[arg5]] + 4] : memref<8x10x14x20xf32>
 //       CHECK:     affine.yield %[[t4]] : memref<8x10x14x20xf32>
 //       CHECK:   return %[[out3]] : memref<8x10x14x20xf32>
+
+
+

--- a/pmlc/dialect/xsmm/ir/ops.td
+++ b/pmlc/dialect/xsmm/ir/ops.td
@@ -220,7 +220,9 @@ def XSMM_BinaryDispatchOp : XSMM_Op<"binary.dispatch", [NoSideEffect]> {
     I64Attr:$ldi1,
     I64Attr:$ldi2,
     I64Attr:$ldo,
-    FuncTypeAttr:$func_type
+    FuncTypeAttr:$func_type,
+    I32Attr:$bcastType1,
+    I32Attr:$bcastType2
   );
   let results = (outs I64:$ptr);
   let printer = ?;

--- a/pmlc/dialect/xsmm/ir/ops.td
+++ b/pmlc/dialect/xsmm/ir/ops.td
@@ -176,6 +176,7 @@ def XSMM_BRGemmOffsInvokeF32Op : XSMM_Op<"brgemm.offs.invoke.f32"> {
   }];
 }
 
+
 def XSMM_UnaryDispatchOp : XSMM_Op<"unary.dispatch", [NoSideEffect]> {
   let summary = "Generate a unary kernel for a specific tile size.";
   let arguments = (ins
@@ -184,14 +185,16 @@ def XSMM_UnaryDispatchOp : XSMM_Op<"unary.dispatch", [NoSideEffect]> {
     I64ArrayAttr:$tile,
     I64Attr:$ldi,
     I64Attr:$ldo,
-    FuncTypeAttr:$func_type
+    FuncTypeAttr:$func_type,
+    I32Attr:$bcastType
   );
   let results = (outs I64:$ptr);
   let assemblyFormat = [{
-    $kind `(` $compute_type `,` $tile `,` $ldi `,` $ldo `)`
+    $kind `(` $compute_type `,` $tile `,` $ldi `,` $ldo `,` $bcastType `)`
     `:` $func_type attr-dict
   }];
 }
+
 
 def XSMM_UnaryInvokeOp : XSMM_Op<"unary.invoke"> {
   let summary = "Invoke a previously generated unary kernel.";

--- a/pmlc/dialect/xsmm/tests/roundtrip.mlir
+++ b/pmlc/dialect/xsmm/tests/roundtrip.mlir
@@ -20,8 +20,8 @@ func @dot(%A: memref<8x8xf32>, %B: memref<8x8xf32>, %C: memref<8x8xf32>) -> () {
 func @relu(%I: memref<8x8xf32>, %O: memref<8x8xf32>) -> () {
   // CHECK: affine.parallel (%[[IX:.*]], %[[JX:.*]]) = (0, 0) to (8, 8) step (2, 2)
   affine.parallel (%i, %j) = (0, 0) to (8, 8) step (2, 2) {
-    // CHECK: %[[PTR:.*]] = xsmm.unary.dispatch RELU(f32, [2, 2], 2, 2) : (f32) -> f32
-    %1 = xsmm.unary.dispatch RELU(f32, [2, 2], 2, 2) : (f32) -> f32
+    // CHECK: %[[PTR:.*]] = xsmm.unary.dispatch RELU(f32, [2, 2], 2, 2, 0) : (f32) -> f32
+    %1 = xsmm.unary.dispatch RELU(f32, [2, 2], 2, 2, 0) : (f32) -> f32
     // CHECK: xsmm.unary.invoke %[[OUT]][%[[IX]], %[[JX]]] = %[[PTR]](%[[IN]][%[[JX]], %[[IX]]])
     // CHECK-SAME: (memref<8x8xf32>) -> memref<8x8xf32>
     xsmm.unary.invoke %O[%i, %j] = %1(%I[%j, %i]) : (memref<8x8xf32>) -> memref<8x8xf32>

--- a/pmlc/rt/xsmm.cc
+++ b/pmlc/rt/xsmm.cc
@@ -7,6 +7,11 @@
 #include "pmlc/rt/symbol_registry.h"
 #include "pmlc/util/logging.h"
 
+static constexpr int NO_BCAST = 0;
+static constexpr int ROW_BCAST = 1;
+static constexpr int COL_BCAST = 2;
+static constexpr int SCALAR_BCAST = 3;
+
 using FunctionPtr = void (*)(const void *, const void *, void *, ...);
 
 extern "C" void plaidml_rt_xsmm_gemm_invoke_f32(int64_t funcAddr, float *a,
@@ -93,19 +98,28 @@ plaidml_rt_xsmm_brgemm_offs_dispatch_f32(int32_t lda, int32_t ldb, int32_t ldc,
   return reinterpret_cast<int64_t>(sgemm);
 }
 
-extern "C" int64_t
-plaidml_rt_xsmm_unary_dispatch(int32_t m, int32_t n, int32_t ldi, int32_t ldo,
-                               int32_t in_type, int32_t compute_type,
-                               int32_t out_type, int32_t type) {
+extern "C" int64_t plaidml_rt_xsmm_unary_dispatch(
+    int32_t m, int32_t n, int32_t ldi, int32_t ldo, int32_t in_type,
+    int32_t compute_type, int32_t out_type, int32_t type, int32_t bcast_type) {
   libxsmm_blasint ldi_int = ldi;
   libxsmm_blasint ldo_int = ldo;
+  unsigned int use_bcast = (unsigned int)bcast_type;
+  libxsmm_meltw_unary_flags unary_flags = LIBXSMM_MELTW_FLAG_UNARY_NONE;
+
+  if (use_bcast == ROW_BCAST) {
+    unary_flags = LIBXSMM_MELTW_FLAG_UNARY_BCAST_ROW;
+  } else if (use_bcast == COL_BCAST) {
+    unary_flags = LIBXSMM_MELTW_FLAG_UNARY_BCAST_COL;
+  } else if (use_bcast == SCALAR_BCAST) {
+    unary_flags = LIBXSMM_MELTW_FLAG_UNARY_BCAST_SCALAR;
+  }
   libxsmm_meltwfunction_unary kernel = libxsmm_dispatch_meltw_unary(
       static_cast<libxsmm_blasint>(n), static_cast<libxsmm_blasint>(m),
       &ldi_int, &ldo_int, // leading dimensions
       static_cast<libxsmm_datatype>(in_type),
       static_cast<libxsmm_datatype>(compute_type),
       static_cast<libxsmm_datatype>(out_type),
-      LIBXSMM_MELTW_FLAG_UNARY_NONE, // TODO: add flags to op definition
+      unary_flags, // TODO: add flags to op definition
       static_cast<libxsmm_meltw_unary_type>(type));
   return reinterpret_cast<int64_t>(kernel);
 }

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -334,6 +334,7 @@ void pipelineBuilderStage2(OpPassManager &pm, const Options &options) {
 
   pm.addNestedPass<FuncOp>(createStencilTppUnaryPass());
   pm.addNestedPass<FuncOp>(createStencilTppBinaryPass());
+  pm.addNestedPass<FuncOp>(pxa::createAffineNormalizePass());
 
   if (pmlc::util::getEnvVar("PLAIDML_PROFILE") == "1")
     pm.addPass(createProfileKernelsPass());

--- a/pmlc/target/x86/stencil_tpp_binary.cc
+++ b/pmlc/target/x86/stencil_tpp_binary.cc
@@ -40,6 +40,19 @@ struct GemmOperand {
   }
 };
 
+double getStride(ArrayRef<int64_t> tileSizes, int tiledIdxCount,
+                 DenseMap<mlir::BlockArgument, int64_t> strides,
+                 SmallVector<mlir::BlockArgument, 8> indexes) {
+  for (size_t j = 0; j < tiledIdxCount; j++) {
+    for (const auto &kvp : strides) {
+      if (indexes[j] == kvp.first) {
+        return static_cast<double>(kvp.second);
+      }
+    }
+  }
+  return 0.0;
+}
+
 bool isLocallyDefined(AffineParallelOp op, Value source) {
   if (!source.isa<BlockArgument>()) {
     // If the definition of load's source is in "op", it is too complex to
@@ -102,7 +115,18 @@ private:
 
   double getCost(const pxa::StencilOption &stencil,
                  ArrayRef<int64_t> tileSizes) {
-    return 0.0;
+    int64_t tiledIdxCount = getTiledIdxCount();
+    double inputStride1 =
+        getStride(tileSizes, tiledIdxCount,
+                  stencil.values[1].strideInfo.strides, stencil.indexes);
+    double inputStride2 =
+        getStride(tileSizes, tiledIdxCount,
+                  stencil.values[2].strideInfo.strides, stencil.indexes);
+    double outputStride =
+        getStride(tileSizes, tiledIdxCount,
+                  stencil.values[0].strideInfo.strides, stencil.indexes);
+
+    return (inputStride1 + inputStride2 + outputStride);
   }
 
   void transform(const pxa::StencilOption &stencil,

--- a/pmlc/target/x86/stencil_tpp_unary.cc
+++ b/pmlc/target/x86/stencil_tpp_unary.cc
@@ -23,6 +23,21 @@ namespace stdx = dialect::stdx;
 
 namespace {
 
+struct GemmOperand {
+  Value memref;
+  AffineMap accessMap;
+  AffineMap tileMap;
+
+  template <typename TOp>
+  GemmOperand(TOp op, ArrayRef<BlockArgument> idxs,
+              SmallVectorImpl<Value> &mapOperands)
+      : memref(op.getMemRef()), accessMap(op.getAffineMap()),
+        tileMap(pxa::makeTileMap(op.getContext(), op.getAffineMap(),
+                                 op.getMapOperands(), idxs)) {
+    mapOperands.append(op.getMapOperands().begin(), op.getMapOperands().end());
+  }
+};
+
 struct TppOperand {
   Value memref;
   AffineMap accessMap;
@@ -91,12 +106,47 @@ private:
     this->opName = inName;
   }
 
+  void maybeCaptureIdentityOp(Optional<pxa::StencilCapture> &capture,
+                              StringRef inName) {
+    if (capture)
+      return;
+
+    using matchers::m_Any;
+
+    Value load, reduce;
+    auto pattern = m_Op<AffineYieldOp>(m_Capture(
+        &reduce,
+        pxa::m_PxaReduceOp(AtomicRMWKind::assign,
+                           m_Capture(&load, m_Op<pxa::PxaLoadOp>()), m_Any())));
+
+    Operation *yield = op.getBody()->getTerminator();
+    if (!matchPattern(yield, pattern))
+      return;
+    if (!load.getType().isF32() ||
+        !reduce.getType().cast<MemRefType>().getElementType().isF32())
+      return;
+
+    auto source = cast<pxa::PxaLoadOp>(load.getDefiningOp()).memref();
+    if (!source.isa<BlockArgument>()) {
+      // If the definition of load's source is in "op", it is too complex to
+      // stencil
+      auto defOp = source.getDefiningOp();
+      while (!isa<FuncOp>(defOp)) {
+        if (defOp == op.getOperation())
+          return;
+        defOp = defOp->getParentOp();
+      }
+    }
+    capture = pxa::StencilCapture{{reduce}, {load}};
+    this->opName = inName;
+  }
+
   Optional<pxa::StencilCapture> capture() {
     Optional<pxa::StencilCapture> ret;
-
     maybeCaptureGeneric<stdx::ReluOp>(ret, "tpp_relu");
     maybeCaptureGeneric<math::TanhOp>(ret, "tpp_tanh");
     maybeCaptureGeneric<math::ExpOp>(ret, "tpp_exp");
+    maybeCaptureIdentityOp(ret, "tpp_identity");
     return ret;
   }
 
@@ -107,51 +157,103 @@ private:
 
   void transform(const pxa::StencilOption &stencil,
                  ArrayRef<int64_t> tileSizes) {
-    OpBuilder builder(op);
-
     auto outputOp =
         cast<pxa::PxaReduceOp>(stencil.values[0].value.getDefiningOp());
     auto inputOp =
         cast<pxa::PxaLoadOp>(stencil.values[1].value.getDefiningOp());
 
-    SmallVector<Value> inputIndices, outputIndices;
-    Optional<TppOperand> output =
-        getTppOperand(outputOp, op->getBlock(), stencil.indexes, outputIndices);
-    if (!output)
-      return;
+    if (op.getIVs().size() == 2) {
+      OpBuilder builder(op);
 
-    Optional<TppOperand> input =
-        getTppOperand(inputOp, op->getBlock(), stencil.indexes, inputIndices);
-    if (!input)
-      return;
+      SmallVector<Value> inputIndices, outputIndices;
+      Optional<TppOperand> output = getTppOperand(
+          outputOp, op->getBlock(), stencil.indexes, outputIndices);
+      if (!output)
+        return;
 
-    ArrayAttr outputAccessMaps =
-        builder.getAffineMapArrayAttr({output->accessMap});
-    ArrayAttr outputTileMaps = builder.getAffineMapArrayAttr({output->tileMap});
+      Optional<TppOperand> input =
+          getTppOperand(inputOp, op->getBlock(), stencil.indexes, inputIndices);
+      if (!input)
+        return;
 
-    ArrayAttr inputAccessMaps =
-        builder.getAffineMapArrayAttr({input->accessMap});
-    ArrayAttr inputTileMaps = builder.getAffineMapArrayAttr({input->tileMap});
+      ArrayAttr outputAccessMaps =
+          builder.getAffineMapArrayAttr({output->accessMap});
+      ArrayAttr outputTileMaps =
+          builder.getAffineMapArrayAttr({output->tileMap});
 
-    ArrayAttr reductions =
-        builder.getI64ArrayAttr({static_cast<int64_t>(outputOp.agg())});
+      ArrayAttr inputAccessMaps =
+          builder.getAffineMapArrayAttr({input->accessMap});
+      ArrayAttr inputTileMaps = builder.getAffineMapArrayAttr({input->tileMap});
 
-    auto genericOp = builder.create<pxa::PxaGenericOp>(
-        op.getLoc(), output->memref.getType(),
-        /*inputs=*/ArrayRef<Value>{input->memref},
-        /*outputs=*/ArrayRef<Value>{output->memref},
-        /*inputIndices=*/inputIndices,
-        /*outputIndices=*/outputIndices,
-        /*inputAccessMaps=*/inputAccessMaps,
-        /*inputTileMaps=*/inputTileMaps,
-        /*outputAccessMaps=*/outputAccessMaps,
-        /*outputTileMaps=*/outputTileMaps,
-        /*kernel=*/builder.getStringAttr(opName),
-        /*tile=*/builder.getI64ArrayAttr(tileSizes),
-        /*reductions=*/reductions);
+      ArrayAttr reductions =
+          builder.getI64ArrayAttr({static_cast<int64_t>(outputOp.agg())});
+      auto genericOp = builder.create<pxa::PxaGenericOp>(
+          op.getLoc(), output->memref.getType(),
+          /*inputs=*/ArrayRef<Value>{input->memref},
+          /*outputs=*/ArrayRef<Value>{output->memref},
+          /*inputIndices=*/inputIndices,
+          /*outputIndices=*/outputIndices,
+          /*inputAccessMaps=*/inputAccessMaps,
+          /*inputTileMaps=*/inputTileMaps,
+          /*outputAccessMaps=*/outputAccessMaps,
+          /*outputTileMaps=*/outputTileMaps,
+          /*kernel=*/builder.getStringAttr(opName),
+          /*tile=*/builder.getI64ArrayAttr(tileSizes),
+          /*reductions=*/reductions);
 
-    op.getResult(0).replaceAllUsesWith(genericOp.getResult(0));
-    op.erase();
+      op.getResult(0).replaceAllUsesWith(genericOp.getResult(0));
+      op.erase();
+
+    } else {
+      OpBuilder builder = op.getBodyBuilder();
+      SmallVector<Value> inputIndices, outputIndices;
+
+      GemmOperand output(outputOp, stencil.indexes, outputIndices);
+
+      GemmOperand input(inputOp, stencil.indexes, inputIndices);
+
+      SmallVector<int64_t, 8> steps = op.getSteps();
+      for (size_t i = 0; i < steps.size(); i++) {
+        BlockArgument idx = op.getBody()->getArgument(i);
+        int64_t idxRange = getIdxRange(idx);
+
+        for (size_t j = 0; j < getTiledIdxCount(); j++) {
+          if (stencil.indexes[j] == idx) {
+            steps[i] *= tileSizes[j];
+          }
+        }
+      }
+      op.setSteps(steps);
+
+      ArrayAttr outputAccessMaps =
+          builder.getAffineMapArrayAttr({output.accessMap});
+      ArrayAttr outputTileMaps =
+          builder.getAffineMapArrayAttr({output.tileMap});
+
+      ArrayAttr inputAccessMaps =
+          builder.getAffineMapArrayAttr({input.accessMap});
+      ArrayAttr inputTileMaps = builder.getAffineMapArrayAttr({input.tileMap});
+
+      ArrayAttr reductions =
+          builder.getI64ArrayAttr({static_cast<int64_t>(outputOp.agg())});
+
+      auto genericOp = builder.create<pxa::PxaGenericOp>(
+          op.getLoc(), output.memref.getType(),
+          /*inputs=*/ArrayRef<Value>{input.memref},
+          /*outputs=*/ArrayRef<Value>{output.memref},
+          /*inputIndices=*/inputIndices,
+          /*outputIndices=*/outputIndices,
+          /*inputAccessMaps=*/inputAccessMaps,
+          /*inputTileMaps=*/inputTileMaps,
+          /*outputAccessMaps=*/outputAccessMaps,
+          /*outputTileMaps=*/outputTileMaps,
+          /*kernel=*/builder.getStringAttr(opName),
+          /*tile=*/builder.getI64ArrayAttr(tileSizes),
+          /*reductions=*/reductions);
+
+      outputOp.result().replaceAllUsesWith(genericOp.getResult(0));
+      outputOp.erase();
+    }
   }
 
 public:
@@ -164,14 +266,18 @@ public:
                     /*tilingGenerator=*/pxa::ExactRangeGenerator(),
                     pxa::IndexStridePredicates{
                         [](int64_t stride) { return stride > 1; }, // output
-                        [](int64_t stride) { return stride > 1; }, // input
+                        [](int64_t stride) {
+                          return stride == 0 || stride > 1;
+                        }, // input
                     }},
                 pxa::StencilIndexRequirement{
                     /*idxName=*/"eltwise_j",
                     /*tilingGenerator=*/pxa::ExactRangeGenerator(),
                     pxa::IndexStridePredicates{
                         [](int64_t stride) { return stride == 1; }, // output
-                        [](int64_t stride) { return stride == 1; }, // input
+                        [](int64_t stride) {
+                          return stride == 1 || stride == 0;
+                        }, // input
                     }},
             }) {}
 };
@@ -181,7 +287,7 @@ public:
 struct StencilTppUnaryPass : public StencilTppUnaryBase<StencilTppUnaryPass> {
   void runOnFunction() final {
     getFunction().walk([](AffineParallelOp op) {
-      if (op.getIVs().size() == 2) {
+      if (op.getIVs().size() >= 2) {
         StencilImpl stencil(op);
         stencil.performStenciling();
       }

--- a/pmlc/target/x86/tests/xsmm_lowering.mlir
+++ b/pmlc/target/x86/tests/xsmm_lowering.mlir
@@ -48,7 +48,7 @@ func @res2a_branch2a(%I: memref<1x56x56x64xf32>, %K: memref<1x1x64x64xf32>, %O: 
 #tile = affine_map<(x, y) -> (0, x, 0, y)>
 
 // CHECK-LABEL: func @relu
-//       CHECK:   xsmm.unary.dispatch RELU(f32, [4, 64], 3584, 3584) : (f32) -> f32
+//       CHECK:   xsmm.unary.dispatch RELU(f32, [4, 64], 3584, 3584, 0) : (f32) -> f32
 //       CHECK:   affine.for
 //       CHECK:     affine.for
 //       CHECK:       xsmm.unary.invoke

--- a/pmlc/target/x86/tests/xsmm_unary_call.mlir
+++ b/pmlc/target/x86/tests/xsmm_unary_call.mlir
@@ -89,7 +89,7 @@ func @main() {
 func @exp_xsmm(%I: !eltwise, %O: !eltwise) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %exp = xsmm.unary.dispatch EXP(f32, [8, 2], 3, 3) : (f32) -> f32
+  %exp = xsmm.unary.dispatch EXP(f32, [8, 2], 3, 3, 0) : (f32) -> f32
   xsmm.unary.invoke %O[%c0, %c1] = %exp(%I[%c0, %c1]) : (!eltwise) -> !eltwise
   return
 }
@@ -97,7 +97,7 @@ func @exp_xsmm(%I: !eltwise, %O: !eltwise) {
 func @relu_xsmm(%I: !eltwise, %O: !eltwise) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %relu = xsmm.unary.dispatch RELU(f32, [7, 3], 3, 3) : (f32) -> f32
+  %relu = xsmm.unary.dispatch RELU(f32, [7, 3], 3, 3, 0) : (f32) -> f32
   xsmm.unary.invoke %O[%c1, %c0] = %relu(%I[%c1, %c0]) : (!eltwise) -> !eltwise
   return
 }

--- a/pmlc/target/x86/xsmm_lowering.cc
+++ b/pmlc/target/x86/xsmm_lowering.cc
@@ -46,6 +46,23 @@ util::StrideArray getStrideArray(Value operand, AffineMap tileMap) {
   return *info;
 }
 
+void getLdi(util::StrideArray inputs, int32_t ldo, int32_t &ldi,
+            int32_t &bcastType) {
+  if (inputs.strides[0] == 0 && inputs.strides[1] == 0) {
+    bcastType = 3; // scalar broadcast
+    ldi = ldo;
+  } else if (inputs.strides[0] == 0) {
+    bcastType = 2; // col broadcast
+    ldi = ldo;
+  } else if (inputs.strides[1] == 0) {
+    bcastType = 1;
+    ldi = ldo;
+  } else {
+    bcastType = 0;
+    ldi = inputs.strides[0];
+  }
+}
+
 SmallVector<util::StrideArray> getStrideArrays(ValueRange operands,
                                                ArrayAttr tileMapsAttr) {
   SmallVector<util::StrideArray> result;
@@ -350,24 +367,9 @@ struct UnaryPxaGenericOpConversion
     SmallVector<util::StrideArray> outputs =
         getStrideArrays(adaptor.outputs(), op.outputTileMaps());
     IndicesCollector collector(loc, rewriter);
-    int32_t bcastType = 0; // no broadcast
-    AffineMap inputTileMap;
-    inputTileMap = op.inputTileMaps()[0].cast<AffineMapAttr>().getValue();
-    AffineMap outputTileMap =
-        op.outputTileMaps()[0].cast<AffineMapAttr>().getValue();
-    int32_t ldi;
     int32_t ldo = outputs[0].strides[0];
-
-    ldi = inputs[0].strides[0];
-    if (inputTileMap.getNumResults() < outputTileMap.getNumResults()) {
-      if (inputTileMap.getNumResults() == 1) {
-        bcastType = 2; // col broadcast
-        ldi = ldo;
-      } else if (inputTileMap.getNumResults() == 0) {
-        bcastType = 3;
-        ldi = ldo;
-      }
-    }
+    int32_t ldi, bcastType;
+    getLdi(inputs[0], ldo, ldi, bcastType);
 
     if (!collector.collect(op.outputAccessMaps(), adaptor.outputIndices()) ||
         !collector.collect(op.inputAccessMaps(), adaptor.inputIndices()))
@@ -377,15 +379,15 @@ struct UnaryPxaGenericOpConversion
     SmallVector<Type> outputTypes = getElementTypes(op.outputs().getTypes());
     Type computeType = outputTypes[0]; // just use the output type for now
     FunctionType funcType = rewriter.getFunctionType(inputTypes, outputTypes);
-    auto dispatchOp = rewriter.create<xsmm::UnaryDispatchOp>(
-        loc, resultType,
-        /*kind=*/kind,
-        /*compute_type=*/computeType,
-        /*tile=*/op.tile(),
-        /*ldi=*/ldi, // inputs[0].strides[0],
-        /*ldo=*/ldo, // outputs[0].strides[0],
-        /*func_type=*/funcType,
-        /*bcast_type=*/bcastType);
+    auto dispatchOp =
+        rewriter.create<xsmm::UnaryDispatchOp>(loc, resultType,
+                                               /*kind=*/kind,
+                                               /*compute_type=*/computeType,
+                                               /*tile=*/op.tile(),
+                                               /*ldi=*/ldi,
+                                               /*ldo=*/ldo,
+                                               /*func_type=*/funcType,
+                                               /*bcast_type=*/bcastType);
 
     rewriter.create<xsmm::UnaryInvokeOp>(loc, ArrayRef<Type>(),
                                          /*ptr=*/dispatchOp,
@@ -434,15 +436,23 @@ struct BinaryPxaGenericOpConversion
     Type computeType = outputTypes[0]; // just use the output type for now
     FunctionType funcType = rewriter.getFunctionType(inputTypes, outputTypes);
 
+    int32_t inputBcast1, inputBcast2;
+    int32_t ldo = outputs[0].strides[0];
+    int32_t ldi1, ldi2;
+    getLdi(inputs[0], ldo, ldi1, inputBcast1);
+    getLdi(inputs[1], ldo, ldi2, inputBcast2);
+
     auto dispatchOp =
         rewriter.create<xsmm::BinaryDispatchOp>(loc, resultType,
                                                 /*kind=*/kind,
                                                 /*compute_type=*/computeType,
                                                 /*tile=*/op.tile(),
-                                                /*ldi=*/inputs[0].strides[0],
-                                                /*ldi=*/inputs[1].strides[0],
+                                                /*ldi1=*/ldi1,
+                                                /*ldi2=*/ldi2,
                                                 /*ldo=*/outputs[0].strides[0],
-                                                /*func_type=*/funcType);
+                                                /*func_type=*/funcType,
+                                                /*bcast_type1=*/inputBcast1,
+                                                /*bcast_type2=*/inputBcast2);
 
     rewriter.create<xsmm::BinaryInvokeOp>(loc, ArrayRef<Type>(),
                                           /*ptr=*/dispatchOp,
@@ -1115,6 +1125,13 @@ struct XSMMBinaryDispatchLowering
         rewriter.getI32IntegerAttr(
             static_cast<int32_t>(op.kindAttr().getValue()))));
 
+    // broadcast type
+    callOperands.push_back(
+        rewriter.create<LLVM::ConstantOp>(loc, int32Type, op.bcastType1Attr()));
+    // broadcast type
+    callOperands.push_back(
+        rewriter.create<LLVM::ConstantOp>(loc, int32Type, op.bcastType2Attr()));
+
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(
         op, int64Type, SymbolRefAttr::get(func), callOperands);
 
@@ -1148,6 +1165,8 @@ struct XSMMBinaryDispatchLowering
                                         int32Type, // compute_type
                                         int32Type, // out_type
                                         int32Type, // type
+                                        int32Type, // bcastType1
+                                        int32Type, // bcastType2
                                     },
                                     /*isVarArg=*/false));
   }
@@ -1174,8 +1193,8 @@ struct XSMMBinaryInvokeLowering
     Value inputVoidPtr1 =
         rewriter.create<LLVM::BitcastOp>(loc, voidPtrType, inputPtr1);
 
-    auto inputIndices2 =
-        transformed.indices().slice(outputType.getRank(), inputType2.getRank());
+    auto inputIndices2 = transformed.indices().slice(
+        outputType.getRank() + inputType1.getRank(), inputType2.getRank());
 
     Value inputPtr2 = getStridedElementPtr(
         loc, inputType2, transformed.input2(), inputIndices2, rewriter);

--- a/pmlc/target/x86/xsmm_lowering.cc
+++ b/pmlc/target/x86/xsmm_lowering.cc
@@ -50,13 +50,13 @@ void getLdi(util::StrideArray inputs, int32_t ldo, int32_t &ldi,
             int32_t &bcastType) {
   if (inputs.strides[0] == 0 && inputs.strides[1] == 0) {
     bcastType = 3; // scalar broadcast
-    ldi = ldo;
+    ldi = ldo;     // 1
   } else if (inputs.strides[0] == 0) {
     bcastType = 2; // col broadcast
     ldi = ldo;
   } else if (inputs.strides[1] == 0) {
-    bcastType = 1;
-    ldi = ldo;
+    bcastType = 1; // row broadcast
+    ldi = inputs.strides[0];
   } else {
     bcastType = 0;
     ldi = inputs.strides[0];


### PR DESCRIPTION
1. Added support for converting scalar constants to zero ranked memrefs in linalg to pxa conversion pass.
2. Added support for lowering (rank > 2) tensors to stencil tpp unary ops.
3. Added support for column and scalar broadcast in xsmm lowering to tpp for unary ops.
4. TODO: need to modify testcases in linalg to pxa conversion to reflect the creation of zero ranked memrefs. eg. fill.mlir
 