### PR TITLE
Backout weight layout reorders when the LoopsToShapeMap can't be inferred for the resulting op

### DIFF
--- a/pmlc/target/x86/reorder_layouts.cc
+++ b/pmlc/target/x86/reorder_layouts.cc
@@ -729,15 +729,12 @@ struct ReorderWeightLayoutsPass
     if (!newConv.getShapesToLoopsMap()) {
       IVLOG(1, "Cannot reorder: LinAlg unable to infer ShapesToLoopsMap. op: "
                    << debugString(op));
-      IVLOG(1, "    Attempted reordered op: " << debugString(newConv));
+      IVLOG(2, "    note: attempted reordered op: " << debugString(newConv));
 
       // Back out the reordered op
       newConv.erase();
       reorderFilter.erase();
       return;
-    } else {
-      IVLOG(1, "TEMP ShapesToLoopsMap OK for op " << debugString(op));
-      IVLOG(1, "    TEMP Resulting reordered op: " << debugString(newConv));
     }
 
     op.getResult(0).replaceAllUsesWith(newConv.getResult(0));

--- a/pmlc/target/x86/reorder_layouts.cc
+++ b/pmlc/target/x86/reorder_layouts.cc
@@ -726,6 +726,20 @@ struct ReorderWeightLayoutsPass
           builder.create<linalg::YieldOp>(loc, ValueRange{add});
         });
 
+    if (!newConv.getShapesToLoopsMap()) {
+      IVLOG(1, "Cannot reorder: LinAlg unable to infer ShapesToLoopsMap. op: "
+                   << debugString(op));
+      IVLOG(1, "    Attempted reordered op: " << debugString(newConv));
+
+      // Back out the reordered op
+      newConv.erase();
+      reorderFilter.erase();
+      return;
+    } else {
+      IVLOG(1, "TEMP ShapesToLoopsMap OK for op " << debugString(op));
+      IVLOG(1, "    TEMP Resulting reordered op: " << debugString(newConv));
+    }
+
     op.getResult(0).replaceAllUsesWith(newConv.getResult(0));
     op.erase();
   }


### PR DESCRIPTION
When we reorder weight layouts we sometimes produce ops for which the LoopsToShapeMap can't be inferred. This appears to be expected behavior for some otherwise-legal ops, at least based on my reading of this comment:
https://github.com/llvm/llvm-project/blob/50f846d63443781a5c00ec7022c381c4f09f543d/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td#L946

With this patch, we just skip the reorder for such cases by calling getLoopsToShapeMap and backing out the transformed op if it is null.