### PR TITLE
Allow users to define CC/CXX options for CMake on configure

### DIFF
--- a/configure
+++ b/configure
@@ -114,6 +114,23 @@ class Configure:
             sys.exit(1)
         run([pre_commit, 'install'], check=True)
 
+    def configure_compiler(self, args):
+        cmake_compiler_flags = []
+
+        cc = args.cc
+        if cc is None:
+            cc = os.getenv('CC')
+        cxx = args.cxx
+        if (cxx is None):
+            cxx = os.getenv('CXX')
+
+        if cc:
+            cmake_compiler_flags.append(f'-DCMAKE_C_COMPILER={cc}')
+        if cxx:
+            cmake_compiler_flags.append(f'-DCMAKE_CXX_COMPILER={cxx}')
+
+        return cmake_compiler_flags
+
     def configure_cmake(self, args):
         build_dir = pathlib.Path(f'build-{args.target}').resolve() / args.type
         cmd = [
@@ -135,6 +152,7 @@ class Configure:
             cmd.append('-DLOCAL_LLVM_DIR={}'.format(args.local_llvm))
         else:
             cmd.append('-ULOCAL_LLVM_DIR')
+        cmd.extend(self.configure_compiler(args))
         run(cmd, check=True)
 
 
@@ -159,6 +177,12 @@ def main():
     parser.add_argument('--temp',
                         type=pathlib.Path,
                         help='Configures the temporary directory for cached assets.')
+    parser.add_argument('--cc',
+                        type=pathlib.Path,
+                        help='Path/name of the C compiler.')
+    parser.add_argument('--cxx',
+                        type=pathlib.Path,
+                        help='Path/name of the C++ compiler.')
     args = parser.parse_args()
 
     print("Configuring PlaidML build environment")


### PR DESCRIPTION
Users that don't have a supported compiler (gcc 9.4) as a system
compiler can still pass the --cc and --cxx (or use standard environment
variables CC and CXX) to set it for the PlaidML build without having to
change their paths.

This, and the feedback on #1972, make it build successfully and pass all
the tests.

Fixes #1972