### PR TITLE
Batch parallelization and allocs to alloca changes

### DIFF
--- a/pmlc/dialect/pxa/transforms/CMakeLists.txt
+++ b/pmlc/dialect/pxa/transforms/CMakeLists.txt
@@ -5,6 +5,7 @@
     passes.h
   SRCS
     autotile.cc
+    alloca_conversion.cc
     cache.cc
     convert_mem_op.cc
     cpu_thread.cc

--- a/pmlc/dialect/pxa/transforms/alloca_conversion.cc
+++ b/pmlc/dialect/pxa/transforms/alloca_conversion.cc
@@ -1,0 +1,55 @@
+// Copyright 2020 Intel Corporation
+#include <list>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Support/DebugStringHelper.h"
+
+#include "pmlc/dialect/pxa/analysis/uses.h"
+#include "pmlc/dialect/pxa/ir/ops.h"
+#include "pmlc/dialect/pxa/transforms/pass_detail.h"
+#include "pmlc/util/logging.h"
+
+using namespace mlir; // NOLINT[build/namespaces]
+
+namespace pmlc::dialect::pxa {
+
+namespace {
+
+struct AllocaConversionPass
+    : public AllocaConversionBase<AllocaConversionPass> {
+  void runOnOperation() final {
+    func::FuncOp f = getOperation();
+    std::list<Operation *> toMove;
+
+    f.walk([&](memref::AllocOp allocOp) {
+      // Find the nearest common ancestor for the users of the alloc op.
+      auto *op = allocOp.getOperation();
+      if (isa<AffineParallelOp>(op->getBlock()->getParentOp()->getParentOp())) {
+        toMove.push_back(op);
+      }
+    });
+
+    // Mark and sweep to avoid redundant analysis.
+    for (auto &kvp : toMove) {
+      Operation *allocOperation = kvp;
+      auto allocOp = cast<memref::AllocOp>(allocOperation);
+
+      OpBuilder builder(allocOp);
+      auto allocaOp = builder.create<mlir::memref::AllocaOp>(
+          allocOp.getLoc(), allocOp.getType().cast<MemRefType>(),
+          allocOp->getOperands());
+      allocOp.replaceAllUsesWith(&*allocaOp);
+      allocOp.erase();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createAllocaConversionPass() {
+  return std::make_unique<AllocaConversionPass>();
+}
+
+} // namespace pmlc::dialect::pxa

--- a/pmlc/dialect/pxa/transforms/passes.h
+++ b/pmlc/dialect/pxa/transforms/passes.h
@@ -35,6 +35,7 @@ std::unique_ptr<mlir::Pass> createGPUThreadPass();
 std::unique_ptr<mlir::Pass> createGPUThreadPass(unsigned maxThreads);
 
 std::unique_ptr<mlir::Pass> createLocalizePass();
+std::unique_ptr<mlir::Pass> createAllocaConversionPass();
 
 std::unique_ptr<mlir::Pass>
 createMemRefDataFlowOptPass(bool onlyParallelNested = false);

--- a/pmlc/dialect/pxa/transforms/passes.td
+++ b/pmlc/dialect/pxa/transforms/passes.td
@@ -114,6 +114,11 @@ def Localize : Pass<"pxa-localize", "mlir::func::FuncOp"> {
   let constructor = "pmlc::dialect::pxa::createLocalizePass()";
 }
 
+def AllocaConversion : Pass<"pxa-alloca-conversion", "mlir::func::FuncOp"> {
+  let summary = "Convert local allocs to alloca";
+  let constructor = "pmlc::dialect::pxa::createAllocaConversionPass()";
+}
+
 def MemRefDataFlowOpt : Pass<"pxa-dataflow-opt", "mlir::func::FuncOp"> {
   let summary = "Perform reduce/load forwarding for memrefs";
   let constructor = "pmlc::dialect::pxa::createMemRefDataFlowOptPass()";

--- a/pmlc/target/x86/pipeline.cc
+++ b/pmlc/target/x86/pipeline.cc
@@ -337,6 +337,7 @@ void pipelineBuilderStage2(OpPassManager &pm, const Options &options) {
 
   pm.addNestedPass<func::FuncOp>(pxa::createLocalizePass());
   pm.addNestedPass<func::FuncOp>(pxa::createResizeTmpsPass());
+  // pm.addNestedPass<func::FuncOp>(pxa::createAllocaConversionPass());
   pm.addPass(pxa::createDeallocPlacementPass());
   pm.addNestedPass<func::FuncOp>(
       pxa::createAffineNormalizePass(/*promote=*/true,


### PR DESCRIPTION
This wip patch modifies scoped allocs to allocas using PromoteBuffersToStackPass as well as pxa localization pass. As of now, the first pass does not seem to be scoping allocs other than weights. On the other hand, pxa localization pass throws a segfault at runtime for threads>1. This patch also parallelizes layers along batch dimension barring those which don't have batch dimension as the outer loop's induction variable.