### PR TITLE
Shape Analysis pass

### DIFF
--- a/pmlc/rt/CMakeLists.txt
+++ b/pmlc/rt/CMakeLists.txt
@@ -48,6 +48,12 @@ set_property(SOURCE xsmm.cc
     LIBXSMM_DEFAULT_CONFIG
 )
 
+set_property(SOURCE instrument.cc
+  PROPERTY COMPILE_DEFINITIONS
+    __BLAS=0
+    LIBXSMM_DEFAULT_CONFIG
+)
+
 set(_RT_DEFINES "")
 set(_RT_DEPS
   ::rt

--- a/pmlc/rt/instrument.cc
+++ b/pmlc/rt/instrument.cc
@@ -4,6 +4,7 @@
 
 #include <chrono>
 
+#include "libxsmm.h" // NOLINT [build/include_subdir]
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -12,27 +13,30 @@
 
 namespace pmlc::rt {
 
-using namespace std::chrono; // NOLINT
-
-static time_point<steady_clock> initTime;
-static time_point<steady_clock> globalTime;
+static uint64_t initTime;
+static uint64_t globalTime;
 
 void initInstrument() { //
-  initTime = globalTime = steady_clock::now();
+  initTime = globalTime =
+      libxsmm_timer_tick(); // globalTime = steady_clock::now();
   if (util::getEnvVar("PLAIDML_PROFILE") == "1") {
     llvm::outs() << "\"id\",\"loc\",\"tag\",\"elapsed\",\"accumulated\"\n";
     llvm::outs().flush();
   }
 }
-
 void instrumentPoint(int64_t id, int64_t tag, const char *loc) {
-  auto now = steady_clock::now();
-  auto lastDuration = duration_cast<duration<double>>(now - globalTime).count();
-  auto initDuration = duration_cast<duration<double>>(now - initTime).count();
+  auto now = libxsmm_timer_tick();
+  auto lastDuration = libxsmm_timer_duration(globalTime, now);
+  auto initDuration = libxsmm_timer_duration(initTime, now);
   llvm::outs() << llvm::format("%03d,%s,%d,%7.6f,%7.6f\n", id, loc, tag,
                                lastDuration, initDuration);
   llvm::outs().flush();
   globalTime = now;
+}
+
+double finishInstrument() {
+  instrumentPoint(9999, 9999, "endTime");
+  return libxsmm_timer_duration(initTime, libxsmm_timer_tick());
 }
 
 } // namespace pmlc::rt

--- a/pmlc/rt/instrument.h
+++ b/pmlc/rt/instrument.h
@@ -6,5 +6,5 @@ namespace pmlc::rt {
 
 void initInstrument();
 void registerInstrument();
-
+double finishInstrument();
 } // namespace pmlc::rt

--- a/pmlc/rt/jit_executable.cc
+++ b/pmlc/rt/jit_executable.cc
@@ -445,6 +445,7 @@ public:
     if (jitFini) {
       IVLOG(3, "Doing jit fini");
       rt::initInstrument();
+
       SmallVector<void *, 1> finiPtrs{initPack};
       jitFini(finiPtrs.data());
       IVLOG(3, "Jit fini complete");
@@ -475,6 +476,7 @@ public:
     rt::initInstrument();
     bindArguments(inputBuffers, outputBuffers);
     jitMain(ptrs.data());
+    device->execTimeInMS = rt::finishInstrument() * 1000;
     return device->execTimeInMS;
   }
 


### PR DESCRIPTION
This patch adds a shape analysis pass that dumps TPP shapes
and surrounding affineparallel op shapes in a file which
can be chosen by setting the environment as follows:
PLAIDML_SHAPE_ANALYSIS_OUTPUT=\<path\>.
This currently dumps tpp tile shape only and needs to be
enhanced to dump the surrounding affine parallel op's bounds.