### PR TITLE
WIP: pass to name n,c,h,w etc at linalg dialect level

### DIFF
--- a/pmlc/dialect/linalgx/transforms/CMakeLists.txt
+++ b/pmlc/dialect/linalgx/transforms/CMakeLists.txt
@@ -4,8 +4,10 @@
     pass_detail.h
     passes.h
     regulate_depthwise.h
+    name_conv_variables.h
   SRCS
     regulate_depthwise.cc
+    name_conv_variables.cc
   DEPS
     LLVMSupport
     MLIRIR

--- a/pmlc/dialect/linalgx/transforms/name_conv_variables.cc
+++ b/pmlc/dialect/linalgx/transforms/name_conv_variables.cc
@@ -1,0 +1,70 @@
+// Copyright 2022 Intel Corporation
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "pmlc/dialect/linalgx/analysis/convolution.h"
+#include "pmlc/dialect/linalgx/transforms/name_conv_variables.h"
+
+#include "pmlc/dialect/linalgx/transforms/pass_detail.h"
+#include "pmlc/util/logging.h"
+using namespace mlir; // NOLINT
+
+static constexpr StringLiteral nameAttribute = "convolution_indices";
+namespace pmlc::dialect::linalgx {
+
+void setNameAttr(Operation *op, std::vector<std::string> tags) {
+  if (tags.empty())
+    return;
+
+  NamedAttrList dict = op->getAttrOfType<DictionaryAttr>(nameAttribute);
+  for (int i = 0; i < tags.size(); i++) {
+    dict.set(tags[i], UnitAttr::get(op->getContext()));
+  }
+  op->setAttr(nameAttribute, dict.getDictionary(op->getContext()));
+}
+
+struct NameConvVariablesPass
+    : public NameConvVariablesBase<NameConvVariablesPass> {
+  NameConvVariablesPass() = default;
+  void runOnFunction() final {
+    auto func = getFunction();
+    func.walk([&](linalg::GenericOp op) { nameConvVariables(op); });
+  }
+
+  void maybeCaptureOp(linalg::GenericOp op) {
+    auto capturedConv = detectConv(op);
+    if (!capturedConv) {
+      IVLOG(3, "Cannot label non conv operator " << debugString(op));
+      return;
+    }
+    if (capturedConv->input.idxMap.getNumResults() != 4 ||
+        capturedConv->filter.idxMap.getNumResults() != 4 ||
+        capturedConv->output.idxMap.getNumResults() != 4) {
+      IVLOG(3, "Cannot label non 2d conv operator " << debugString(op));
+      return;
+    }
+    std::vector<std::string> tagsList;
+    std::string prefixes[7] = {"N:", "H:", "W:", "C:", "K:", "R:", "S:"};
+    auto shapesToLoopsMap = op.getShapesToLoopsMap();
+    for (int i = 0; i < shapesToLoopsMap.getNumResults(); i++) {
+      AffineExpr term = shapesToLoopsMap.getResult(i);
+      AffineDimExpr termDimExpr = term.dyn_cast<AffineDimExpr>();
+      unsigned pos = termDimExpr.getPosition();
+      std::stringstream stream(prefixes[i]);
+      stream << "d" << pos;
+      tagsList.push_back(stream.str());
+    }
+    setNameAttr(op, tagsList);
+  }
+  void nameConvVariables(linalg::GenericOp op) { maybeCaptureOp(op); }
+};
+
+std::unique_ptr<mlir::Pass> createNameConvVariablesPass() {
+  return std::make_unique<NameConvVariablesPass>();
+}
+
+} // namespace pmlc::dialect::linalgx

--- a/pmlc/dialect/linalgx/transforms/name_conv_variables.h
+++ b/pmlc/dialect/linalgx/transforms/name_conv_variables.h
@@ -1,0 +1,7 @@
+// Copyright 2022 Intel Corporation
+
+#pragma once
+
+#include "pmlc/dialect/linalgx/ir/ops.h"
+
+namespace pmlc::dialect::linalgx {} // namespace pmlc::dialect::linalgx

--- a/pmlc/dialect/linalgx/transforms/passes.h
+++ b/pmlc/dialect/linalgx/transforms/passes.h
@@ -11,6 +11,7 @@
 namespace pmlc::dialect::linalgx {
 
 std::unique_ptr<mlir::Pass> createRegulateDepthwisePass();
+std::unique_ptr<mlir::Pass> createNameConvVariablesPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/pmlc/dialect/linalgx/transforms/passes.td
+++ b/pmlc/dialect/linalgx/transforms/passes.td
@@ -8,4 +8,8 @@ def RegulateDepthwise : FunctionPass<"linalgx-regulate-depthwise"> {
   let constructor = "pmlc::dialect::linalgx::createRegulateDepthwisePass()";
 }
 
+def NameConvVariables : FunctionPass<"linalgx-name-conv-variables"> {
+  let summary = "Name variables of convolution as n, c, h, w and so on";
+  let constructor = "pmlc::dialect::linalgx::createNameConvVariablesPass()";
+}
 #endif // __PMLC_DIALECT_LINALGX_PASSES__

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -265,6 +265,8 @@ void pipelineBuilderStage1(OpPassManager &pm) {
 
   pm.addPass(pmlc::conversion::tile_to_linalg::createLowerTileToLinalgPass());
   pm.addNestedPass<FuncOp>(linalgx::createRegulateDepthwisePass());
+  if (!util::getEnvVar("PLAIDML_THREAD_DIST_CONFIG_FILE").empty())
+    pm.addNestedPass<FuncOp>(linalgx::createNameConvVariablesPass());
   if (!util::getEnvVar("PLAIDML_REORDER").empty())
     pm.addNestedPass<FuncOp>(createReorderLayoutsPass());
   else


### PR DESCRIPTION
This is a wip pass to name the induction variables (N,C,H,W,K,R,S) for conv operations in linalg dialect.